### PR TITLE
Few missing tags from alpha 16 to the translation

### DIFF
--- a/DefInjected/ConceptDef/Example_Concepts.xml
+++ b/DefInjected/ConceptDef/Example_Concepts.xml
@@ -1,0 +1,8 @@
+
+</LanguageData>Add your translation here<//LanguageData>
+</rep>Add your translation here<//rep>
+<?xml version="1.0" encoding="utf-8" ?>Add your translation here</?xml version="1.0" encoding="utf-8" ?>
+<LanguageData>Add your translation here</LanguageData>
+<path>Add your translation here</path>
+<rep>Add your translation here</rep>
+<trans>Add your translation here</trans>

--- a/DefInjected/TraitDef/Example_Traits.xml
+++ b/DefInjected/TraitDef/Example_Traits.xml
@@ -1,0 +1,13 @@
+
+<!--This is a path-driven translation:-->
+</LanguageData>Add your translation here<//LanguageData>
+</rep>Add your translation here<//rep>
+</rep>Add your translation here<//rep>
+<?xml version="1.0" encoding="utf-8" ?>Add your translation here</?xml version="1.0" encoding="utf-8" ?>
+<LanguageData>Add your translation here</LanguageData>
+<path>Add your translation here</path>
+<path>Add your translation here</path>
+<rep>Add your translation here</rep>
+<rep>Add your translation here</rep>
+<trans>Add your translation here</trans>
+<trans>Add your translation here</trans>

--- a/Keyed/Credits.xml
+++ b/Keyed/Credits.xml
@@ -29,3 +29,5 @@
   <ThanksForPlaying>Oynadığınız için teşekkürler!</ThanksForPlaying>
 
 </LanguageData>
+
+<Credit_WritingDonation>Add your translation here</Credit_WritingDonation>

--- a/Keyed/Designators.xml
+++ b/Keyed/Designators.xml
@@ -123,3 +123,5 @@
 
 
 </LanguageData>
+
+<!-- Desc helpers -->

--- a/Keyed/Dialog_Trees.xml
+++ b/Keyed/Dialog_Trees.xml
@@ -26,3 +26,7 @@
 
 
 </LanguageData>
+
+<!-- gift offer -->
+<!-- military aid request -->
+<!-- trade caravan request -->

--- a/Keyed/Enums.xml
+++ b/Keyed/Enums.xml
@@ -155,3 +155,6 @@
 
   
 </LanguageData>
+
+<!-- Trainable intelligence -->
+<FoodTypeFlags_Seed>Add your translation here</FoodTypeFlags_Seed>

--- a/Keyed/GameplayCommands.xml
+++ b/Keyed/GameplayCommands.xml
@@ -228,3 +228,6 @@
   <CommandSelectNextTransporterDesc>Select next transport pod in this launch group.</CommandSelectNextTransporterDesc>
 
 </LanguageData>
+
+<CommandAllowFiringDesc>Add your translation here</CommandAllowFiringDesc>
+<CommandAllowFiringLabel>Add your translation here</CommandAllowFiringLabel>

--- a/Keyed/Menus_Main.xml
+++ b/Keyed/Menus_Main.xml
@@ -174,3 +174,6 @@
   <GeneratingMapForNewEncounter>Yeni karşılaşma için harita oluşturuluyor</GeneratingMapForNewEncounter>
 
 </LanguageData>
+
+<!--=========== Mods config ==========-->
+<PermanentMoodEffect>Add your translation here</PermanentMoodEffect>

--- a/Keyed/Misc_Gameplay.xml
+++ b/Keyed/Misc_Gameplay.xml
@@ -442,3 +442,12 @@
 
 
 </LanguageData>
+
+<!-- Control -->
+<!-- Hostility response -->
+<!-- Map conditions -->
+<!-- Snow -->
+<!-- Zones -->
+<HostilityReponseTip>Add your translation here</HostilityReponseTip>
+<HostilityResponseCurrentMode>Add your translation here</HostilityResponseCurrentMode>
+<Mood_MentalState>Add your translation here</Mood_MentalState>

--- a/Keyed/WITabs.xml
+++ b/Keyed/WITabs.xml
@@ -35,3 +35,5 @@
   <PlanetCoverageShort>Coverage</PlanetCoverageShort>
 
 </LanguageData>
+
+<?xml version="1.0" encoding="utf-8" ?>Add your translation here</?xml version="1.0" encoding="utf-8" ?>

--- a/LanguageInfo.xml
+++ b/LanguageInfo.xml
@@ -62,3 +62,5 @@
      </li>	
   </credits>
 </LanguageInfo>
+
+<languageWorkerClass>Add your translation here</languageWorkerClass>


### PR DESCRIPTION
There's no need to accept, this is just to guide the translations to what's missing. This diff was created by my tool [XML-Comp](https://github.com/xml-comp/XML-Comp/) that compares the Steam's folder to your Github's repo.

Please ignore `Example_concepts.xml` and `Example_traits.xml`, they're kinda bugged.