### PR TITLE
Missing </li> in LanguageInfo.xml causes red error in the credits

### DIFF
--- a/Core/LanguageInfo.xml
+++ b/Core/LanguageInfo.xml
@@ -52,6 +52,7 @@
      <li Class="CreditRecord_Role">
       <roleKey>Credit_Translator</roleKey>
       <creditee>TinyTemim</creditee>
+     </li>
      <li Class="CreditRecord_Role">
       <roleKey>Credit_Translator</roleKey>
       <creditee>Emrah yılmaz</creditee>


### PR DESCRIPTION
Funnily enough, this error can be seen in any language, even English. To reproduce the error, simply click on "Credits" in the main menu (with dev mode enabled).