### PR TITLE
1.5 Çevirisi Sonrası Hata Düzeltimleri ve Discord Topluluğu

### DIFF
--- a/Core/DefInjected/BackstoryDef/Offworld_Glitterworld_Adult.xml
+++ b/Core/DefInjected/BackstoryDef/Offworld_Glitterworld_Adult.xml
@@ -20,7 +20,7 @@
   <!-- EN: charity worker -->
   <CharityWorker36.title>hayırsever</CharityWorker36.title>
   <!-- EN: altruist -->
-  <CharityWorker36.titleShort>diğerkam</CharityWorker36.titleShort>
+  <CharityWorker36.titleShort>fedakar</CharityWorker36.titleShort>
   
   <!-- EN: [PAWN_nameDef] found it easy to relate to others and mediate conflict. [PAWN_pronoun] was selected to train as an empath. The training intensified [PAWN_possessive] natural abilities, but [PAWN_pronoun] became unable to cause others pain. -->
   <GlitterworldEmpath26.description>[PAWN_nameDef] başkalarıyla ilişki kurmayı ve çatışmalara aracılık etmeyi kolay buluyordu. [PAWN_pronoun] empat olarak yetiştirilmek üzere seçildi. Eğitim doğal yeteneklerini daha da güçlendirdi ama artık [PAWN_pronoun] başkalarına zarar veremez hale geldi.</GlitterworldEmpath26.description>
@@ -37,7 +37,7 @@
   <GlitterworldOfficer60.titleShort>memur</GlitterworldOfficer60.titleShort>
   
   <!-- EN: [PAWN_nameDef] worked as a surgeon on a world mostly free of disease and human suffering, so [PAWN_possessive] job focused on elaborate and creative cosmetic surgeries. \n\n[PAWN_pronoun] understands human biology, deeply, but has never had to remove a tumour — or a bullet. -->
-  <GlitterworldSurgeon15.description>[PAWN_nameDef] çoğunlukla hastalık ve insan acısı olmayan bir dünyada cerrah olarak çalıştı, bu yüzden [PAWN_possessive] işi ayrıntılı ve yaratıcı kozmetik ameliyatlara odaklandı. [PAWN_pronoun] insan biyolojisini derinden anlıyor, ancak hiçbir zaman bir tümör ya da bir mermi çıkarmak zorunda kalmadı.</GlitterworldSurgeon15.description>
+  <GlitterworldSurgeon15.description>[PAWN_nameDef] çoğunlukla hastalık ve insan acısı olmayan bir dünyada cerrah olarak çalıştı, bu yüzden [PAWN_possessive] işi ayrıntılı ve yaratıcı kozmetik ameliyatlara odaklandı. \n\n[PAWN_pronoun] insan biyolojisini derinden anlıyor, ancak hiçbir zaman bir tümör ya da bir mermi çıkarmak zorunda kalmadı.</GlitterworldSurgeon15.description>
   <!-- EN: glitterworld surgeon -->
   <GlitterworldSurgeon15.title>glitterworld cerrahı</GlitterworldSurgeon15.title>
   <!-- EN: surgeon -->

--- a/Core/DefInjected/BackstoryDef/Offworld_Nonspecific_Adult.xml
+++ b/Core/DefInjected/BackstoryDef/Offworld_Nonspecific_Adult.xml
@@ -20,7 +20,7 @@
   <AnimalFarmer21.titleShortFemale>hayvan çiftçisi</AnimalFarmer21.titleShortFemale>
   
   <!-- EN: After taking a vow of silence, [PAWN_nameDef] joined a monastery to spend [PAWN_possessive] days in quiet contemplation.\n\n[PAWN_pronoun] found happiness growing vegetables in the garden and making cheese in the monastery cellars. -->
-  <AsceticPriest84.description>[PAWN_nameDef] sessizlik yemini ettikten sonra günlerini sessizce tefekkür içinde geçirmek için bir manastıra katıldı.\n\n Bahçede sebze yetiştirmenin ve manastırın mahzenlerinde peynir yapmanın mutluluğunu buldu.</AsceticPriest84.description>
+  <AsceticPriest84.description>[PAWN_nameDef] sessizlik yemini ettikten sonra günlerini sessizce tefekkür içinde geçirmek için bir manastıra katıldı.\n\nBahçede sebze yetiştirmenin ve manastırın mahzenlerinde peynir yapmanın mutluluğunu buldu.</AsceticPriest84.description>
   <!-- EN: ascetic priest -->
   <AsceticPriest84.title>münzevi rahip</AsceticPriest84.title>
   <AsceticPriest84.titleFemale>münzevi rahip</AsceticPriest84.titleFemale>
@@ -83,7 +83,7 @@
   <ConArtist80.titleShortFemale>dubaracı</ConArtist80.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was well-known in art circles on [PAWN_possessive] home world for [PAWN_possessive] unique and creative conceptual artworks.\n\nNobody was sure exactly what [PAWN_pronoun] was trying to communicate, but [PAWN_possessive] pieces were highly valued by collectors. -->
-  <ConceptualArtist39.description>[PAWN_nameDef], benzersiz ve yaratıcı kavramsal sanat eserleriyle kendi dünyasındaki sanat çevrelerinde iyi biliniyordu. \n\n Kimse tam olarak ne anlatmaya çalıştığından emin değildi, ancak parçaları koleksiyoncular tarafından çok değerliydi.</ConceptualArtist39.description>
+  <ConceptualArtist39.description>[PAWN_nameDef], benzersiz ve yaratıcı kavramsal sanat eserleriyle kendi dünyasındaki sanat çevrelerinde iyi biliniyordu.\n\nKimse tam olarak ne anlatmaya çalıştığından emin değildi, ancak parçaları koleksiyoncular tarafından çok değerliydi.</ConceptualArtist39.description>
   <!-- EN: conceptual artist -->
   <ConceptualArtist39.title>kavramsal sanatçı</ConceptualArtist39.title>
   <ConceptualArtist39.titleFemale>kavramsal sanatçı</ConceptualArtist39.titleFemale>
@@ -92,13 +92,13 @@
   <ConceptualArtist39.titleShortFemale>sanatçı</ConceptualArtist39.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was a construction worker. [PAWN_pronoun] lead a team which built everything from office blocks to cathedrals.\n\n[PAWN_possessive] busy job and numerous nearby fast-food outlets meant [PAWN_pronoun] never cooked for [PAWN_objective]self. -->
-  <ConstructionEngineer32.description>[PAWN_nameDef] bir inşaat işçisiydi. Ofis bloklarından katedrallere kadar her şeyi inşa eden bir ekibi yönetiyor. \n\n. Meşgul olması yüzünden yakınlardaki fast-food yemeklerini yiyordu.Bu kendisi için asla yemek pişirmediği anlamına geliyordu.</ConstructionEngineer32.description>
+  <ConstructionEngineer32.description>[PAWN_nameDef] bir inşaat işçisiydi. Ofis bloklarından katedrallere kadar her şeyi inşa eden bir ekibi yönetiyor.\n\nMeşgul olması yüzünden yakınlardaki fast-food yemeklerini yiyordu.Bu kendisi için asla yemek pişirmediği anlamına geliyordu.</ConstructionEngineer32.description>
   <!-- EN: construction engineer -->
   <ConstructionEngineer32.title>kuvramsal mühendis</ConstructionEngineer32.title>
   <ConstructionEngineer32.titleFemale>kuvramsal mühendis</ConstructionEngineer32.titleFemale>
   <!-- EN: builder -->
-  <ConstructionEngineer32.titleShort>inşaatçı</ConstructionEngineer32.titleShort>
-  <ConstructionEngineer32.titleShortFemale>inşaatçı</ConstructionEngineer32.titleShortFemale>
+  <ConstructionEngineer32.titleShort>İnşaatçı</ConstructionEngineer32.titleShort>
+  <ConstructionEngineer32.titleShortFemale>İnşaatçı</ConstructionEngineer32.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] moved from job to job, extracting minerals and ancient valuables in tunnels and strip-mines. The work was tough and dirty, but [PAWN_pronoun] found it rewarding. -->
   <ContractMiner86.description>[PAWN_nameDef], tünellerde ve maden ocaklarında mineralleri ve eski değerli eşyaları çıkararak işten işe taşındı. İş zor ve kirliydi ama o ödüllendirici buldu.</ContractMiner86.description>
@@ -110,7 +110,7 @@
   <ContractMiner86.titleShortFemale>sözleşmeli madenci</ContractMiner86.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] worked in a massive open-plan office, ensuring that [PAWN_possessive] assigned team of workers stayed mostly on-task.\n\nThe job was intensely political. In order to advance, [PAWN_nameDef] learned how to arrange things so [PAWN_pronoun] could take credit for work done by almost anyone. -->
-  <CorporateManager76.description>[PAWN_nameDef] devasa bir açık plan ofiste çalıştı ve kendisine atanan işçi ekibinin çoğunlukla görev başında kalmasını sağladı.\n\n İş yoğun bir şekilde politikti. [PAWN_nameDef] ilerlemek için işleri nasıl düzenleyeceğini öğrendi, böylece neredeyse herkes tarafından yapılan işler için kredi alabilirdi.</CorporateManager76.description>
+  <CorporateManager76.description>[PAWN_nameDef] devasa bir açık plan ofiste çalıştı ve kendisine atanan işçi ekibinin çoğunlukla görev başında kalmasını sağladı.\n\nİş yoğun bir şekilde politikti. [PAWN_nameDef] ilerlemek için işleri nasıl düzenleyeceğini öğrendi, böylece neredeyse herkes tarafından yapılan işler için kredi alabilirdi.</CorporateManager76.description>
   <!-- EN: corporate manager -->
   <CorporateManager76.title>kurumsal yönetici</CorporateManager76.title>
   <CorporateManager76.titleFemale>kurumsal yönetici</CorporateManager76.titleFemale>
@@ -137,7 +137,7 @@
   <CropFarmer17.titleShortFemale>çiftçi</CropFarmer17.titleShortFemale>
   
   <!-- EN: Early in [PAWN_possessive] adulthood, [PAWN_nameDef] decided to leave the oppressive dictatorship where [PAWN_pronoun] lived. [PAWN_possessive] defection was not well-received, and agents were sent out after [PAWN_objective].\n\n[PAWN_pronoun] spent years on the run, treating [PAWN_possessive] own wounds so no doctor could betray [PAWN_objective]. The ordeal made [PAWN_objective] bitter and untrusting. -->
-  <Defector78.description>[PAWN_nameDef], yetişkinliğinin başlarında yaşadığı baskıcı diktatörlüğü bırakmaya karar verdi. İltica etmesi iyi karşılanmadı ve ajanlar onun peşinden gönderildi.\n\n Hiçbir doktor ona ihanet etmesin diye yıllarını kaçarak kendi yaralarını tedavi ederek geçirdi. Bu çile onu sert ve güvensiz yaptı.</Defector78.description>
+  <Defector78.description>[PAWN_nameDef], yetişkinliğinin başlarında yaşadığı baskıcı diktatörlüğü bırakmaya karar verdi. İltica etmesi iyi karşılanmadı ve ajanlar onun peşinden gönderildi.\n\nHiçbir doktor ona ihanet etmesin diye yıllarını kaçarak kendi yaralarını tedavi ederek geçirdi. Bu çile onu sert ve güvensiz yaptı.</Defector78.description>
   <!-- EN: defector -->
   <Defector78.title>mülteci</Defector78.title>
   <Defector78.titleFemale>mülteci</Defector78.titleFemale>
@@ -146,7 +146,7 @@
   <Defector78.titleShortFemale>mülteci</Defector78.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] never figured out what to do with [PAWN_possessive] life. [PAWN_pronoun] traveled often, taking up casual work wherever [PAWN_pronoun] found it.\n\n[PAWN_pronoun] also occasionally worked on a novel that [PAWN_pronoun] knew would be a bestseller - just as soon as [PAWN_pronoun] could find a publisher who was interested. -->
-  <Drifter67.description>[PAWN_nameDef] hayatıyla ne yapacağını asla bulamadı. Sık sık seyahat eder, bulduğu her yerde gündelik işlere başlardı.\n\n Ayrıca ara sıra en çok satan olacağını bildiği bir roman üzerinde çalıştı - tam da ilgilenen bir yayıncı bulur bulmaz.</Drifter67.description>
+  <Drifter67.description>[PAWN_nameDef] hayatıyla ne yapacağını asla bulamadı. Sık sık seyahat eder, bulduğu her yerde gündelik işlere başlardı.\n\nAyrıca ara sıra en çok satan olacağını bildiği bir roman üzerinde çalıştı - tam da ilgilenen bir yayıncı bulur bulmaz.</Drifter67.description>
   <!-- EN: drifter -->
   <Drifter67.title>avare</Drifter67.title>
   <Drifter67.titleFemale>avare</Drifter67.titleFemale>
@@ -208,7 +208,7 @@
   <Gardener99.titleShortFemale>bahçıvan</Gardener99.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] worked with miners and cave-diggers, identifying rock types and natural formations.\n\nDuring [PAWN_possessive] years underground [PAWN_pronoun] also gained experience repairing drilling machines and other technical equipment. -->
-  <Geologist66.description>[PAWN_nameDef], kaya türlerini ve doğal oluşumları belirleyerek madenciler ve mağara kazıcılarıyla birlikte çalıştı.\n\n Yeraltında geçirdiği yıllarda, sondaj makineleri ve diğer teknik ekipmanların onarımında da deneyim kazandı.</Geologist66.description>
+  <Geologist66.description>[PAWN_nameDef], kaya türlerini ve doğal oluşumları belirleyerek madenciler ve mağara kazıcılarıyla birlikte çalıştı.\n\nYeraltında geçirdiği yıllarda, sondaj makineleri ve diğer teknik ekipmanların onarımında da deneyim kazandı.</Geologist66.description>
   <!-- EN: geologist -->
   <Geologist66.title>jeolog</Geologist66.title>
   <Geologist66.titleFemale>jeolog</Geologist66.titleFemale>
@@ -228,7 +228,7 @@
   <Housemate8.titleShortFemale>ev hanımı</Housemate8.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was a domestic servant to wealthy homeowners.\n\n[PAWN_pronoun] got to know the kitchens and basements of [PAWN_possessive] master's mansion well, but never did any work outside. -->
-  <HouseServant63.description>[PAWN_nameDef] varlıklı ev sahiplerinin hizmetçisiydi.\n\n Efendisinin malikanesinin mutfaklarını ve bodrum katlarını iyi tanıyordu ama dışarıda hiç çalışmadı.</HouseServant63.description>
+  <HouseServant63.description>[PAWN_nameDef] varlıklı ev sahiplerinin hizmetçisiydi.\n\nEfendisinin malikanesinin mutfaklarını ve bodrum katlarını iyi tanıyordu ama dışarıda hiç çalışmadı.</HouseServant63.description>
   <!-- EN: house servant -->
   <HouseServant63.title>ev hizmetçisi</HouseServant63.title>
   <HouseServant63.titleFemale>ev hizmetçisi</HouseServant63.titleFemale>
@@ -291,7 +291,7 @@
   <LowWageWorker7.titleShortFemale>ayakçı</LowWageWorker7.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was obsessed with old machines and arcane pieces of technology. [PAWN_pronoun] obtained them wherever [PAWN_pronoun] could, and loved taking them apart to see how they worked.\n\n[PAWN_pronoun] had a habit of talking about [PAWN_possessive] collection long after people around [PAWN_objective] had stopped listening. -->
-  <MachineCollector55.description>[PAWN_nameDef] eski makinelere ve gizli teknoloji parçalarına takıntılıydı. Onları bulabildiği her yerden alırdı ve nasıl çalıştıklarını görmek için onları parçalamayı severdi.\n\n Etrafındaki insanlar dinlemeyi bıraktıktan çok sonra bile koleksiyonu hakkında konuşma alışkanlığı edindi.</MachineCollector55.description>
+  <MachineCollector55.description>[PAWN_nameDef] eski makinelere ve gizli teknoloji parçalarına takıntılıydı. Onları bulabildiği her yerden alırdı ve nasıl çalıştıklarını görmek için onları parçalamayı severdi.\n\nEtrafındaki insanlar dinlemeyi bıraktıktan çok sonra bile koleksiyonu hakkında konuşma alışkanlığı edindi.</MachineCollector55.description>
   <!-- EN: machine collector -->
   <MachineCollector55.title>makine koleksiyoncusu</MachineCollector55.title>
   <MachineCollector55.titleFemale>makine koleksiyoncusu</MachineCollector55.titleFemale>
@@ -300,7 +300,7 @@
   <MachineCollector55.titleShortFemale>koleksiyoncu</MachineCollector55.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] did mathematical research at a university.\n\n[PAWN_pronoun] spent much of [PAWN_possessive] spare time immersed in shooting simulations, though [PAWN_pronoun] was frequently ridiculed by other players for [PAWN_possessive] terrible aim. -->
-  <Mathematician6.description>[PAWN_nameDef] bir üniversitede matematiksel araştırma yaptı.\n\n Boş zamanlarının çoğunu atış simülasyonlarıyla geçirdi, ancak korkunç atışları nedeniyle diğer oyuncular tarafından sık sık alay konusu oldu.</Mathematician6.description>
+  <Mathematician6.description>[PAWN_nameDef] bir üniversitede matematiksel araştırma yaptı.\n\nBoş zamanlarının çoğunu atış simülasyonlarıyla geçirdi, ancak korkunç atışları nedeniyle diğer oyuncular tarafından sık sık alay konusu oldu.</Mathematician6.description>
   <!-- EN: mathematician -->
   <Mathematician6.title>metematikçi</Mathematician6.title>
   <Mathematician6.titleFemale>metematikçi</Mathematician6.titleFemale>
@@ -316,7 +316,7 @@
   <Model99.titleShort>model</Model99.titleShort>
   
   <!-- EN: [PAWN_nameDef] worked in a hospital, doing routine work such as changing bandages and taking temperatures.\n\nIt was a busy job, but [PAWN_pronoun] could always find time for a chat with a patient. -->
-  <Nurse61.description>[PAWN_nameDef] bir hastanede çalıştı, bandaj değiştirmek ve ateş ölçmek gibi rutin işler yaptı.\n\n Yoğun bir işti ama her zaman bir hastayla sohbet etmek için zaman bulabilirdi.</Nurse61.description>
+  <Nurse61.description>[PAWN_nameDef] bir hastanede çalıştı, bandaj değiştirmek ve ateş ölçmek gibi rutin işler yaptı.\n\nYoğun bir işti ama her zaman bir hastayla sohbet etmek için zaman bulabilirdi.</Nurse61.description>
   <!-- EN: nurse -->
   <Nurse61.title>hemşire</Nurse61.title>
   <Nurse61.titleFemale>hemşire</Nurse61.titleFemale>
@@ -325,7 +325,7 @@
   <Nurse61.titleShortFemale>hemşire</Nurse61.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef]'s job was to respond rapidly to medical emergencies. [PAWN_pronoun] is used to dealing with severe injuries with only limited medical supplies.\n\n[PAWN_pronoun] treated so many gunshot wounds over the years that even seeing a gun made [PAWN_objective] uncomfortable. -->
-  <Paramedic45.description>[PAWN_nameDef]'in işi, tıbbi acil durumlara hızla yanıt vermekti. Sadece sınırlı tıbbi malzemeyle ciddi yaralanmalarla uğraşmaya alışkın.\n\n Yıllar içinde o kadar çok kurşun yarası tedavi etti ki, silah görmek bile onu rahatsız etti.</Paramedic45.description>
+  <Paramedic45.description>[PAWN_nameDef]'in işi, tıbbi acil durumlara hızla yanıt vermekti. Sadece sınırlı tıbbi malzemeyle ciddi yaralanmalarla uğraşmaya alışkın.\n\nYıllar içinde o kadar çok kurşun yarası tedavi etti ki, silah görmek bile onu rahatsız etti.</Paramedic45.description>
   <!-- EN: paramedic -->
   <Paramedic45.title>paramedik</Paramedic45.title>
   <Paramedic45.titleFemale>paramedik</Paramedic45.titleFemale>
@@ -334,7 +334,7 @@
   <Paramedic45.titleShortFemale>paramedik</Paramedic45.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] kept the peace as a line officer in a municipal social enforcement unit.\n\n[PAWN_pronoun] was trained in de-escalation, physical control, shooting, and other police skills. -->
-  <Policeman45.description>[PAWN_nameDef], bir belediye polis teşkilatında bir kolluk kuvveti olarak huzuru sağladı.\n\n. Gerginliği azaltma, fiziksel kontrol, ateş etme ve diğer polis becerileri konusunda eğitim aldı.</Policeman45.description>
+  <Policeman45.description>[PAWN_nameDef], bir belediye polis teşkilatında bir kolluk kuvveti olarak huzuru sağladı.\n\nGerginliği azaltma, fiziksel kontrol, ateş etme ve diğer polis becerileri konusunda eğitim aldı.</Policeman45.description>
   <!-- EN: policeman -->
   <Policeman45.title>polis</Policeman45.title>
   <!-- EN: policewoman -->
@@ -354,7 +354,7 @@
   <QuarryWorker29.titleShortFemale>taş ocağı işçisi</QuarryWorker29.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] owned and operated a successful ranch where [PAWN_pronoun] raised animals for meat and wool.\n\n[PAWN_pronoun] refused to do any dumb labour [PAWN_pronoun] could pay someone else to do for [PAWN_objective]. -->
-  <Rancher43.description>[PAWN_nameDef], et ve yün için hayvanlar yetiştirdiği başarılı bir çiftliğin sahibi ve işletmecisiydi.\n\n. Parasını ödeyip yaptırabileceği işleri yapmayı istemiyordu.</Rancher43.description>
+  <Rancher43.description>[PAWN_nameDef], et ve yün için hayvanlar yetiştirdiği başarılı bir çiftliğin sahibi ve işletmecisiydi.\n\nParasını ödeyip yaptırabileceği işleri yapmayı istemiyordu.</Rancher43.description>
   <!-- EN: rancher -->
   <Rancher43.title>çiftlik sahibi</Rancher43.title>
   <Rancher43.titleFemale>çiftlik sahibi</Rancher43.titleFemale>
@@ -372,13 +372,13 @@
   <Ranger96.titleShortFemale>korucu</Ranger96.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was part of a revered order of martial artists, infamous both for their skill in combat and for their practice of refusing to treat their wounded.\n\n[PAWN_pronoun] traveled [PAWN_possessive] homeworld, judging the young people [PAWN_pronoun] met to determine if they might be suitable for training. -->
-  <Recruiter14.description>[PAWN_nameDef], hem dövüş becerileri hem de yaralılarını tedavi etmeyi reddetme uygulamalarıyla ün salmış, saygı duyulan dövüş sanatçıları tarikatının bir parçasıydı.\n\n Tanıştığı gençleri eğitim için uygun olup olmadıklarını belirlemek için değerlendirerek anavatanını gezdi.</Recruiter14.description>
+  <Recruiter14.description>[PAWN_nameDef], hem dövüş becerileri hem de yaralılarını tedavi etmeyi reddetme uygulamalarıyla ün salmış, saygı duyulan dövüş sanatçıları tarikatının bir parçasıydı.\n\nTanıştığı gençleri eğitim için uygun olup olmadıklarını belirlemek için değerlendirerek anavatanını gezdi.</Recruiter14.description>
   <!-- EN: recruiter -->
-  <Recruiter14.title>işe alım görevlisi</Recruiter14.title>
-  <Recruiter14.titleFemale>işe alım görevlisi</Recruiter14.titleFemale>
+  <Recruiter14.title>İşe alım görevlisi</Recruiter14.title>
+  <Recruiter14.titleFemale>İşe alım görevlisi</Recruiter14.titleFemale>
   <!-- EN: recruiter -->
-  <Recruiter14.titleShort>işe alım görevlisi</Recruiter14.titleShort>
-  <Recruiter14.titleShortFemale>işe alım görevlisi</Recruiter14.titleShortFemale>
+  <Recruiter14.titleShort>İşe alım görevlisi</Recruiter14.titleShort>
+  <Recruiter14.titleShortFemale>İşe alım görevlisi</Recruiter14.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] slaughtered animals for a living. Others looked down on this work as filthy, but the skills required to manage and cleanly slaughter large numbers of animals were never simple. -->
   <Slaughterer58.description>[PAWN_nameDef] geçimini sağlamak için hayvanları kesti. Diğerleri bu işi pis olarak gördü, ancak çok sayıda hayvanı yönetmek ve temiz bir şekilde kesmek için gereken beceriler asla basit değildi.</Slaughterer58.description>
@@ -401,11 +401,11 @@
   <!-- EN: Working for a tyrannical dictator, [PAWN_nameDef] earned a reputation as an expert in 'persuasion.' Any prisoner who went down into the dungeons left with no secrets - and with [PAWN_nameDef]'s smile scarred permanently into their nightmares. -->
   <Torturer37.description>Zalim bir diktatör için çalışan [PAWN_nameDef], 'ikna etme' konusunda uzman olarak ün kazandı. Zindanlara giren herhangi bir mahkûmun hemen dili çözülürdü ve [PAWN_nameDef]'nin kahkahaları kabuslarına kalıcı olarak girerdi.</Torturer37.description>
   <!-- EN: torturer -->
-  <Torturer37.title>işkenceci</Torturer37.title>
-  <Torturer37.titleFemale>işkenceci</Torturer37.titleFemale>
+  <Torturer37.title>İşkenceci</Torturer37.title>
+  <Torturer37.titleFemale>İşkenceci</Torturer37.titleFemale>
   <!-- EN: torturer -->
-  <Torturer37.titleShort>işkenceci</Torturer37.titleShort>
-  <Torturer37.titleShortFemale>işkenceci</Torturer37.titleShortFemale>
+  <Torturer37.titleShort>İşkenceci</Torturer37.titleShort>
+  <Torturer37.titleShortFemale>İşkenceci</Torturer37.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] treated sick and injured animals for a living. Seeing their suffering affected [PAWN_possessive] stance on the practice of eating meat, and for many years [PAWN_pronoun] lived as a vegetarian. -->
   <Veterinarian99.description>[PAWN_nameDef] hasta ve yaralı hayvanları tedavi etti. Acılarını görmek, et yeme konusundaki tutumunu etkiledi ve uzun yıllar vejeteryan olarak yaşadı.</Veterinarian99.description>

--- a/Core/DefInjected/BackstoryDef/Offworld_Nonspecific_Child.xml
+++ b/Core/DefInjected/BackstoryDef/Offworld_Nonspecific_Child.xml
@@ -2,7 +2,7 @@
 <LanguageData>
   
   <!-- EN: Children are presumed innocent, which makes them excellent spies. [PAWN_nameDef] was trained in the art of infiltration when [PAWN_pronoun] was just a small child.\n\n[PAWN_possessive] years undercover gave [PAWN_objective] experience with social manipulation and lying, but [PAWN_pronoun] never had a normal education. -->
-  <ChildSpy47.description>Çocukların masum olduğu varsayılır, bu da onları mükemmel casuslar yapar. [PAWN_nameDef] daha küçük bir çocukken sızma sanatı konusunda eğitildi.\n\n Gizli görevi ona sosyal manipülasyon ve yalan söyleme konusunda deneyim kazandırdı, ancak hiçbir zaman normal bir eğitimi olmadı.</ChildSpy47.description>
+  <ChildSpy47.description>Çocukların masum olduğu varsayılır, bu da onları mükemmel casuslar yapar. [PAWN_nameDef] daha küçük bir çocukken sızma sanatı konusunda eğitildi.\n\nGizli görevi ona sosyal manipülasyon ve yalan söyleme konusunda deneyim kazandırdı, ancak hiçbir zaman normal bir eğitimi olmadı.</ChildSpy47.description>
   <!-- EN: child spy -->
   <ChildSpy47.title>casus çocuk</ChildSpy47.title>
   <ChildSpy47.titleFemale>casus çocuk</ChildSpy47.titleFemale>
@@ -25,14 +25,14 @@
   <ComaChild93.titleShort>komadaki çocuk</ComaChild93.titleShort>
   
   <!-- EN: [PAWN_nameDef] was born into a powerful cult which shunned advanced technology and believed that all illness could be cured by cleansing the soul through sacred art.\n\nAfter [PAWN_possessive] first glimpse of the outside world, [PAWN_pronoun] decided to run away. -->
-  <CultChild3.description>[PAWN_nameDef], ileri teknolojiden kaçınan ve tüm hastalıkların  ruhsal kutsal sanat yoluyla temizleyerek iyileştirilebileceğine inanan güçlü bir tarikatın içinde doğdu.\n\n Dış dünyaya ilk bakışından sonra kaçmaya karar verdi.</CultChild3.description>
+  <CultChild3.description>[PAWN_nameDef], ileri teknolojiden kaçınan ve tüm hastalıkların  ruhsal kutsal sanat yoluyla temizleyerek iyileştirilebileceğine inanan güçlü bir tarikatın içinde doğdu.\n\nDış dünyaya ilk bakışından sonra kaçmaya karar verdi.</CultChild3.description>
   <!-- EN: cult child -->
   <CultChild3.title>tarikat çoçuğu</CultChild3.title>
   <!-- EN: cult kid -->
   <CultChild3.titleShort>tarikat çoçuğu</CultChild3.titleShort>
   
   <!-- EN: [PAWN_nameDef] grew up with a laundry list of phobias and neuroses. [PAWN_pronoun] feared, among other things, doctors and foodborne pathogens.\n\nAs a result, [PAWN_pronoun] learned to cook and care for [PAWN_objective]self, but many of [PAWN_possessive] fears dog [PAWN_objective] in adulthood. -->
-  <FrightenedChild43.description>[PAWN_nameDef] fobiler ve sinir krizleriyle bereber bir şekilde büyüdü. Diğer şeylerin yanı sıra doktorlardan ve gıda kaynaklı patojenlerden korktu.\n\n Sonuç olarak, yemek yapmayı ve kendine bakmayı öğrendi, ancak korkularının çoğu yetişkinliğinde de onu korkutuyor.</FrightenedChild43.description>
+  <FrightenedChild43.description>[PAWN_nameDef] fobiler ve sinir krizleriyle bereber bir şekilde büyüdü. Diğer şeylerin yanı sıra doktorlardan ve gıda kaynaklı patojenlerden korktu.\n\nSonuç olarak, yemek yapmayı ve kendine bakmayı öğrendi, ancak korkularının çoğu yetişkinliğinde de onu korkutuyor.</FrightenedChild43.description>
   <!-- EN: frightened child -->
   <FrightenedChild43.title>ürkmüş çocuk</FrightenedChild43.title>
   <!-- EN: scared -->
@@ -73,7 +73,7 @@
   <OrganFarm67.titleShort>organ tarlası</OrganFarm67.titleShort>
   
   <!-- EN: From an early age, [PAWN_nameDef] had an unhealthy fascination with fire. [PAWN_pronoun] would set refuse heaps ablaze and become so entranced by the flames [PAWN_pronoun] would absent-mindedly burn [PAWN_objective]self.\n\nOne day while playing with matches, [PAWN_pronoun] carelessly burned down [PAWN_possessive] home. -->
-  <Pyromaniac18.description>[PAWN_nameDef], erken yaşlardan itibaren ateşe sağlıksız bir ilgi duymuştur. Çöp yığınlarını tutuşturur ve alevlerin büyüsüne kapılarak dalgınlıkla kendini yakardı.\n\n Bir gün kibritle oynarken evini dikkatsizce yaktı.</Pyromaniac18.description>
+  <Pyromaniac18.description>[PAWN_nameDef], erken yaşlardan itibaren ateşe sağlıksız bir ilgi duymuştur. Çöp yığınlarını tutuşturur ve alevlerin büyüsüne kapılarak dalgınlıkla kendini yakardı.\n\nBir gün kibritle oynarken evini dikkatsizce yaktı.</Pyromaniac18.description>
   <!-- EN: pyromaniac -->
   <Pyromaniac18.title>piromanik</Pyromaniac18.title>
   <Pyromaniac18.titleFemale>piromanik</Pyromaniac18.titleFemale>
@@ -88,7 +88,7 @@
   <ShopKid36.titleShort>marketçi</ShopKid36.titleShort>
   
   <!-- EN: As a child, [PAWN_nameDef] suffered from a rare disease. Quarantined in a hospital, [PAWN_pronoun] had minimal human contact and got little physical exercise. In the sterile hospital environment, however, [PAWN_pronoun] became very familiar with science and medicine. -->
-  <SicklyChild55.description>[PAWN_nameDef] çocukken nadir görülen bir hastalıktan mustaripti. Bir hastanede karantinaya alındı, çok az insanla teması oldu ve çok az fiziksel egzersiz yaptı. Ancak steril hastane ortamında bilim ve tıbba çok aşina oldu.</SicklyChild55.description>
+  <SicklyChild55.description>[PAWN_nameDef] çocukken nadir görülen bir hastalıktan muzdaripti. Bir hastanede karantinaya alındı, çok az insanla teması oldu ve çok az fiziksel egzersiz yaptı. Ancak steril hastane ortamında bilim ve tıbba çok aşina oldu.</SicklyChild55.description>
   <!-- EN: sickly child -->
   <SicklyChild55.title>hasta çocuk</SicklyChild55.title>
   <!-- EN: patient -->
@@ -114,7 +114,7 @@
   <VatgrownSoldier8.titleShortFemale>klonoid</VatgrownSoldier8.titleShortFemale>
   
   <!-- EN: War broke out in [PAWN_nameDef]'s home when [PAWN_pronoun] was a baby. [PAWN_possessive] parents fled with [PAWN_objective], seeking safety wherever they could find it. [PAWN_nameDef]'s earliest memories are of being taught how to defend [PAWN_objective]self.\n\nThe violence and destruction [PAWN_pronoun] witnessed left [PAWN_objective] scarred for life. -->
-  <WarRefugee51.description>[PAWN_nameDef] bebekken evinde savaş çıktı. Ailesi, bulabilecekleri her yerde güvenlik arayarak onunla kaçtı. [PAWN_nameDef]'nin eski anılarında sadece kendini nasıl savunacağının öğretilmesi vardı.\n\n Tanık olduğu şiddet ve yıkım onu ömür boyu zihinsel olarak yaraladı.</WarRefugee51.description>
+  <WarRefugee51.description>[PAWN_nameDef] bebekken evinde savaş çıktı. Ailesi, bulabilecekleri her yerde güvenlik arayarak onunla kaçtı. [PAWN_nameDef]'nin eski anılarında sadece kendini nasıl savunacağının öğretilmesi vardı.\n\nTanık olduğu şiddet ve yıkım onu ömür boyu zihinsel olarak yaraladı.</WarRefugee51.description>
   <!-- EN: war refugee -->
   <WarRefugee51.title>savaş mültecisi</WarRefugee51.title>
   <!-- EN: refugee -->

--- a/Core/DefInjected/BackstoryDef/Offworld_Specific_Adult.xml
+++ b/Core/DefInjected/BackstoryDef/Offworld_Specific_Adult.xml
@@ -2,7 +2,7 @@
 <LanguageData>
   
   <!-- EN: [PAWN_nameDef] was the only survivor of a ship crash on an unhabited animal world. For many years until [PAWN_possessive] rescue [PAWN_pronoun] scrounged an existence out of whatever [PAWN_pronoun] could find.\n\n[PAWN_possessive] survival skills became razor-sharp, but spending so long alone severely dampened [PAWN_possessive] conversatial abilities. -->
-  <Castaway57.description>[PAWN_nameDef], ıssız bir hayvan dünyasında bir gemi kazasından kurtulan tek kişiydi. Kurtarılmasına kadar uzun yıllar boyunca bulabildiği her türden varlık aradı.\n\n Hayatta kalma becerileri keskinleşti, ancak bu kadar uzun süre yalnız kalmak konuşma yeteneklerini ciddi şekilde azalttı.</Castaway57.description>
+  <Castaway57.description>[PAWN_nameDef], ıssız bir hayvan dünyasında bir gemi kazasından kurtulan tek kişiydi. Kurtarılmasına kadar uzun yıllar boyunca bulabildiği her türden varlık aradı.\n\nHayatta kalma becerileri keskinleşti, ancak bu kadar uzun süre yalnız kalmak konuşma yeteneklerini ciddi şekilde azalttı.</Castaway57.description>
   <!-- EN: castaway -->
   <Castaway57.title>kazazede</Castaway57.title>
   <Castaway57.titleFemale>kazazede</Castaway57.titleFemale>
@@ -20,7 +20,7 @@
   <CaveworldIlluminator95.titleShortFemale>tezhipçi</CaveworldIlluminator95.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was a settler on a new colony world.\n\nSuch a life requires a jack-of-all trades at basic hands-on tasks. -->
-  <ColonySettler53.description>[PAWN_nameDef], yeni bir koloni dünyasının yerleşimcisiydi.\n\n Böyle bir yaşam, temel uygulamalı görevlerde her şeyden önce bir esnaf gerektirir.</ColonySettler53.description>
+  <ColonySettler53.description>[PAWN_nameDef], yeni bir koloni dünyasının yerleşimcisiydi.\n\nBöyle bir yaşam, temel uygulamalı görevlerde her şeyden önce bir esnaf gerektirir.</ColonySettler53.description>
   <!-- EN: colony settler -->
   <ColonySettler53.title>koloni yerleşimcisi</ColonySettler53.title>
   <ColonySettler53.titleFemale>koloni yerleşimcisi</ColonySettler53.titleFemale>
@@ -43,18 +43,18 @@
   <FactoryWorker58.title>fabrika işçisi</FactoryWorker58.title>
   <FactoryWorker58.titleFemale>fabrika işçisi</FactoryWorker58.titleFemale>
   <!-- EN: worker -->
-  <FactoryWorker58.titleShort>işçi</FactoryWorker58.titleShort>
-  <FactoryWorker58.titleShortFemale>işçi</FactoryWorker58.titleShortFemale>
+  <FactoryWorker58.titleShort>İşçi</FactoryWorker58.titleShort>
+  <FactoryWorker58.titleShortFemale>İşçi</FactoryWorker58.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] turned out to have an excellent memory and a gift for performing complex calculations in [PAWN_possessive] head. An industrial-world dictator decided to employ [PAWN_nameDef] to keep track of [PAWN_possessive] state's finances and expenditure. -->
   <HumanComputer83.description>[PAWN_nameDef] mükemmel bir hafızaya ve kafasında karmaşık hesaplamalar yapmak için bir yeteneğe sahip olduğu ortaya çıktı. Bir sanayi dünyası diktatörü, devletinin mali durumunu ve harcamalarını takip etmek için [PAWN_nameDef]'yi kullanmaya karar verdi.</HumanComputer83.description>
   <!-- EN: human computer -->
-  <HumanComputer83.title>insan bilgisayar</HumanComputer83.title>
+  <HumanComputer83.title>İnsan bilgisayar</HumanComputer83.title>
   <!-- EN: computer -->
   <HumanComputer83.titleShort>bilgisayar</HumanComputer83.titleShort>
   
   <!-- EN: [PAWN_nameDef] worked in an urbworld lab developing cutting-edge joywire software to maximize user pleasure.\n\nWhen the local government imposed harsh restrictions on joywire manufacturing, [PAWN_pronoun] began selling [PAWN_possessive] products on the black market. -->
-  <JoywireArtist8.description>[PAWN_nameDef], kullanıcı memnuniyetini en üst düzeye çıkarmak için son teknoloji joywire geliştiren bir urbworld laboratuvarında çalıştı.\n\n Yerel hükümet, joywire üretimine sert kısıtlamalar getirdiğinde, ürünlerini karaborsada satmaya başladı.</JoywireArtist8.description>
+  <JoywireArtist8.description>[PAWN_nameDef], kullanıcı memnuniyetini en üst düzeye çıkarmak için son teknoloji joywire geliştiren bir urbworld laboratuvarında çalıştı.\n\nYerel hükümet, joywire üretimine sert kısıtlamalar getirdiğinde, ürünlerini karaborsada satmaya başladı.</JoywireArtist8.description>
   <!-- EN: joywire artist -->
   <JoywireArtist8.title>joywire üreticisi</JoywireArtist8.title>
   <JoywireArtist8.titleFemale>joywire üreticisi</JoywireArtist8.titleFemale>
@@ -63,14 +63,14 @@
   <JoywireArtist8.titleShortFemale>joywirer</JoywireArtist8.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was a high-ranking member of an urbworld crime syndicate.\n\n[PAWN_pronoun] bribed officials, maintained the loyalty of [PAWN_possessive] subordinates, and extracted overdue payments - by any means necessary. -->
-  <MafiaBoss17.description>[PAWN_nameDef] bir urbworld suç örgütünün yüksek rütbeli bir üyesiydi.\n\n Yetkililere rüşvet verdi, astlarının sadakatini sürdürdü ve her ne pahasına olursa olsun gecikmiş ödemeleri tahsil etti.</MafiaBoss17.description>
+  <MafiaBoss17.description>[PAWN_nameDef] bir urbworld suç örgütünün yüksek rütbeli bir üyesiydi.\n\nYetkililere rüşvet verdi, astlarının sadakatini sürdürdü ve her ne pahasına olursa olsun gecikmiş ödemeleri tahsil etti.</MafiaBoss17.description>
   <!-- EN: mafia boss -->
   <MafiaBoss17.title>mafya patronu</MafiaBoss17.title>
   <!-- EN: boss -->
   <MafiaBoss17.titleShort>patron</MafiaBoss17.titleShort>
   
   <!-- EN: [PAWN_nameDef] spent most of [PAWN_possessive] adult life in an insane asylum. [PAWN_possessive] industrial homeworld had a poor understanding of mental illness, and [PAWN_pronoun] was treated more like an animal than a person.\n\nThough [PAWN_pronoun] eventually recovered and was released, [PAWN_possessive] experience dampened many of [PAWN_possessive] basic life skills. -->
-  <PsychiatricPatient94.description>[PAWN_nameDef] yetişkin yaşamının çoğunu bir akıl hastanesinde geçirdi. Endüstriyel anavatanı akıl hastalığı konusunda zayıf bir anlayışa sahipti ve ona bir insandan çok bir hayvan gibi davranıldı.\n\n Sonunda iyileşip serbest bırakılsa da, deneyimi temel yaşam becerilerinin çoğunu azalttı.</PsychiatricPatient94.description>
+  <PsychiatricPatient94.description>[PAWN_nameDef] yetişkin yaşamının çoğunu bir akıl hastanesinde geçirdi. Endüstriyel anavatanı akıl hastalığı konusunda zayıf bir anlayışa sahipti ve ona bir insandan çok bir hayvan gibi davranıldı.\n\nSonunda iyileşip serbest bırakılsa da, deneyimi temel yaşam becerilerinin çoğunu azalttı.</PsychiatricPatient94.description>
   <!-- EN: psychiatric patient -->
   <PsychiatricPatient94.title>psikiyatri hastası</PsychiatricPatient94.title>
   <PsychiatricPatient94.titleFemale>psikiyatri hastası</PsychiatricPatient94.titleFemale>
@@ -120,7 +120,7 @@
   <UrbworldDrone32.titleShort>dron</UrbworldDrone32.titleShort>
   
   <!-- EN: In the urbworlds, most suffer. But someone has to run the corporations.\n\n[PAWN_nameDef] learned the skills of the trade - greasing palms and technical analysis. [PAWN_pronoun] is a sociointellectual machine. -->
-  <UrbworldEntrepreneur14.description>Urbworld'lerde çoğu insan acı çekiyor. Ama birilerinin şirketleri yönetmesi gerekiyor.\n\n [PAWN_nameDef], yalakalık ve ticari analiz gibi ticaret becerilerini öğrendi. O sosyo-entelektüel makinedir.</UrbworldEntrepreneur14.description>
+  <UrbworldEntrepreneur14.description>Urbworld'lerde çoğu insan acı çekiyor. Ama birilerinin şirketleri yönetmesi gerekiyor.\n\n[PAWN_nameDef], yalakalık ve ticari analiz gibi ticaret becerilerini öğrendi. O sosyo-entelektüel makinedir.</UrbworldEntrepreneur14.description>
   <!-- EN: urbworld entrepreneur -->
   <UrbworldEntrepreneur14.title>urbworld'lü girişimci</UrbworldEntrepreneur14.title>
   <UrbworldEntrepreneur14.titleFemale>urbworld'lü girişimci</UrbworldEntrepreneur14.titleFemale>

--- a/Core/DefInjected/BackstoryDef/Offworld_Specific_Child.xml
+++ b/Core/DefInjected/BackstoryDef/Offworld_Specific_Child.xml
@@ -19,7 +19,7 @@
   <CaveworldTender26.titleShort>mağara cocuğu</CaveworldTender26.titleShort>
   
   <!-- EN: [PAWN_nameDef] worked as a digger in the massive underground cave complex.\n\n[PAWN_pronoun] knows rock so well that [PAWN_pronoun] can almost navigate caves by smell. -->
-  <CaveworldTunneler48.description>[PAWN_nameDef] devasa yeraltı mağara kompleksinde kazıcı olarak çalıştı.\n\n Taşı o kadar iyi tanıyor ki, neredeyse kokuyla mağaralarda gezinebiliyor.</CaveworldTunneler48.description>
+  <CaveworldTunneler48.description>[PAWN_nameDef] devasa yeraltı mağara kompleksinde kazıcı olarak çalıştı.\n\nTaşı o kadar iyi tanıyor ki, neredeyse kokuyla mağaralarda gezinebiliyor.</CaveworldTunneler48.description>
   <!-- EN: caveworld tunneler -->
   <CaveworldTunneler48.title>caveworld tünelcisi</CaveworldTunneler48.title>
   <CaveworldTunneler48.titleFemale>caveworld tünelcisi</CaveworldTunneler48.titleFemale>
@@ -28,20 +28,20 @@
   <CaveworldTunneler48.titleShortFemale>tünelci</CaveworldTunneler48.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] never knew [PAWN_possessive] parents. [PAWN_possessive] earliest memories were of drudgery in the mines and workhouses of [PAWN_possessive] industrial world.\n\nBecause of this, [PAWN_pronoun] never received a proper education. -->
-  <IndustrialOrphan13.description>[PAWN_nameDef] anne ve babasını hiç tanımamıştı.En eski anıları, endüstriyel dünyasının madenlerinde ve çalışma evlerinde yaşadığı angaryalardı.\n\n Bu nedenle, hiçbir zaman düzgün bir eğitim almadı.</IndustrialOrphan13.description>
+  <IndustrialOrphan13.description>[PAWN_nameDef] anne ve babasını hiç tanımamıştı. En eski anıları, endüstriyel dünyasının madenlerinde ve çalışma evlerinde yaşadığı angaryalardı.\n\nBu nedenle, hiçbir zaman düzgün bir eğitim almadı.</IndustrialOrphan13.description>
   <!-- EN: industrial orphan -->
   <IndustrialOrphan13.title>endüstriyel yetim</IndustrialOrphan13.title>
   <!-- EN: orphan -->
   <IndustrialOrphan13.titleShort>yetim</IndustrialOrphan13.titleShort>
   
   <!-- EN: Born to the administrators of a rimworld colony, [PAWN_nameDef] was enrolled in a youth program that taught military scouting skills.\n\n[PAWN_pronoun] learned to survive in the wilderness, to obey, and not to ask questions. -->
-  <Scout44.description>Bir rimworld kolonisinin yöneticileri olarak dünyaya gelen [PAWN_nameDef], askeri keşif becerileri öğreten bir gençlik programına kaydoldu.\n\n Vahşi doğada hayatta kalmayı, itaat etmeyi ve soru sormamayı öğrendi.</Scout44.description>
+  <Scout44.description>Bir rimworld kolonisinin yöneticileri olarak dünyaya gelen [PAWN_nameDef], askeri keşif becerileri öğreten bir gençlik programına kaydoldu.\n\nVahşi doğada hayatta kalmayı, itaat etmeyi ve soru sormamayı öğrendi.</Scout44.description>
   <!-- EN: scout -->
-  <Scout44.title>izci</Scout44.title>
-  <Scout44.titleFemale>izci</Scout44.titleFemale>
+  <Scout44.title>İzci</Scout44.title>
+  <Scout44.titleFemale>İzci</Scout44.titleFemale>
   <!-- EN: scout -->
-  <Scout44.titleShort>izci</Scout44.titleShort>
-  <Scout44.titleShortFemale>izci</Scout44.titleShortFemale>
+  <Scout44.titleShort>İzci</Scout44.titleShort>
+  <Scout44.titleShortFemale>İzci</Scout44.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] grew up in a shelter deep beneath a toxic world. [PAWN_pronoun] received a comprehensive education, but had no opportunity to do physical labour. -->
   <ShelterChild50.description>[PAWN_nameDef] zehirli bir dünyanın derinliklerinde bir sığınakta büyüdü. Kapsamlı bir eğitim aldı, ancak öğrendiklerini fiziksel olarak yapma fırsatı olmadı.</ShelterChild50.description>

--- a/Core/DefInjected/BackstoryDef/Pirate_Adult.xml
+++ b/Core/DefInjected/BackstoryDef/Pirate_Adult.xml
@@ -24,8 +24,8 @@
   <!-- EN: There is a law that says that you're not allowed to put terawatt-range grasers on a cargo scow. Especially if you hide them under what looks like a communications dish for better ambush potential. [PAWN_nameDef] discovered that there is great profit to be made, however, from those who are uninterested in these laws. -->
   <IllegalShipwright76.description>Bir kargo kovuğuna terawatt menzilli çayır otları koymanıza izin verilmediğini söyleyen bir yasa var. Özellikle daha iyi pusuya düşürme  potansiyeli için iletişim çanağı gibi görünen şeyin altına saklarsanız. [PAWN_nameDef], bu yasalara ilgi duymayanlardan elde edilecek büyük kazanç olduğunu keşfetti.</IllegalShipwright76.description>
   <!-- EN: illegal shipwright -->
-  <IllegalShipwright76.title>illegal tersane işçisi</IllegalShipwright76.title>
-  <IllegalShipwright76.titleFemale>illegal tersane işçisi</IllegalShipwright76.titleFemale>
+  <IllegalShipwright76.title>İllegal tersane işçisi</IllegalShipwright76.title>
+  <IllegalShipwright76.titleFemale>İllegal tersane işçisi</IllegalShipwright76.titleFemale>
   <!-- EN: shipwright -->
   <IllegalShipwright76.titleShort>tersane işçisi</IllegalShipwright76.titleShort>
   <IllegalShipwright76.titleShortFemale>tersane işçisi</IllegalShipwright76.titleShortFemale>

--- a/Core/DefInjected/BackstoryDef/Solid_Adult.xml
+++ b/Core/DefInjected/BackstoryDef/Solid_Adult.xml
@@ -2,7 +2,7 @@
 <LanguageData>
   
   <!-- EN: [PAWN_nameDef] graduated from the Star Academy with honors and distinguished [PAWN_objective]self as an ace fighter pilot in three campaigns against more advanced aggressor cultures.\n\nHowever, after one vicious battle, [PAWN_pronoun] found [PAWN_objective]self stranded and [PAWN_possessive] carrier ship destroyed. With nowhere to go, [PAWN_pronoun] entered [PAWN_possessive] escape pod and prayed. -->
-  <AceFighterPilot54.description>[PAWN_nameDef] Star Academy'den onur derecesiyle mezun oldu ve daha gelişmiş saldırgan kültürlere karşı üç konfedarasyonda başarılı bir savaş pilotu olarak öne çıktı.\n\n Ancak çetin bir savaştan sonra kendini mahsur buldu ve taşıyıcı gemisi yok edildi. Gidecek hiçbir yeri olmadığı için kaçış bölmesine girdi ve dua etti.</AceFighterPilot54.description>
+  <AceFighterPilot54.description>[PAWN_nameDef] Star Academy'den onur derecesiyle mezun oldu ve daha gelişmiş saldırgan kültürlere karşı üç konfedarasyonda başarılı bir savaş pilotu olarak öne çıktı.\n\nAncak çetin bir savaştan sonra kendini mahsur buldu ve taşıyıcı gemisi yok edildi. Gidecek hiçbir yeri olmadığı için kaçış bölmesine girdi ve dua etti.</AceFighterPilot54.description>
   <!-- EN: ace fighter pilot -->
   <AceFighterPilot54.title>as savaş pilotu</AceFighterPilot54.title>
   <AceFighterPilot54.titleFemale>as savaş pilotu</AceFighterPilot54.titleFemale>
@@ -10,7 +10,7 @@
   <AceFighterPilot54.titleShort>as</AceFighterPilot54.titleShort>
   
   <!-- EN: Ever the dreamer, [PAWN_nameDef] traveled across the universe to find the thing [PAWN_pronoun] felt was calling to him.\n\n[PAWN_pronoun] became poorer and poorer, but used every means possible to carry on. -->
-  <AcolyteOfStars6.description>Her zaman hayalperest olan [PAWN_nameDef], kendisini çağırdığını hissettiği şeyi bulmak için evreni dolaştı.\n\n giderek daha da fakirleşti, ancak devam etmek için mümkün olan her yolu kullandı.</AcolyteOfStars6.description>
+  <AcolyteOfStars6.description>Her zaman hayalperest olan [PAWN_nameDef], kendisini çağırdığını hissettiği şeyi bulmak için evreni dolaştı.\n\nGiderek daha da fakirleşti, ancak devam etmek için mümkün olan her yolu kullandı.</AcolyteOfStars6.description>
   <!-- EN: acolyte of stars -->
   <AcolyteOfStars6.title>'Yıldızların' yardımcısı</AcolyteOfStars6.title>
   <AcolyteOfStars6.titleFemale>'Yıldızların' yardımcısı</AcolyteOfStars6.titleFemale>
@@ -19,7 +19,7 @@
   <AcolyteOfStars6.titleShortFemale>rahip</AcolyteOfStars6.titleShortFemale>
   
   <!-- EN: After recovering from a joywire addiction, [PAWN_nameDef] adopted a non-violent way of life and vowed to help others.\n\nTravelling between communities, [PAWN_pronoun] used medicine, arts, and crafts to aid others who struggled with their own addictions. -->
-  <AddictionCounsel60.description>Joywire bağımlılığından kurtulduktan sonra [PAWN_nameDef] şiddet içermeyen bir yaşam tarzı benimsedi ve başkalarına yardım etmeye yemin etti.\n\n Topluluklar arasında seyahat ederek kendi bağımlılıklarıyla mücadele eden diğer kişilere yardım etmek için tıp, sanat ve zanaat kullandı</AddictionCounsel60.description>
+  <AddictionCounsel60.description>Joywire bağımlılığından kurtulduktan sonra [PAWN_nameDef] şiddet içermeyen bir yaşam tarzı benimsedi ve başkalarına yardım etmeye yemin etti.\n\nTopluluklar arasında seyahat ederek kendi bağımlılıklarıyla mücadele eden diğer kişilere yardım etmek için tıp, sanat ve zanaat kullandı</AddictionCounsel60.description>
   <!-- EN: counselor -->
   <AddictionCounsel60.title>danışman</AddictionCounsel60.title>
   <AddictionCounsel60.titleFemale>danışman</AddictionCounsel60.titleFemale>
@@ -28,7 +28,7 @@
   <AddictionCounsel60.titleShortFemale>danışman</AddictionCounsel60.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef]'s thirst for adventure took [PAWN_objective] to many planets. [PAWN_pronoun] visited the brightest glitterworlds and the darkest war-torn toxic planets in [PAWN_possessive] quest to find novelty and excitement.\n\n[PAWN_pronoun] worked as little as possible, often skirting ethical boundaries to make a quick buck. Among all jobs, [PAWN_pronoun] hated cooking the most. -->
-  <Adventurer19.description>[PAWN_nameDef]'in macera tutkusu onu birçok gezegene götürdü. Yenilik ve heyecan bulma arayışında en parlak glitterworld'leri ve şiddetli savaşlardan zarar görmüş zehirli gezegenleri ziyaret etti.\n\n Mümkün olduğunca az çalıştı, genellikle hızlı para kazanmak için etik sınırları aşıyordu. Bütün işler arasında en çok yemek yapmaktan nefret ederdi.</Adventurer19.description>
+  <Adventurer19.description>[PAWN_nameDef]'in macera tutkusu onu birçok gezegene götürdü. Yenilik ve heyecan bulma arayışında en parlak glitterworld'leri ve şiddetli savaşlardan zarar görmüş zehirli gezegenleri ziyaret etti.\n\nMümkün olduğunca az çalıştı, genellikle hızlı para kazanmak için etik sınırları aşıyordu. Bütün işler arasında en çok yemek yapmaktan nefret ederdi.</Adventurer19.description>
   <!-- EN: adventurer -->
   <Adventurer19.title>maceracı</Adventurer19.title>
   <Adventurer19.titleFemale>maceracı</Adventurer19.titleFemale>
@@ -37,7 +37,7 @@
   <Adventurer19.titleShortFemale>maceracı</Adventurer19.titleShortFemale>
   
   <!-- EN: A creative but strange individual, [PAWN_nameDef] dedicated [PAWN_possessive] life to [PAWN_possessive] twin passions of medieval world history and high technology.\n\n[PAWN_pronoun] was fascinated by the idea of becoming a 'skyknight' with glittering armor and a giant sword. -->
-  <AdventurousWeirdo55.description>Yaratıcı ama tuhaf bir birey olan [PAWN_nameDef], hayatını ortaçağ dünya tarihi ve yüksek teknoloji konusundaki ikiz tutkusuna adadı.\n\n ışıltılı zırhı ve dev bir kılıcı olan bir "gökyüzü şövalyesi" olma fikri onu büyüledi.</AdventurousWeirdo55.description>
+  <AdventurousWeirdo55.description>Yaratıcı ama tuhaf bir birey olan [PAWN_nameDef], hayatını ortaçağ dünya tarihi ve yüksek teknoloji konusundaki ikiz tutkusuna adadı.\n\nIşıltılı zırhı ve dev bir kılıcı olan bir "gökyüzü şövalyesi" olma fikri onu büyüledi.</AdventurousWeirdo55.description>
   <!-- EN: adventurous weirdo -->
   <AdventurousWeirdo55.title>tuhaf maceracı</AdventurousWeirdo55.title>
   <AdventurousWeirdo55.titleFemale>tuhaf maceracı</AdventurousWeirdo55.titleFemale>
@@ -55,7 +55,7 @@
   <AerospaceEngineer44.titleShortFemale>mühendis</AerospaceEngineer44.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] enlisted in the military's robotics division, developing smarter combat AI.\n\nThe whole time [PAWN_pronoun] was there, [PAWN_pronoun] never spoke with another human. [PAWN_pronoun] spent all [PAWN_possessive] time conversing with the AI [PAWN_pronoun] was developing. -->
-  <AIProgrammer22.description>[PAWN_nameDef] ordunun robotik bölümünde yer aldı ve daha akıllı savaş yapay zekası geliştirdi.\n\n Orada olduğu süre boyunca başka bir insanla hiç konuşmadı. Tüm zamanını geliştirmekte olduğu yapay zeka ile konuşarak geçirdi.</AIProgrammer22.description>
+  <AIProgrammer22.description>[PAWN_nameDef] ordunun robotik bölümünde yer aldı ve daha akıllı savaş yapay zekası geliştirdi.\n\nOrada olduğu süre boyunca başka bir insanla hiç konuşmadı. Tüm zamanını geliştirmekte olduğu yapay zeka ile konuşarak geçirdi.</AIProgrammer22.description>
   <!-- EN: AI programmer -->
   <AIProgrammer22.title>Ai programcısı</AIProgrammer22.title>
   <AIProgrammer22.titleFemale>Ai programcısı</AIProgrammer22.titleFemale>
@@ -73,7 +73,7 @@
   <AIResearcher94.titleShortFemale>araştırmacı</AIResearcher94.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was a space trucker working for Arcknight Industries when [PAWN_pronoun] killed [PAWN_possessive] wife and daughter in a crash.\n\n[PAWN_possessive] body was repaired with an experimental nano-genetic therapy. Now [PAWN_possessive] muscles continually regenerate and harden, and every movement tears the tissue anew. [PAWN_pronoun] bears the pain in silence. -->
-  <AlcoholicTrucker93.description>[PAWN_nameDef] bir kazada karısını ve kızını öldürdüğünde Arcknight Industries için çalışan bir uzay kamyoncusuydu.\n\n Vücudu deneysel bir nano-genetik terapi ile onarıldı. Şimdi kasları sürekli olarak yenileniyor ve sertleşiyor ve her hareket dokuyu yeniden yırtıyor. Acıya sessizce katlanıyor.</AlcoholicTrucker93.description>
+  <AlcoholicTrucker93.description>[PAWN_nameDef] bir kazada karısını ve kızını öldürdüğünde Arcknight Industries için çalışan bir uzay kamyoncusuydu.\n\nVücudu deneysel bir nano-genetik terapi ile onarıldı. Şimdi kasları sürekli olarak yenileniyor ve sertleşiyor ve her hareket dokuyu yeniden yırtıyor. Acıya sessizce katlanıyor.</AlcoholicTrucker93.description>
   <!-- EN: alcoholic trucker -->
   <AlcoholicTrucker93.title>alkollü kamyoncu</AlcoholicTrucker93.title>
   <AlcoholicTrucker93.titleFemale>alkollü kamyoncu</AlcoholicTrucker93.titleFemale>
@@ -82,7 +82,7 @@
   <AlcoholicTrucker93.titleShortFemale>alkolik</AlcoholicTrucker93.titleShortFemale>
   
   <!-- EN: After being abandoned on a special operation, [PAWN_nameDef] swore vengeance upon the state. [PAWN_pronoun] formed an anarchist group dedicated to bringing down coreworld governments.\n\nAfter too many close calls, and too few successes, [PAWN_nameDef] fled to the outer rim. -->
-  <AnarchistRebel77.description>[PAWN_nameDef], özel bir harekâtta terk edildikten sonra devletten intikam almaya yemin etti. Kendilerini coreworld hükümetlerini devirmeye adamış bir anarşist grup kurdu.\n\n Çok fazla denemeden ve çok az başarıdan sonra [PAWN_nameDef] dış çembere kaçtı.</AnarchistRebel77.description>
+  <AnarchistRebel77.description>[PAWN_nameDef], özel bir harekâtta terk edildikten sonra devletten intikam almaya yemin etti. Kendilerini coreworld hükümetlerini devirmeye adamış bir anarşist grup kurdu.\n\nÇok fazla denemeden ve çok az başarıdan sonra [PAWN_nameDef] dış çembere kaçtı.</AnarchistRebel77.description>
   <!-- EN: anarchist rebel -->
   <AnarchistRebel77.title>anarşist isyancı</AnarchistRebel77.title>
   <AnarchistRebel77.titleFemale>anarşist isyancı</AnarchistRebel77.titleFemale>
@@ -127,7 +127,7 @@
   <ArmyScientist35.titleShortFemale>bilimadamı</ArmyScientist35.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] served in [PAWN_possessive] country's military, commanding small units as a non-commissioned officer.\n\n[PAWN_pronoun] excelled creating tactically sound plans despite difficult circumstances. -->
-  <ArmySergeant16.description>[PAWN_nameDef], ülkesinin ordusunda görev yaptı ve astsubay olarak küçük birliklere komuta etti.\n\n Zor koşullara rağmen taktiksel olarak sağlam planlar oluşturmada başarılı oldu.</ArmySergeant16.description>
+  <ArmySergeant16.description>[PAWN_nameDef], ülkesinin ordusunda görev yaptı ve astsubay olarak küçük birliklere komuta etti.\n\nZor koşullara rağmen taktiksel olarak sağlam planlar oluşturmada başarılı oldu.</ArmySergeant16.description>
   <!-- EN: army sergeant -->
   <ArmySergeant16.title>ordu cerrahı</ArmySergeant16.title>
   <!-- EN: sergeant -->
@@ -143,7 +143,7 @@
   <Aromatherapist80.titleShortFemale>terapist</Aromatherapist80.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] became depressed and lost interest in life. [PAWN_pronoun] traveled from planet to planet, searching for psychic artifacts amid mechanoid ruins in the hope that they would cure the pain in [PAWN_possessive] soul.\n\nA steady trigger finger and careful planning kept [PAWN_nameDef] alive. -->
-  <ArtifactHunter48.description>[PAWN_nameDef] depresyona girdi ve hayata olan ilgisini kaybetti. Ruhundaki acıyı iyileştireceklerini umarak mekanoid kalıntıları arasında psişik eserler arayarak gezegenden gezegene seyahat etti.\n\n Sabit bir tetik parmağı ve dikkatli bir planlama [PAWN_nameDef]'i canlı tuttu.</ArtifactHunter48.description>
+  <ArtifactHunter48.description>[PAWN_nameDef] depresyona girdi ve hayata olan ilgisini kaybetti. Ruhundaki acıyı iyileştireceklerini umarak mekanoid kalıntıları arasında psişik eserler arayarak gezegenden gezegene seyahat etti.\n\nSabit bir tetik parmağı ve dikkatli bir planlama [PAWN_nameDef]'i canlı tuttu.</ArtifactHunter48.description>
   <!-- EN: artifact hunter -->
   <ArtifactHunter48.title>artifakt avcısı</ArtifactHunter48.title>
   <ArtifactHunter48.titleFemale>artifakt avcısı</ArtifactHunter48.titleFemale>
@@ -152,7 +152,7 @@
   <ArtifactHunter48.titleShortFemale>artifaktçı</ArtifactHunter48.titleShortFemale>
   
   <!-- EN: Fuelled by the thrill of discovery and [PAWN_possessive] own megalomania, [PAWN_nameDef] set out to invent new devices and improve existing ones, breaking laws and customs as necessary.\n\n[PAWN_pronoun] formed a crew to gather materials for [PAWN_possessive] work - and to deal with outsiders who might interfere. -->
-  <ArtificerRampant95.description>Keşif heyecanı ve kendi megalomanisiyle beslenen [PAWN_nameDef], gerektiğinde yasaları ve gelenekleri çiğneyerek yeni cihazlar icat etmek ve mevcut cihazları geliştirmek için yola çıktı.\n\n Çalışmaları için malzeme toplamak üzere bir ekip kurdu- müdahale edebilecek yabancılarla başa çıkmak için de.</ArtificerRampant95.description>
+  <ArtificerRampant95.description>Keşif heyecanı ve kendi megalomanisiyle beslenen [PAWN_nameDef], gerektiğinde yasaları ve gelenekleri çiğneyerek yeni cihazlar icat etmek ve mevcut cihazları geliştirmek için yola çıktı.\n\nÇalışmaları için malzeme toplamak üzere bir ekip kurdu- müdahale edebilecek yabancılarla başa çıkmak için de.</ArtificerRampant95.description>
   <!-- EN: artificer rampant -->
   <ArtificerRampant95.title>başıboş artifaktçı</ArtificerRampant95.title>
   <ArtificerRampant95.titleFemale>başıboş artifaktçı</ArtificerRampant95.titleFemale>
@@ -170,7 +170,7 @@
   <ArtStudent79.titleShortFemale>sanatçı</ArtStudent79.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was specially trained as an operative to be used for high-risk assassinations. [PAWN_possessive] skill with a rifle was unrivalled.\n\n[PAWN_pronoun] was eventually betrayed by [PAWN_possessive] superiors when a target found out about the hit and offered to fund their future projects. [PAWN_nameDef] swore to never trust anyone again. -->
-  <Assassin7.description>[PAWN_nameDef], yüksek riskli suikastlarda kullanılmak üzere özel olarak eğitilmişti.Tüfek kullanma becerisi rakipsizdi.\n\n. Sonunda, bir hedef suikasti öğrendiğinde ve gelecekteki projelerine fon sağlamayı teklif ettiğinde ,üstleri tarafından ihanete uğradı. [PAWN_nameDef] bir daha kimseye güvenmemeye yemin etti.</Assassin7.description>
+  <Assassin7.description>[PAWN_nameDef], yüksek riskli suikastlarda kullanılmak üzere özel olarak eğitilmişti.Tüfek kullanma becerisi rakipsizdi.\n\nSonunda, bir hedef suikasti öğrendiğinde ve gelecekteki projelerine fon sağlamayı teklif ettiğinde ,üstleri tarafından ihanete uğradı. [PAWN_nameDef] bir daha kimseye güvenmemeye yemin etti.</Assassin7.description>
   <!-- EN: assassin -->
   <Assassin7.title>suikastçi</Assassin7.title>
   <Assassin7.titleFemale>suikastçi</Assassin7.titleFemale>
@@ -197,7 +197,7 @@
   <BanditLeader74.titleShortFemale>Haydut lideri</BanditLeader74.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] became the most physically intimidating of the slaves, spending [PAWN_possessive] little free time obsessively sculpting [PAWN_possessive] body. [PAWN_possessive] efforts eventually paid off when the lord offered [PAWN_objective] a job as a personal bodyguard.\n\nLater, when [PAWN_pronoun] plotted to use [PAWN_possessive] position to kill the lord and free the slaves, [PAWN_pronoun] was discovered and barely escaped with [PAWN_possessive] life. -->
-  <BanishedSoldier85.description>[PAWN_nameDef], kölelerin fiziksel olarak en korkutucusu haline geldi ve küçük boş zamanını takıntılı bir şekilde vücudunu şekillendirerek geçirdi. Çabaları sonunda lord ona kişisel koruma olarak bir iş teklif ettiğinde meyvesini verdi.\n\n . Daha sonra, konumunu lordu öldürmek ve köleleri serbest bırakmak için kullanmayı planladığında, keşfedildi ve canını zor kurtardı.</BanishedSoldier85.description>
+  <BanishedSoldier85.description>[PAWN_nameDef], kölelerin fiziksel olarak en korkutucusu haline geldi ve küçük boş zamanını takıntılı bir şekilde vücudunu şekillendirerek geçirdi. Çabaları sonunda lord ona kişisel koruma olarak bir iş teklif ettiğinde meyvesini verdi.\n\nDaha sonra, konumunu lordu öldürmek ve köleleri serbest bırakmak için kullanmayı planladığında, keşfedildi ve canını zor kurtardı.</BanishedSoldier85.description>
   <!-- EN: banished soldier -->
   <BanishedSoldier85.title>sürgün asker</BanishedSoldier85.title>
   <BanishedSoldier85.titleFemale>sürgün asker</BanishedSoldier85.titleFemale>
@@ -206,7 +206,7 @@
   <BanishedSoldier85.titleShortFemale>kanun kaçağı</BanishedSoldier85.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] had received firearms training, but [PAWN_possessive] work was focused on technical adaptation and manipulation of combat mechanoids on the battlefield.\n\n[PAWN_pronoun] developed PTSD after narrowly escaping a primitive firebomb attack in a wheat field. The army medically discharged [PAWN_objective] from service. -->
-  <BattlefieldTech52.description>[PAWN_nameDef] ateşli silah eğitimi almıştı.Çalışmalarında; savaş alanı ve savaş mekanoidlerinin teknik adaptasyonu ve manipülasyonuna odaklanmıştı.\n\n .Bir buğday tarlasında ilkel bir ateş bombası saldırısından kıl payı kurtulduktan sonra travma sonrası stres sozukluğuna yakalandı. Ordu onu zihinsel hasarlı olarak gördü ve görevden aldı.</BattlefieldTech52.description>
+  <BattlefieldTech52.description>[PAWN_nameDef] ateşli silah eğitimi almıştı.Çalışmalarında; savaş alanı ve savaş mekanoidlerinin teknik adaptasyonu ve manipülasyonuna odaklanmıştı.\n\nBir buğday tarlasında ilkel bir ateş bombası saldırısından kıl payı kurtulduktan sonra travma sonrası stres sozukluğuna yakalandı. Ordu onu zihinsel hasarlı olarak gördü ve görevden aldı.</BattlefieldTech52.description>
   <!-- EN: battlefield tech -->
   <BattlefieldTech52.title>savaş alanı teknikeri</BattlefieldTech52.title>
   <BattlefieldTech52.titleFemale>tekniker</BattlefieldTech52.titleFemale>
@@ -214,7 +214,7 @@
   <BattlefieldTech52.titleShort>tekniker</BattlefieldTech52.titleShort>
   
   <!-- EN: [PAWN_nameDef] was a tech-obsessed mercenary in an early fusion-era system.\n\n[PAWN_pronoun] was unusually obsessed with gathering the right gear, and often customized [PAWN_possessive] own equipment with original modifications. -->
-  <BattleMechanic27.description>[PAWN_nameDef] erken füzyon çağındaki bir sistemde teknoloji takıntılı bir paralı askerdi.\n\n .Olağandışı bir şekilde doğru teçhizatı toplama takıntısına sahipti ve genellikle kendi ekipmanını orijinal modifikasyonlarla özelleştiriyordu.</BattleMechanic27.description>
+  <BattleMechanic27.description>[PAWN_nameDef] erken füzyon çağındaki bir sistemde teknoloji takıntılı bir paralı askerdi.\n\nOlağandışı bir şekilde doğru teçhizatı toplama takıntısına sahipti ve genellikle kendi ekipmanını orijinal modifikasyonlarla özelleştiriyordu.</BattleMechanic27.description>
   <!-- EN: battle mechanic -->
   <BattleMechanic27.title>savaş makinisti</BattleMechanic27.title>
   <BattleMechanic27.titleFemale>savaş makinisti</BattleMechanic27.titleFemale>
@@ -223,7 +223,7 @@
   <BattleMechanic27.titleShortFemale>makinist</BattleMechanic27.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] traveled between planets, following news of animal attacks. [PAWN_pronoun] would camp on the planet for weeks, learning about [PAWN_possessive] prey before striking. [PAWN_pronoun] most enjoyed hunting thrumbos.\n\nPreferring to work alone, [PAWN_nameDef] enjoyed the thrill of the hunt, and the meat from the kill. -->
-  <BeastSlayer67.description>[PAWN_nameDef], hayvan saldırıları haberlerinin ardından gezegenler arasında seyahat etti. Saldırmadan önce avını öğrenerek haftalarca gezegende kamp kurardı. En çok thrumboları avlamaktan hoşlanırdı.\n\n .Yalnız çalışmayı tercih eden [PAWN_nameDef], avın heyecanını ve avlanmanın verdiği hazzın tadını çıkardı.</BeastSlayer67.description>
+  <BeastSlayer67.description>[PAWN_nameDef], hayvan saldırıları haberlerinin ardından gezegenler arasında seyahat etti. Saldırmadan önce avını öğrenerek haftalarca gezegende kamp kurardı. En çok thrumboları avlamaktan hoşlanırdı.\n\nYalnız çalışmayı tercih eden [PAWN_nameDef], avın heyecanını ve avlanmanın verdiği hazzın tadını çıkardı.</BeastSlayer67.description>
   <!-- EN: beast slayer -->
   <BeastSlayer67.title>canavar katili</BeastSlayer67.title>
   <BeastSlayer67.titleFemale>canavar katili</BeastSlayer67.titleFemale>
@@ -232,7 +232,7 @@
   <BeastSlayer67.titleShortFemale>katil</BeastSlayer67.titleShortFemale>
   
   <!-- EN: Captured as a feral child, [PAWN_nameDef] was forced into the ways of modern society. [PAWN_pronoun] quickly adapted and became a behavioural researcher, eventually owning a private facility.\n\n[PAWN_pronoun] specialized in canines, but learned a great deal about all animals. [PAWN_pronoun] never had interest in plants, however. -->
-  <BehaviourResearch74.description>Vahşi bir çocuk olarak yakalanan [PAWN_nameDef], modern toplumun yaşantısına girmeye zorlandı. Hızla adapte oldu ve davranış bilimcisi oldu ve sonunda özel bir tesise sahip oldu.\n\n Köpeklerde uzmanlaştı ve diğer hayvanlar hakkında çok şey öğrendi. Bununla birlikte, bitkilere hiçbir zaman ilgi duymadı.</BehaviourResearch74.description>
+  <BehaviourResearch74.description>Vahşi bir çocuk olarak yakalanan [PAWN_nameDef], modern toplumun yaşantısına girmeye zorlandı. Hızla adapte oldu ve davranış bilimcisi oldu ve sonunda özel bir tesise sahip oldu.\n\nKöpeklerde uzmanlaştı ve diğer hayvanlar hakkında çok şey öğrendi. Bununla birlikte, bitkilere hiçbir zaman ilgi duymadı.</BehaviourResearch74.description>
   <!-- EN: behaviour research -->
   <BehaviourResearch74.title>davranış bilimcisi</BehaviourResearch74.title>
   <BehaviourResearch74.titleFemale>davranış bilimcisi</BehaviourResearch74.titleFemale>
@@ -250,7 +250,7 @@
   <Blacksmith7.titleShortFemale>demirci</Blacksmith7.titleShortFemale>
   
   <!-- EN: As a young blacksmith, [PAWN_nameDef]'s family shop was raided by the police. [PAWN_pronoun] shot two officers before they knocked [PAWN_objective] out and arrested him.\n\nSentenced to life in prison, [PAWN_nameDef] learned about traveling and raiding from other criminals. -->
-  <BlacksmithShooter21.description>Genç bir demirci olarak, [PAWN_nameDef]'in aile dükkanı polis tarafından basıldı. Onu bayıltıp tutuklamadan önce iki memuru vurdu.\n\n Ömür boyu hapis cezasına çarptırılan [PAWN_nameDef], seyahat etmeyi ve baskın yapmayı diğer suçlulardan öğrendi.</BlacksmithShooter21.description>
+  <BlacksmithShooter21.description>Genç bir demirci olarak, [PAWN_nameDef]'in aile dükkanı polis tarafından basıldı. Onu bayıltıp tutuklamadan önce iki memuru vurdu.\n\nÖmür boyu hapis cezasına çarptırılan [PAWN_nameDef], seyahat etmeyi ve baskın yapmayı diğer suçlulardan öğrendi.</BlacksmithShooter21.description>
   <!-- EN: blacksmith shooter -->
   <BlacksmithShooter21.title>Silah demircisi</BlacksmithShooter21.title>
   <BlacksmithShooter21.titleFemale>Silah demircisi</BlacksmithShooter21.titleFemale>
@@ -268,7 +268,7 @@
   <BloodgameSurvivor6.titleShortFemale>BLOODGAME oyuncusu</BloodgameSurvivor6.titleShortFemale>
   
   <!-- EN: After studying at a famous college, [PAWN_nameDef]'s weak personality eventually snapped under the strain of angry administrators and whining patients. [PAWN_pronoun] went on a secret murder spree, killing many of those under [PAWN_possessive] care.\n\nAfter a pursuit, [PAWN_pronoun] managed to escape [PAWN_possessive] planet and travel to a new world. -->
-  <BloodyDentist9.description>Ünlü bir kolejde okuduktan sonra, [PAWN_nameDef]'in zayıf kişiliği sonunda öfkeli yöneticilerin ve sızlanan hastaların baskısı altında yıkıldı. Gizli bir cinayet çılgınlığına girdi ve gözetimi altındakilerin birçoğunu öldürdü.\n\n Bir takipten sonra gezegeninden kaçmayı ve yeni bir dünyaya seyahat etmeyi başardı.</BloodyDentist9.description>
+  <BloodyDentist9.description>Ünlü bir kolejde okuduktan sonra, [PAWN_nameDef]'in zayıf kişiliği sonunda öfkeli yöneticilerin ve sızlanan hastaların baskısı altında yıkıldı. Gizli bir cinayet çılgınlığına girdi ve gözetimi altındakilerin birçoğunu öldürdü.\n\nBir takipten sonra gezegeninden kaçmayı ve yeni bir dünyaya seyahat etmeyi başardı.</BloodyDentist9.description>
   <!-- EN: bloody dentist -->
   <BloodyDentist9.title>kanlı dişçi</BloodyDentist9.title>
   <BloodyDentist9.titleFemale>kanlı dişçi</BloodyDentist9.titleFemale>
@@ -277,7 +277,7 @@
   <BloodyDentist9.titleShortFemale>dişçi</BloodyDentist9.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was a wanderer, traveling from town to town, taking odd jobs and stealing to live.\n\nOne day, [PAWN_pronoun] had a mental break and went on a long rampage, destroying several towns and killing many. [PAWN_pronoun] eventually calmed, but [PAWN_possessive] bloodlust never left [PAWN_objective]. -->
-  <BloodyWanderer28.description>[PAWN_nameDef], kasabadan kasabaya seyahat eden, tuhaf işler yapan ve yaşamak için hırsızlık yapan bir gezgindi.\n\n Bir gün, sinir kriz geçirdi ve uzun bir öfkeye girdi, birkaç kasabayı yok etti ve birçok insanı öldürdü. Sonunda sakinleşti, ama kana susamışlığı onu asla terk etmedi.</BloodyWanderer28.description>
+  <BloodyWanderer28.description>[PAWN_nameDef], kasabadan kasabaya seyahat eden, tuhaf işler yapan ve yaşamak için hırsızlık yapan bir gezgindi.\n\nBir gün, sinir kriz geçirdi ve uzun bir öfkeye girdi, birkaç kasabayı yok etti ve birçok insanı öldürdü. Sonunda sakinleşti, ama kana susamışlığı onu asla terk etmedi.</BloodyWanderer28.description>
   <!-- EN: bloody wanderer -->
   <BloodyWanderer28.title>kanlı gezgin</BloodyWanderer28.title>
   <BloodyWanderer28.titleFemale>kanlı gezgin</BloodyWanderer28.titleFemale>
@@ -322,7 +322,7 @@
   <Brigand68.titleShortFemale>eşkiya</Brigand68.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef]'s peaceful life was cut short when [PAWN_possessive] country was brutally invaded.\n\n[PAWN_nameDef] was drafted into service as soon as [PAWN_pronoun] was of legal age, and quickly showed an aptitude for rifles. [PAWN_pronoun] spent months living in the forests picking off soldiers who dared cross the border. -->
-  <BushSniper94.description>[PAWN_nameDef]'in huzurlu yaşamı, ülkesi vahşice işgal edildiğinde kesildi.\n\n [PAWN_nameDef] reşit olur olmaz hizmete alındı ve kısa sürede tüfeklere karşı bir yetenek gösterdi. Aylarını ormanda yaşayarak sınırı geçmeye cüret eden askerleri avlayarak geçirdi.</BushSniper94.description>
+  <BushSniper94.description>[PAWN_nameDef]'in huzurlu yaşamı, ülkesi vahşice işgal edildiğinde kesildi.\n\n[PAWN_nameDef] reşit olur olmaz hizmete alındı ve kısa sürede tüfeklere karşı bir yetenek gösterdi. Aylarını ormanda yaşayarak sınırı geçmeye cüret eden askerleri avlayarak geçirdi.</BushSniper94.description>
   <!-- EN: bush sniper -->
   <BushSniper94.title>Fundalık keskin nişancısı</BushSniper94.title>
   <BushSniper94.titleFemale>Fundalık keskin nişancısı</BushSniper94.titleFemale>
@@ -340,7 +340,7 @@
   <BusinessGangster58.titleShortFemale>gangster</BusinessGangster58.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was the leader of a caravan. [PAWN_pronoun] was responsible for the safety of [PAWN_possessive] caravan and was the head negotiator in countless trade deals.\n\n[PAWN_pronoun] and [PAWN_possessive] people prospered, but their wealth made them a target for brigands. They often had to take up arms to fend off bandits and highwaymen. -->
-  <Caravaneer53.description>[PAWN_nameDef] bir kervanın lideriydi. Kervanının güvenliğinden sorumluydu ve sayısız ticaret anlaşmasının baş müzakerecisiydi.\n\n O ve halkı zengin oldu, ancak zenginlikleri onları haydutların hedefi haline getirdi. Haydutları ve eşkıyaları savuşturmak için sık sık silahlara sarılmak zorunda kaldılar.</Caravaneer53.description>
+  <Caravaneer53.description>[PAWN_nameDef] bir kervanın lideriydi. Kervanının güvenliğinden sorumluydu ve sayısız ticaret anlaşmasının baş müzakerecisiydi.\n\nO ve halkı zengin oldu, ancak zenginlikleri onları haydutların hedefi haline getirdi. Haydutları ve eşkıyaları savuşturmak için sık sık silahlara sarılmak zorunda kaldılar.</Caravaneer53.description>
   <!-- EN: caravaneer -->
   <Caravaneer53.title>kervancı</Caravaneer53.title>
   <Caravaneer53.titleFemale>kervancı</Caravaneer53.titleFemale>
@@ -358,7 +358,7 @@
   <CargoPilot58.titleShortFemale>pilot</CargoPilot58.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was fascinated with cryptosleep, and spent [PAWN_possessive] life learning about the mysterious technology.\n\nWorking as an assembler on a midworld, [PAWN_nameDef] built an experimental prototype casket from discarded parts. Unfortunately, while [PAWN_pronoun] was searching for the final component, [PAWN_possessive] home was leveled by a bomb. -->
-  <CasketBuilder52.description>[PAWN_nameDef] kripto uykusundan büyülendi ve hayatını gizemli teknolojiyi öğrenerek geçirdi.\n\n Bir orta dünyada montajcı olarak çalışan [PAWN_nameDef], atılan parçalardan deneysel bir prototip tabut yaptı. Ne yazık ki, son bileşeni ararken evi bir bombayla yerle bir oldu.</CasketBuilder52.description>
+  <CasketBuilder52.description>[PAWN_nameDef] kripto uykusundan büyülendi ve hayatını gizemli teknolojiyi öğrenerek geçirdi.\n\nBir orta dünyada montajcı olarak çalışan [PAWN_nameDef], atılan parçalardan deneysel bir prototip tabut yaptı. Ne yazık ki, son bileşeni ararken evi bir bombayla yerle bir oldu.</CasketBuilder52.description>
   <!-- EN: casket builder -->
   <CasketBuilder52.title>tabut üreticisi</CasketBuilder52.title>
   <CasketBuilder52.titleFemale>tabut üreticisi</CasketBuilder52.titleFemale>
@@ -385,7 +385,7 @@
   <Chemist73.titleShortFemale>eczacı</Chemist73.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was a renowned chemist on a thriving midworld.\n\nAfter performing inhumane experiments that turned men into beasts, [PAWN_pronoun] was arrested and banished to a far-off rimworld. -->
-  <Chemist78.description>[PAWN_nameDef] gelişen bir orta dünyada ünlü bir kimyagerdi.\n\n İnsanları canavara dönüştüren insanlık dışı deneyler yaptıktan sonra tutuklandı ve çok uzak bir rimworld'e sürgün edildi.</Chemist78.description>
+  <Chemist78.description>[PAWN_nameDef] gelişen bir orta dünyada ünlü bir kimyagerdi.\n\nİnsanları canavara dönüştüren insanlık dışı deneyler yaptıktan sonra tutuklandı ve çok uzak bir rimworld'e sürgün edildi.</Chemist78.description>
   <!-- EN: chemist -->
   <Chemist78.title>eczacı</Chemist78.title>
   <Chemist78.titleFemale>eczacı</Chemist78.titleFemale>
@@ -394,7 +394,7 @@
   <Chemist78.titleShortFemale>eczacı</Chemist78.titleShortFemale>
   
   <!-- EN: As chief engineer on board a large spaceship, [PAWN_nameDef] was an expert in all things fiddly and complex.\n\n[PAWN_pronoun] relied on other members of the crew for some of the basic necessities of life. [PAWN_pronoun] and [PAWN_possessive] ship eventually disappeared into a longsleep voyage of exploration. -->
-  <ChiefEngineer62.description>Büyük bir uzay gemisinde baş mühendis olarak [PAWN_nameDef], karmaşık ve zor  her konuda uzmandı.\n\n Yaşamın bazı temel ihtiyaçları için mürettebatın diğer üyelerine güveniyordu.Gemisi ile beraber uzun bir keşif yolculuğunda ortadan kayboldu.</ChiefEngineer62.description>
+  <ChiefEngineer62.description>Büyük bir uzay gemisinde baş mühendis olarak [PAWN_nameDef], karmaşık ve zor  her konuda uzmandı.\n\nYaşamın bazı temel ihtiyaçları için mürettebatın diğer üyelerine güveniyordu.Gemisi ile beraber uzun bir keşif yolculuğunda ortadan kayboldu.</ChiefEngineer62.description>
   <!-- EN: chief engineer -->
   <ChiefEngineer62.title>baş mühendis</ChiefEngineer62.title>
   <ChiefEngineer62.titleFemale>baş mühendis</ChiefEngineer62.titleFemale>
@@ -448,7 +448,7 @@
   <ColiseumFighter22.titleShortFemale>dövüşçü</ColiseumFighter22.titleShortFemale>
   
   <!-- EN: Disillusioned by rampant government corruption, [PAWN_nameDef] ran for governor and won. However, the local gangs and their pet officials soon forced [PAWN_objective] out of power.\n\n[PAWN_pronoun] left the community to return to [PAWN_possessive] life as a marshal. -->
-  <ColonialGovernor78.description>Hükümetin yaygın yolsuzluğundan hayal kırıklığına uğrayan [PAWN_nameDef] valilik için uğraştı ve kazandı. Ancak, yerel çeteler ve çetelerin satın aldığı yetkililer onu kısa sürede iktidardan uzaklaştırdı.\n\n Bir mareşal olarak hayatına geri dönmek için topluluğu terk etti.</ColonialGovernor78.description>
+  <ColonialGovernor78.description>Hükümetin yaygın yolsuzluğundan hayal kırıklığına uğrayan [PAWN_nameDef] valilik için uğraştı ve kazandı. Ancak, yerel çeteler ve çetelerin satın aldığı yetkililer onu kısa sürede iktidardan uzaklaştırdı.\n\nBir mareşal olarak hayatına geri dönmek için topluluğu terk etti.</ColonialGovernor78.description>
   <!-- EN: colonial governor -->
   <ColonialGovernor78.title>koloni valisi</ColonialGovernor78.title>
   <ColonialGovernor78.titleFemale>koloni valisi</ColonialGovernor78.titleFemale>
@@ -457,7 +457,7 @@
   <ColonialGovernor78.titleShortFemale>vali</ColonialGovernor78.titleShortFemale>
   
   <!-- EN: The children took over the facility, and they declared independence from the corporation.\n\n[PAWN_nameDef] had used the VR system to become a master engineer, and [PAWN_pronoun] worked diligently to prepare the colony for the corporation's inevitable return. -->
-  <ColonyEngineer7.description>Çocuklar tesisi devraldı ve emperyalistlerden bağımsızlıklarını ilan ettiler.\n\n [PAWN_nameDef] VR sistemini usta bir mühendis olmak için kullanmıştı ve koloniyi emperyalistlerin kaçınılmaz dönüşüne hazırlamak için özenle çalıştı.</ColonyEngineer7.description>
+  <ColonyEngineer7.description>Çocuklar tesisi devraldı ve emperyalistlerden bağımsızlıklarını ilan ettiler.\n\n[PAWN_nameDef] VR sistemini usta bir mühendis olmak için kullanmıştı ve koloniyi emperyalistlerin kaçınılmaz dönüşüne hazırlamak için özenle çalıştı.</ColonyEngineer7.description>
   <!-- EN: colony engineer -->
   <ColonyEngineer7.title>koloni mühendisi</ColonyEngineer7.title>
   <ColonyEngineer7.titleFemale>koloni mühendisi</ColonyEngineer7.titleFemale>
@@ -466,7 +466,7 @@
   <ColonyEngineer7.titleShortFemale>mühendis</ColonyEngineer7.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was recruited by the military as an engineer and set to work improving the navy's space shuttles. The harsh training taught [PAWN_objective] how to build and repair military vehicles and structures.\n\nOne mission left [PAWN_nameDef] with pyrophobia and a strong desire to avoid plants. -->
-  <CombatEngineer30.description>[PAWN_nameDef] ordu tarafından mühendis olarak işe alındı ve donanmanın uzay mekiklerini geliştirmek için çalışmaya başladı. Sert eğitim ona askeri araç ve yapıların nasıl inşa edileceğini ve onarılacağını öğretti. \n\n Bir görevde [PAWN_nameDef] yangın korkusu ve bitkilerden uzak durmak için güçlü bir istekle baş başa kaldı.</CombatEngineer30.description>
+  <CombatEngineer30.description>[PAWN_nameDef] ordu tarafından mühendis olarak işe alındı ve donanmanın uzay mekiklerini geliştirmek için çalışmaya başladı. Sert eğitim ona askeri araç ve yapıların nasıl inşa edileceğini ve onarılacağını öğretti.\n\nBir görevde [PAWN_nameDef] yangın korkusu ve bitkilerden uzak durmak için güçlü bir istekle baş başa kaldı.</CombatEngineer30.description>
   <!-- EN: combat engineer -->
   <CombatEngineer30.title>savaş mühendisi</CombatEngineer30.title>
   <CombatEngineer30.titleFemale>savaş mühendisi</CombatEngineer30.titleFemale>
@@ -484,7 +484,7 @@
   <CombatEngineer4.titleShortFemale>mühendis</CombatEngineer4.titleShortFemale>
   
   <!-- EN: After [PAWN_possessive] home country entered a large-scale war, [PAWN_nameDef] was drafted into the army as a combat medic.\n\n[PAWN_possessive] few years in the trenches trying to keep [PAWN_possessive] fellow soldiers alive gave [PAWN_objective] an acute sense for first aid. Losing many friend has made [PAWN_objective] stoic and reserved. -->
-  <CombatMedic82.description>Anavatanı geniş çaplı bir savaşa girdikten sonra, [PAWN_nameDef] sıhhıye doktoru olarak orduya alındı. \n\n Siperlerdeki asker arkadaşlarını hayatta tutmaya çalışırken geçirdiği birkaç yıl ona ilk yardım konusunda keskin bir his verdi. Birçok arkadaşını kaybetmek onun sabırlı ve çekingen olmasına neden oldu.</CombatMedic82.description>
+  <CombatMedic82.description>Anavatanı geniş çaplı bir savaşa girdikten sonra, [PAWN_nameDef] sıhhıye doktoru olarak orduya alındı.\n\nSiperlerdeki asker arkadaşlarını hayatta tutmaya çalışırken geçirdiği birkaç yıl ona ilk yardım konusunda keskin bir his verdi. Birçok arkadaşını kaybetmek onun sabırlı ve çekingen olmasına neden oldu.</CombatMedic82.description>
   <!-- EN: combat medic -->
   <CombatMedic82.title>sıhhıye</CombatMedic82.title>
   <CombatMedic82.titleFemale>sıhhıye</CombatMedic82.titleFemale>
@@ -493,7 +493,7 @@
   <CombatMedic82.titleShortFemale>doktor</CombatMedic82.titleShortFemale>
   
   <!-- EN: As a military medtech, [PAWN_nameDef]'s job was to fix and build anything [PAWN_pronoun] could get [PAWN_possessive] hands on, from living people to machines and mechs.\n\nSent into dangerous areas, [PAWN_pronoun] never had a problem saving soldiers' lives and building the technology and machines needed to win. -->
-  <CombatMedtech59.description>Bir askeri tıp teknisyeni olarak [PAWN_nameDef]'in işi, yaşayan insanlardan makinelere ve mekaniklere kadar eline geçen her şeyi onarmak ve inşa etmekti. \n\n Tehlikeli bölgelere gönderildiğinde, askerlerin hayatlarını kurtarmakta ve kazanmak için gereken teknoloji ve makineleri inşa etmekte hiçbir zaman sorun yaşamadı.</CombatMedtech59.description>
+  <CombatMedtech59.description>Bir askeri tıp teknisyeni olarak [PAWN_nameDef]'in işi, yaşayan insanlardan makinelere ve mekaniklere kadar eline geçen her şeyi onarmak ve inşa etmekti.\n\nTehlikeli bölgelere gönderildiğinde, askerlerin hayatlarını kurtarmakta ve kazanmak için gereken teknoloji ve makineleri inşa etmekte hiçbir zaman sorun yaşamadı.</CombatMedtech59.description>
   <!-- EN: combat medtech -->
   <CombatMedtech59.title>askeri tıp teknikeri</CombatMedtech59.title>
   <CombatMedtech59.titleFemale>askeri tıp teknikeri</CombatMedtech59.titleFemale>
@@ -502,7 +502,7 @@
   <CombatMedtech59.titleShortFemale>doktor</CombatMedtech59.titleShortFemale>
   
   <!-- EN: After escaping [PAWN_possessive] homeworld, [PAWN_nameDef] took [PAWN_possessive] skills to the stars.\n\n[PAWN_pronoun] chose to operate as a hired gun, working for various rebel organizations, enslaved groups, and merchant enclaves. [PAWN_possessive] specialty was negotiation in combat situations. -->
-  <CombatNegotiator31.description>[PAWN_nameDef] anavatanından kaçtıktan sonra yeteneklerini yıldızlara taşıdı. \n\n Çeşitli isyancı örgütler, köleleştirilmiş gruplar ve tüccar yerleşim bölgeleri için çalışan kiralık olarak çalışmayı seçti. Uzmanlığı, savaş durumlarında müzakereydi.</CombatNegotiator31.description>
+  <CombatNegotiator31.description>[PAWN_nameDef] anavatanından kaçtıktan sonra yeteneklerini yıldızlara taşıdı.\n\nÇeşitli isyancı örgütler, köleleştirilmiş gruplar ve tüccar yerleşim bölgeleri için çalışan kiralık olarak çalışmayı seçti. Uzmanlığı, savaş durumlarında müzakereydi.</CombatNegotiator31.description>
   <!-- EN: combat negotiator -->
   <CombatNegotiator31.title>muharebe müzakerecisi</CombatNegotiator31.title>
   <CombatNegotiator31.titleFemale>muharebe müzakerecisi</CombatNegotiator31.titleFemale>
@@ -520,7 +520,7 @@
   <CommonerLord45.titleShortFemale>lord</CommonerLord45.titleShortFemale>
   
   <!-- EN: Bored of [PAWN_possessive] code-monkey office job and missing the glory days of the Academy, [PAWN_nameDef] saw a commercial about the frontier where "only the strong survive".\n\nWith [PAWN_possessive] wife Morgan, [PAWN_nameDef] undertook a journey into the unknown. -->
-  <ComputerEngineer10.description>Kod-Mon olan ofis işinden sıkılan ve Akademi'nin görkemli günlerini özleyen [PAWN_nameDef], "sadece güçlülerin hayatta kaldığı" sınırla ilgili bir reklam gördü. \n\n [PAWN_nameDef] karısı Morgan ile bilinmeyene doğru bir yolculuğa çıktı.</ComputerEngineer10.description>
+  <ComputerEngineer10.description>Kod-Mon olan ofis işinden sıkılan ve Akademi'nin görkemli günlerini özleyen [PAWN_nameDef], "sadece güçlülerin hayatta kaldığı" sınırla ilgili bir reklam gördü.\n\n[PAWN_nameDef] karısı Morgan ile bilinmeyene doğru bir yolculuğa çıktı.</ComputerEngineer10.description>
   <!-- EN: computer engineer -->
   <ComputerEngineer10.title>bilgisayar mühendisi</ComputerEngineer10.title>
   <ComputerEngineer10.titleFemale>bilgisayar mühendisi</ComputerEngineer10.titleFemale>
@@ -546,16 +546,16 @@
   <CoreworldJeweler19.titleShortFemale>kuyumcu</CoreworldJeweler19.titleShortFemale>
   
   <!-- EN: Even as [PAWN_pronoun] stewed in [PAWN_possessive] own wasted potential, [PAWN_nameDef] found [PAWN_pronoun] had a knack for moving objects quickly. It was just what the planetary mega-corps wanted in their construction divisions.\n\nUnfortunately, the monotonous work erased [PAWN_possessive] remaining creative impulses. -->
-  <CorporateBuilder58.description>[PAWN_nameDef], kendi boşa harcanan potansiyeliyle uğraşırken bile, nesneleri hızlı bir şekilde hareket ettirme becerisine sahip olduğunu keşfetti. Bu tam da gezegensel mega birliklerin inşaat bölümlerinde istedikleri şeydi.\n\n Ne yazık ki, monoton çalışma, kalan yaratıcı dürtülerini sildi.</CorporateBuilder58.description>
+  <CorporateBuilder58.description>[PAWN_nameDef], kendi boşa harcanan potansiyeliyle uğraşırken bile, nesneleri hızlı bir şekilde hareket ettirme becerisine sahip olduğunu keşfetti. Bu tam da gezegensel mega birliklerin inşaat bölümlerinde istedikleri şeydi.\n\nNe yazık ki, monoton çalışma, kalan yaratıcı dürtülerini sildi.</CorporateBuilder58.description>
   <!-- EN: corporate builder -->
   <CorporateBuilder58.title>kurumsal inşaatçı</CorporateBuilder58.title>
   <CorporateBuilder58.titleFemale>kurumsal inşaatçı</CorporateBuilder58.titleFemale>
   <!-- EN: builder -->
-  <CorporateBuilder58.titleShort>inşaat işçisi</CorporateBuilder58.titleShort>
-  <CorporateBuilder58.titleShortFemale>inşaat işçisi</CorporateBuilder58.titleShortFemale>
+  <CorporateBuilder58.titleShort>İnşaat işçisi</CorporateBuilder58.titleShort>
+  <CorporateBuilder58.titleShortFemale>İnşaat işçisi</CorporateBuilder58.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was sold to a corporation and put to work as a corporate slave doing scientific research.\n\nUnable to adapt to the social politics of [PAWN_possessive] workplace, [PAWN_pronoun] buried [PAWN_objective]self in [PAWN_possessive] work and failed to progress up the corporate ladder. Every day, [PAWN_pronoun] yearned to be left alone. -->
-  <CorpResearcher71.description>[PAWN_nameDef] bir şirkete satıldı ve bilimsel araştırma yapan bir kurumsal köle olarak çalıştırıldı.\n\n İş yerinin sosyal politikalarına uyum sağlayamadığı için kendini işine gömdü ve kurumsal merdiveni tırmanamadı. Her gün yalnız bırakılmayı özlemişti.</CorpResearcher71.description>
+  <CorpResearcher71.description>[PAWN_nameDef] bir şirkete satıldı ve bilimsel araştırma yapan bir kurumsal köle olarak çalıştırıldı.\n\nİş yerinin sosyal politikalarına uyum sağlayamadığı için kendini işine gömdü ve kurumsal merdiveni tırmanamadı. Her gün yalnız bırakılmayı özlemişti.</CorpResearcher71.description>
   <!-- EN: corp researcher -->
   <CorpResearcher71.title>şirket araştırmacısı</CorpResearcher71.title>
   <CorpResearcher71.titleFemale>şirket araştırmacısı</CorpResearcher71.titleFemale>
@@ -573,7 +573,7 @@
   <CorpResearcher93.titleShortFemale>araştırmacı</CorpResearcher93.titleShortFemale>
   
   <!-- EN: Living on the streets, [PAWN_nameDef] submitted [PAWN_objective]self to an unethical cosmetics lab in exchange for food and shelter.\n\nAfter some painful cosmetic modification, [PAWN_nameDef] barely resembles [PAWN_possessive] former self. Having been forced to work for the lab until [PAWN_pronoun] was rescued, [PAWN_nameDef] is now too afraid to lash out at anyone. -->
-  <CosmeticReject64.description>Sokaklarda yaşayan [PAWN_nameDef], yiyecek ve barınak karşılığında kendisini etik olmayan bir kozmetik laboratuvarına teslim etti.\n\n Bazı acı verici kozmetik modifikasyonlardan sonra, [PAWN_nameDef] eski haline neredeyse hiç benzemiyor. Kurtarılana kadar laboratuvarda çalışmak zorunda kalan [PAWN_nameDef] artık birisine saldırmaktan çok korkuyor.</CosmeticReject64.description>
+  <CosmeticReject64.description>Sokaklarda yaşayan [PAWN_nameDef], yiyecek ve barınak karşılığında kendisini etik olmayan bir kozmetik laboratuvarına teslim etti.\n\nBazı acı verici kozmetik modifikasyonlardan sonra, [PAWN_nameDef] eski haline neredeyse hiç benzemiyor. Kurtarılana kadar laboratuvarda çalışmak zorunda kalan [PAWN_nameDef] artık birisine saldırmaktan çok korkuyor.</CosmeticReject64.description>
   <!-- EN: cosmetic reject -->
   <CosmeticReject64.title>kozmetik defolu</CosmeticReject64.title>
   <CosmeticReject64.titleFemale>kozmetik defolu</CosmeticReject64.titleFemale>
@@ -582,7 +582,7 @@
   <CosmeticReject64.titleShortFemale>defolu</CosmeticReject64.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] had a terrible bedside manner due to [PAWN_possessive] abrasiveness. [PAWN_pronoun] often bullied [PAWN_possessive] patients into getting cosmetic surgery. [PAWN_pronoun] made a lot of money this way.\n\nWhile very studious and careful in [PAWN_possessive] work, [PAWN_pronoun] never had to lift a finger doing domestic chores. -->
-  <CosmeticSurgeon36.description>[PAWN_nameDef] hastalarına karşı toksik tavıra sahipti. Sık sık hastalarını estetik ameliyat olmaları için zorlardı. Bu şekilde çok para kazandı.\n\n İşinde çok çalışkan ve dikkatli olmasına rağmen, ev işlerini yaparken parmağını bile kıpırdatmadı.</CosmeticSurgeon36.description>
+  <CosmeticSurgeon36.description>[PAWN_nameDef] hastalarına karşı toksik tavıra sahipti. Sık sık hastalarını estetik ameliyat olmaları için zorlardı. Bu şekilde çok para kazandı.\n\nİşinde çok çalışkan ve dikkatli olmasına rağmen, ev işlerini yaparken parmağını bile kıpırdatmadı.</CosmeticSurgeon36.description>
   <!-- EN: cosmetic surgeon -->
   <CosmeticSurgeon36.title>estetisyen</CosmeticSurgeon36.title>
   <CosmeticSurgeon36.titleFemale>estetisyen</CosmeticSurgeon36.titleFemale>
@@ -591,7 +591,7 @@
   <CosmeticSurgeon36.titleShortFemale>cerrah</CosmeticSurgeon36.titleShortFemale>
   
   <!-- EN: By day, [PAWN_nameDef] was an office worker on a midworld. At night, [PAWN_pronoun] designed and built elaborate monster costumes for science fiction conventions.\n\n[PAWN_pronoun] learned a great deal about sewing. Unfortunately this came at the cost of being able to cook anything more complex than an instant meal. -->
-  <CostumeCrafter41.description>[PAWN_nameDef] gündüzleri bir orta dünyada bir ofis çalışanıydı. Geceleri ise bilim kurgu kongreleri için ayrıntılı canavar kostümleri tasarladı ve dikti.\n\n Dikiş hakkında çok şey öğrendi. Ne yazık ki bu hazır yemekten daha karmaşık bir şey pişirememe durumuna geldi.</CostumeCrafter41.description>
+  <CostumeCrafter41.description>[PAWN_nameDef] gündüzleri bir orta dünyada bir ofis çalışanıydı. Geceleri ise bilim kurgu kongreleri için ayrıntılı canavar kostümleri tasarladı ve dikti.\n\nDikiş hakkında çok şey öğrendi. Ne yazık ki bu hazır yemekten daha karmaşık bir şey pişirememe durumuna geldi.</CostumeCrafter41.description>
   <!-- EN: costume crafter -->
   <CostumeCrafter41.title>desinatör</CostumeCrafter41.title>
   <CostumeCrafter41.titleFemale>desinatör</CostumeCrafter41.titleFemale>
@@ -600,7 +600,7 @@
   <CostumeCrafter41.titleShortFemale>terzi</CostumeCrafter41.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] locked [PAWN_objective]self in [PAWN_possessive] studio for years, ordering delivery food to save time on cooking.\n\nEventually, [PAWN_possessive] creations brought [PAWN_objective] the highest honor on Semantic World: Permission to materialize any design in minutes using the most advanced technologies. -->
-  <CraftShaper37.description>[PAWN_nameDef] yıllarca kendini stüdyoya kilitledi ve yemek pişirmekten zaman kazanmak için yemek siparişi verdi.\n\n Sonunda, yarattıkları ona Semantik Dünya'daki en büyük onuru getirdi: En gelişmiş teknolojileri kullanarak herhangi bir tasarımı dakikalar içinde gerçekleştirme izni.</CraftShaper37.description>
+  <CraftShaper37.description>[PAWN_nameDef] yıllarca kendini stüdyoya kilitledi ve yemek pişirmekten zaman kazanmak için yemek siparişi verdi.\n\nSonunda, yarattıkları ona Semantik Dünya'daki en büyük onuru getirdi: En gelişmiş teknolojileri kullanarak herhangi bir tasarımı dakikalar içinde gerçekleştirme izni.</CraftShaper37.description>
   <!-- EN: craft shaper -->
   <CraftShaper37.title>Yaratıcı tornacı</CraftShaper37.title>
   <CraftShaper37.titleFemale>Yaratıcı tornacı</CraftShaper37.titleFemale>
@@ -609,7 +609,7 @@
   <CraftShaper37.titleShortFemale>tornacı</CraftShaper37.titleShortFemale>
   
   <!-- EN: Through brutality and cruelty, [PAWN_nameDef] rose to become a crime lord.\n\n[PAWN_pronoun] relied less on [PAWN_possessive] fists and more on [PAWN_possessive] guns. [PAWN_possessive] reputation spread quickly due to [PAWN_possessive] cold-bloodedness and ruthless methods. -->
-  <CrimeLord10.description>[PAWN_nameDef], gaddarlık ve acımasızlıkla bir suç lordu haline geldi.\n\n Yumruklarına daha az, silahlarına daha çok güveniyordu. Soğukkanlılığı ve acımasız yöntemleri nedeniyle ünü hızla yayıldı.</CrimeLord10.description>
+  <CrimeLord10.description>[PAWN_nameDef], gaddarlık ve acımasızlıkla bir suç lordu haline geldi.\n\nYumruklarına daha az, silahlarına daha çok güveniyordu. Soğukkanlılığı ve acımasız yöntemleri nedeniyle ünü hızla yayıldı.</CrimeLord10.description>
   <!-- EN: crime lord -->
   <CrimeLord10.title>Suç lordu</CrimeLord10.title>
   <CrimeLord10.titleFemale>Suç lordu</CrimeLord10.titleFemale>
@@ -618,7 +618,7 @@
   <CrimeLord10.titleShortFemale>Suç lordu</CrimeLord10.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] discovered [PAWN_possessive] gift - people did what [PAWN_pronoun] said, when [PAWN_pronoun] said it. Taking advantage of this, [PAWN_pronoun] set off for the rimworlds to make a name for [PAWN_objective]self in the criminal underworld.\n\nHaving people do things for [PAWN_objective] taught [PAWN_objective] to avoid manual labor at all costs. -->
-  <CriminalKingpin36.description>[PAWN_nameDef] özelliğini keşfetti - insanlar o söylediğinde söylediklerini yaptılar. Bundan yararlanarak, yeraltı dünyasında kendisine bir isim yapmak için rimworlds'e doğru yola çıktı.\n\n İnsanların onun için bir şeyler yapmasını sağlamak, ona ne pahasına olursa olsun el emeğinden kaçınmayı öğretti.</CriminalKingpin36.description>
+  <CriminalKingpin36.description>[PAWN_nameDef] özelliğini keşfetti - insanlar o söylediğinde söylediklerini yaptılar. Bundan yararlanarak, yeraltı dünyasında kendisine bir isim yapmak için rimworlds'e doğru yola çıktı.\n\nİnsanların onun için bir şeyler yapmasını sağlamak, ona ne pahasına olursa olsun el emeğinden kaçınmayı öğretti.</CriminalKingpin36.description>
   <!-- EN: criminal kingpin -->
   <CriminalKingpin36.title>suçlu elebaşı</CriminalKingpin36.title>
   <!-- EN: kingpin -->
@@ -634,7 +634,7 @@
   <CriminalSurgeon99.titleShortFemale>cerrah</CriminalSurgeon99.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was a deep space surveyor. [PAWN_pronoun] studied which worlds were the most suitable for colonization.\n\n[PAWN_possessive] expeditions were met by hostile natives, green-painted space-women, and wannabe Greek gods. Surviving many firefights, [PAWN_pronoun] learned to build rudimentary lathes and rock cannons to fend off enemies. -->
-  <DeepSpaceSurveyor1.description>[PAWN_nameDef] bir derin uzay bilirkişisiydi. Hangi dünyaların kolonizasyon için en uygun olduğunu araştırdı.\n\n Keşif gezilerinde düşman yerliler, yeşile boyanmış uzay kadınları ve özenti Yunan tanrıları tarafından karşılandı. Birçok çatışmada hayatta kalarak, düşmanları savuşturmak için ilkel torna techizatları ve kaya topları yapmayı öğrendi.</DeepSpaceSurveyor1.description>
+  <DeepSpaceSurveyor1.description>[PAWN_nameDef] bir derin uzay bilirkişisiydi. Hangi dünyaların kolonizasyon için en uygun olduğunu araştırdı.\n\nKeşif gezilerinde düşman yerliler, yeşile boyanmış uzay kadınları ve özenti Yunan tanrıları tarafından karşılandı. Birçok çatışmada hayatta kalarak, düşmanları savuşturmak için ilkel torna techizatları ve kaya topları yapmayı öğrendi.</DeepSpaceSurveyor1.description>
   <!-- EN: deep space surveyor -->
   <DeepSpaceSurveyor1.title>derin uzay bilirkişi</DeepSpaceSurveyor1.title>
   <DeepSpaceSurveyor1.titleFemale>derin uzay bilirkişi</DeepSpaceSurveyor1.titleFemale>
@@ -643,7 +643,7 @@
   <DeepSpaceSurveyor1.titleShortFemale>bilirkişi</DeepSpaceSurveyor1.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] decided to leave the oppressive dictatorship where [PAWN_pronoun] lived. [PAWN_possessive] defection was not well-received, and agents were sent after [PAWN_objective].\n\n[PAWN_pronoun] spent years on the run. Since [PAWN_pronoun] could trust no doctor, [PAWN_pronoun] treated [PAWN_possessive] own wounds. The ordeal made [PAWN_objective] bitter and untrusting. -->
-  <Defector95.description>[PAWN_nameDef] yaşadığı baskıcı diktatörlükten ayrılmaya karar verdi. Onun iltica etmesi iyi karşılanmadı ve ajanlar peşinden gönderildi.\n\n Yıllarını kaçarak geçirdi. Hiçbir doktora güvenemediği için kendi yaralarını tedavi ediyordu. Bu çile onu sert ve güvensiz yaptı.</Defector95.description>
+  <Defector95.description>[PAWN_nameDef] yaşadığı baskıcı diktatörlükten ayrılmaya karar verdi. Onun iltica etmesi iyi karşılanmadı ve ajanlar peşinden gönderildi.\n\nYıllarını kaçarak geçirdi. Hiçbir doktora güvenemediği için kendi yaralarını tedavi ediyordu. Bu çile onu sert ve güvensiz yaptı.</Defector95.description>
   <!-- EN: defector -->
   <Defector95.title>mülteci</Defector95.title>
   <Defector95.titleFemale>mülteci</Defector95.titleFemale>
@@ -652,7 +652,7 @@
   <Defector95.titleShortFemale>mülteci</Defector95.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] found that [PAWN_pronoun] could make more money with a quick word than a blaster. Seeking a job where [PAWN_possessive] silver tongue could be useful, [PAWN_pronoun] turned to the law.\n\n[PAWN_pronoun] often defended the illegal speeder racers [PAWN_pronoun] grew up with. -->
-  <DefenseLawyer71.description>[PAWN_nameDef], hızlı söylenmiş bir kelimeyle Wall Street'daki birinden daha fazla para kazanabileceğini buldu. Gümüş dilinin işe yarayacağı bir iş arayarak kanuna başvurdu.\n\n Birlikte büyüdüğü yasadışı hız yarışçılarını sıklıkla savundu.</DefenseLawyer71.description>
+  <DefenseLawyer71.description>[PAWN_nameDef], hızlı söylenmiş bir kelimeyle Wall Street'daki birinden daha fazla para kazanabileceğini buldu. Gümüş dilinin işe yarayacağı bir iş arayarak kanuna başvurdu.\n\nBirlikte büyüdüğü yasadışı hız yarışçılarını sıklıkla savundu.</DefenseLawyer71.description>
   <!-- EN: defense lawyer -->
   <DefenseLawyer71.title>savunma avukatı</DefenseLawyer71.title>
   <DefenseLawyer71.titleFemale>savunma avukatı</DefenseLawyer71.titleFemale>
@@ -661,7 +661,7 @@
   <DefenseLawyer71.titleShortFemale>avukat</DefenseLawyer71.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] held the rank of Destroyer-General in a powerful midworld military.\n\n[PAWN_pronoun] was known for [PAWN_possessive] mastery of weapons, and was also a good ship pilot. -->
-  <DestroyerGeneral26.description>[PAWN_nameDef], güçlü bir orta dünya ordusunda Muhrip General rütbesine sahipti.\n\n Silah ustalığıyla tanınırdı ve aynı zamanda iyi bir gemi pilotuydu.</DestroyerGeneral26.description>
+  <DestroyerGeneral26.description>[PAWN_nameDef], güçlü bir orta dünya ordusunda Muhrip General rütbesine sahipti.\n\nSilah ustalığıyla tanınırdı ve aynı zamanda iyi bir gemi pilotuydu.</DestroyerGeneral26.description>
   <!-- EN: destroyer-general -->
   <DestroyerGeneral26.title>Yokedici general</DestroyerGeneral26.title>
   <DestroyerGeneral26.titleFemale>Yokedici general</DestroyerGeneral26.titleFemale>
@@ -670,7 +670,7 @@
   <DestroyerGeneral26.titleShortFemale>general</DestroyerGeneral26.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] prostituted [PAWN_objective]self to fund [PAWN_possessive] drug habits. As an escape, [PAWN_pronoun] joined the military and learned to fight.\n\nToo smart for the army, [PAWN_pronoun] questioned and often disagreed with [PAWN_possessive] superiors' decisions. This eventually led to [PAWN_possessive] dishonorable discharge and left [PAWN_objective] with a chip on [PAWN_possessive] shoulder. -->
-  <DischargedSoldier53.description>[PAWN_nameDef] uyuşturucu alışkanlıklarını finanse etmek için kendi kendini sattı. Bir kaçış olarak orduya katıldı ve savaşmayı öğrendi.\n\n Ordu için fazla akıllıydı, sorguladı ve üstlerinin kararlarına çoğu zaman katılmadı. Bu durum sonunda onursuz bir şekilde terhis edilmesine yol açtı ve omzunda bir çip ile kalakaldı.</DischargedSoldier53.description>
+  <DischargedSoldier53.description>[PAWN_nameDef] uyuşturucu alışkanlıklarını finanse etmek için kendi kendini sattı. Bir kaçış olarak orduya katıldı ve savaşmayı öğrendi.\n\nOrdu için fazla akıllıydı, sorguladı ve üstlerinin kararlarına çoğu zaman katılmadı. Bu durum sonunda onursuz bir şekilde terhis edilmesine yol açtı ve omzunda bir çip ile kalakaldı.</DischargedSoldier53.description>
   <!-- EN: discharged soldier -->
   <DischargedSoldier53.title>ıskarta asker</DischargedSoldier53.title>
   <DischargedSoldier53.titleFemale>ıskarta asker</DischargedSoldier53.titleFemale>
@@ -688,16 +688,16 @@
   <DoomsdayPariah18.titleShortFemale>parya</DoomsdayPariah18.titleShortFemale>
   
   <!-- EN: Some followers say that [PAWN_nameDef] and [PAWN_possessive] crew of misfits found the fountain of youth, many, many centuries ago, and that they caused the extinction of the dinosaurs on many planets.\n\nThere's even a religion about them, somewhere, involving noodles and meatballs. -->
-  <DreadedDude58.description>Bazı takipçiler, [PAWN_nameDef] ve uyumsuz ekibinin gençlik pınarını yüzyıllar önce bulduğunu ve birçok gezegende dinozorların yok olmasına neden olduklarını söylüyor.\n\n Hatta onlar hakkında bir yerlerde erişte ve köfte içeren bir din bile var.</DreadedDude58.description>
+  <DreadedDude58.description>Bazı takipçiler, [PAWN_nameDef] ve uyumsuz ekibinin gençlik pınarını yüzyıllar önce bulduğunu ve birçok gezegende dinozorların yok olmasına neden olduklarını söylüyor.\n\nHatta onlar hakkında bir yerlerde erişte ve köfte içeren bir din bile var.</DreadedDude58.description>
   <!-- EN: dreaded dude -->
-  <DreadedDude58.title>korkulan dude</DreadedDude58.title>
-  <DreadedDude58.titleFemale>korkulan dude</DreadedDude58.titleFemale>
+  <DreadedDude58.title>korkulan herif</DreadedDude58.title>
+  <DreadedDude58.titleFemale>korkulan herif</DreadedDude58.titleFemale>
   <!-- EN: dude -->
-  <DreadedDude58.titleShort>dude</DreadedDude58.titleShort>
-  <DreadedDude58.titleShortFemale>dude</DreadedDude58.titleShortFemale>
+  <DreadedDude58.titleShort>herif</DreadedDude58.titleShort>
+  <DreadedDude58.titleShortFemale>herif</DreadedDude58.titleShortFemale>
   
   <!-- EN: Having caught the eye of [PAWN_possessive] people's Sand King, [PAWN_nameDef] was trained in the Sandy Boomrat fighting technique.\n\nAlways with a camel to carry [PAWN_possessive] things, [PAWN_pronoun] served [PAWN_possessive] sand people faithfully. -->
-  <DromedaryKnight37.description>Halkının Kum Kralı'nın dikkatini çeken [PAWN_nameDef], Sandy Boomrat dövüş tekniğinde eğitildi.\n\n Her zaman eşyalarını taşımak için bir deve ile kum halkına sadakatle hizmet etti.</DromedaryKnight37.description>
+  <DromedaryKnight37.description>Halkının Kum Kralı'nın dikkatini çeken [PAWN_nameDef], Sandy Boomrat dövüş tekniğinde eğitildi.\n\nHer zaman eşyalarını taşımak için bir deve ile kum halkına sadakatle hizmet etti.</DromedaryKnight37.description>
   <!-- EN: dromedary knight -->
   <DromedaryKnight37.title>develi şovalye</DromedaryKnight37.title>
   <DromedaryKnight37.titleFemale>develi şovalye</DromedaryKnight37.titleFemale>
@@ -706,7 +706,7 @@
   <DromedaryKnight37.titleShortFemale>şovalye</DromedaryKnight37.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] worked the drug trade under kingpin Grady Loughman. [PAWN_pronoun] had [PAWN_possessive] men sell drugs when it was profitable, and fight the other cartels when the government came around.\n\n[PAWN_possessive] social skills kept [PAWN_objective] on top of the political game, and [PAWN_pronoun] always had servants to cook and clean. -->
-  <DrugLieutenant98.description>[PAWN_nameDef] uyuşturucu ticaretinde kral Grady Loughman altında çalıştı. Kârlı olduğunda adamlarına uyuşturucu sattırdı ve hükümet veya diğer kartellerle savaştı.\n\n Sosyal becerileri onu politik oyunun zirvesinde tutuyordu ve her zaman yemek pişirmek ve temizlik yapmak için hizmetçileri vardı.</DrugLieutenant98.description>
+  <DrugLieutenant98.description>[PAWN_nameDef] uyuşturucu ticaretinde kral Grady Loughman altında çalıştı. Kârlı olduğunda adamlarına uyuşturucu sattırdı ve hükümet veya diğer kartellerle savaştı.\n\nSosyal becerileri onu politik oyunun zirvesinde tutuyordu ve her zaman yemek pişirmek ve temizlik yapmak için hizmetçileri vardı.</DrugLieutenant98.description>
   <!-- EN: drug lieutenant -->
   <DrugLieutenant98.title>kartel lideri</DrugLieutenant98.title>
   <DrugLieutenant98.titleFemale>kartel lideri</DrugLieutenant98.titleFemale>
@@ -733,7 +733,7 @@
   <Engineer40.titleShortFemale>mühendis</Engineer40.titleShortFemale>
   
   <!-- EN: After [PAWN_possessive] province was besieged by one of its neighbors, [PAWN_nameDef] volunteered for a generic modification program that created pilots for the very fighter craft that [PAWN_pronoun] had helped develop. The modifications allowed [PAWN_objective] to pilot the ship, but also made [PAWN_objective] less able to focus on the people around him.\n\nBy this time, people were calling [PAWN_objective] "Squirrel." -->
-  <EngineeredPilot75.description>Eyaleti komşularından biri tarafından kuşatıldıktan sonra [PAWN_nameDef] geliştirilmesine yardım ettiği savaş gemisi için pilotlar eğiten genel bir değişiklik programı için gönüllü oldu. Değişiklikler, gemiye pilotluk yapmasına izin verdi, ancak aynı zamanda etrafındaki insanlara daha az odaklanmasını sağladı.\n\n Bu sırada insanlar ona "Sincap" diyordu.</EngineeredPilot75.description>
+  <EngineeredPilot75.description>Eyaleti komşularından biri tarafından kuşatıldıktan sonra [PAWN_nameDef] geliştirilmesine yardım ettiği savaş gemisi için pilotlar eğiten genel bir değişiklik programı için gönüllü oldu. Değişiklikler, gemiye pilotluk yapmasına izin verdi, ancak aynı zamanda etrafındaki insanlara daha az odaklanmasını sağladı.\n\nBu sırada insanlar ona "Sincap" diyordu.</EngineeredPilot75.description>
   <!-- EN: engineered pilot -->
   <EngineeredPilot75.title>mühendis pilot</EngineeredPilot75.title>
   <EngineeredPilot75.titleFemale>mühendis pilot</EngineeredPilot75.titleFemale>
@@ -742,7 +742,7 @@
   <EngineeredPilot75.titleShortFemale>pilot</EngineeredPilot75.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] entered the diplomatic corps. Honor and tradition were the values [PAWN_pronoun] took with [PAWN_objective] on every mission.\n\n[PAWN_possessive] prestigious position distanced [PAWN_objective] from backbreaking manual labor, allowing [PAWN_objective] to focus on [PAWN_possessive] wordsmithing abilities. [PAWN_pronoun] left the blacksmithing to others. -->
-  <EnvoyOfTheStars19.description>[PAWN_nameDef] diplomatik birliğe girdi. Onur ve gelenek, her görevde yanına aldığı değerlerdi.\n\n Prestijli konumu, onu yıpratıcı el emeğinden uzaklaştırarak, onun kelime ustalığı yeteneklerine odaklanmasını sağladı. Demirciliği başkalarına bıraktı.</EnvoyOfTheStars19.description>
+  <EnvoyOfTheStars19.description>[PAWN_nameDef] diplomatik birliğe girdi. Onur ve gelenek, her görevde yanına aldığı değerlerdi.\n\nPrestijli konumu, onu yıpratıcı el emeğinden uzaklaştırarak, onun kelime ustalığı yeteneklerine odaklanmasını sağladı. Demirciliği başkalarına bıraktı.</EnvoyOfTheStars19.description>
   <!-- EN: envoy of the stars -->
   <EnvoyOfTheStars19.title>yıldızların elçisi</EnvoyOfTheStars19.title>
   <EnvoyOfTheStars19.titleFemale>yıldızların elçisi</EnvoyOfTheStars19.titleFemale>
@@ -751,7 +751,7 @@
   <EnvoyOfTheStars19.titleShortFemale>elçi</EnvoyOfTheStars19.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was an executive officer for a large space trading corporation. After a failed attempt at manipulating [PAWN_possessive] way up the corporate ladder, [PAWN_pronoun] was framed for the rape and murder of another executive and [PAWN_possessive] family.\n\n[PAWN_pronoun] was found guilty. However, because of [PAWN_possessive] family's influence, [PAWN_pronoun] was exiled instead of put to death. -->
-  <ExecutiveOfficer5.description>[PAWN_nameDef], büyük bir uzay ticaret şirketi için üst düzey yöneticiydi. Kariyer basamaklarını tırmanmak için yaptığı başarısız bir girişimden sonra, başka bir yöneticiye ve ailesine tecavüz ve cinayetle suçlandı.\n\n Suçlu bulundu. Ancak ailesinin etkisiyle idam edilmek yerine sürgüne gönderildi.</ExecutiveOfficer5.description>
+  <ExecutiveOfficer5.description>[PAWN_nameDef], büyük bir uzay ticaret şirketi için üst düzey yöneticiydi. Kariyer basamaklarını tırmanmak için yaptığı başarısız bir girişimden sonra, başka bir yöneticiye ve ailesine tecavüz ve cinayetle suçlandı.\n\nSuçlu bulundu. Ancak ailesinin etkisiyle idam edilmek yerine sürgüne gönderildi.</ExecutiveOfficer5.description>
   <!-- EN: executive officer -->
   <ExecutiveOfficer5.title>üst düzey yönetici</ExecutiveOfficer5.title>
   <ExecutiveOfficer5.titleFemale>üst düzey yönetici</ExecutiveOfficer5.titleFemale>
@@ -769,7 +769,7 @@
   <ExiledResearcher44.titleShortFemale>sürgün</ExiledResearcher44.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] has always gone overboard when it comes to food. [PAWN_pronoun] is always seeking new and exotic ingredients.\n\n[PAWN_possessive] quest for ingredients has brought [PAWN_objective] into some close calls with local flora and fauna. -->
-  <ExoticChef96.description>[PAWN_nameDef] konu yemek olduğunda her zaman aşırıya kaçtı. Her zaman yeni ve egzotik malzemeler arardı.\n\n İçerik arayışı  onu yerel flora ve fauna ile yakından ilgilenmeye sevketti.</ExoticChef96.description>
+  <ExoticChef96.description>[PAWN_nameDef] konu yemek olduğunda her zaman aşırıya kaçtı. Her zaman yeni ve egzotik malzemeler arardı.\n\nİçerik arayışı  onu yerel flora ve fauna ile yakından ilgilenmeye sevketti.</ExoticChef96.description>
   <!-- EN: exotic chef -->
   <ExoticChef96.title>egzotik şef</ExoticChef96.title>
   <ExoticChef96.titleFemale>egzotik şef</ExoticChef96.titleFemale>
@@ -823,7 +823,7 @@
   <FallenOfficial12.titleShortFemale>memur</FallenOfficial12.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was a excellent chef who worked in a high-end restaurant.\n\nOne day, [PAWN_pronoun] left the stove on, and accidentally burned down the whole building. This event shook [PAWN_objective] so much that [PAWN_pronoun] swore to never touch a stove again. -->
-  <FearfulChef49.description>[PAWN_nameDef], lüks bir restoranda çalışan mükemmel bir şefti.\n\n Bir gün sobayı açık bıraktı ve yanlışlıkla tüm binayı yaktı. Bu olay onu o kadar sarstı ki bir daha sobaya dokunmamaya yemin etti.</FearfulChef49.description>
+  <FearfulChef49.description>[PAWN_nameDef], lüks bir restoranda çalışan mükemmel bir şefti.\n\nBir gün sobayı açık bıraktı ve yanlışlıkla tüm binayı yaktı. Bu olay onu o kadar sarstı ki bir daha sobaya dokunmamaya yemin etti.</FearfulChef49.description>
   <!-- EN: fearful chef -->
   <FearfulChef49.title>Korkak şef</FearfulChef49.title>
   <FearfulChef49.titleFemale>Korkak şef</FearfulChef49.titleFemale>
@@ -841,7 +841,7 @@
   <FelineScientist76.titleShortFemale>bilim adamı</FelineScientist76.titleShortFemale>
   
   <!-- EN: As a young adult, [PAWN_nameDef] was sure that [PAWN_possessive] planet and its people were nearing their time of transcendence.\n\nA firm belief that [PAWN_possessive] research would be the catalyst drove [PAWN_objective] to increasingly alarming acts as bureaucrats and bioethics committees worked to stall [PAWN_possessive] progress. -->
-  <FerventResearcher72.description>[PAWN_nameDef] genç bir yetişkinken, gezegeninin ve insanlarının son zamanlarına yaklaştıklarından emindi.\n\n Bürokratlar ve biyoetik komiteler çalışmasını durdurmak için çalışırken, araştırmasının katalizör olacağına dair kesin inancı onu giderek daha fazla endişe verici eylemlere yöneltti.</FerventResearcher72.description>
+  <FerventResearcher72.description>[PAWN_nameDef] genç bir yetişkinken, gezegeninin ve insanlarının son zamanlarına yaklaştıklarından emindi.\n\nBürokratlar ve biyoetik komiteler çalışmasını durdurmak için çalışırken, araştırmasının katalizör olacağına dair kesin inancı onu giderek daha fazla endişe verici eylemlere yöneltti.</FerventResearcher72.description>
   <!-- EN: fervent researcher -->
   <FerventResearcher72.title>tutkulu araştırmacı</FerventResearcher72.title>
   <FerventResearcher72.titleFemale>tutkulu araştırmacı</FerventResearcher72.titleFemale>
@@ -859,7 +859,7 @@
   <FighterController67.titleShortFemale>kontrolör</FighterController67.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] strolled and sipped [PAWN_possessive] way through the streets and cafes of [PAWN_possessive] world, pursuing freedom at every turn, never becoming attached.\n\nThrough all this time, [PAWN_pronoun] remained distrustful of others. And never took an order from anyone. -->
-  <Flaneur30.description>[PAWN_nameDef]  her fırsatta özgürlüğün peşinden koşarak, asla bağlanmadan, dünyasının sokaklarında ve kafelerinde dolaşıp yudumladı.\n\n. Bunca zaman boyunca, diğerlerine karşı güvensizliğini korudu. Ve asla kimseden emir almadı.</Flaneur30.description>
+  <Flaneur30.description>[PAWN_nameDef]  her fırsatta özgürlüğün peşinden koşarak, asla bağlanmadan, dünyasının sokaklarında ve kafelerinde dolaşıp yudumladı.\n\nBunca zaman boyunca, diğerlerine karşı güvensizliğini korudu. Ve asla kimseden emir almadı.</Flaneur30.description>
   <!-- EN: flaneur -->
   <Flaneur30.title>avare</Flaneur30.title>
   <Flaneur30.titleFemale>avare</Flaneur30.titleFemale>
@@ -877,14 +877,14 @@
   <ForestProwler15.titleShortFemale>sinsi</ForestProwler15.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was the marshal of [PAWN_possessive] colony. [PAWN_pronoun] tried to honorably uphold the law, but the corrupt local mayor killed [PAWN_possessive] family and left [PAWN_objective] for dead.\n\nAfter regaining [PAWN_possessive] health, [PAWN_nameDef] arrested the mayor. [PAWN_pronoun] left [PAWN_possessive] homeworld and started a new life working to make a difference in the universe. -->
-  <FrontierMarshal27.description>[PAWN_nameDef] kolonisinin mareşaliydi. Yasayı onurlu bir şekilde savunmaya çalıştı, ancak yozlaşmış yerel belediye başkanı ailesini öldürdü ve onu ölüme terk etti.\n\n [PAWN_nameDef] sağlığına kavuştuktan sonra belediye başkanını tutukladı. Ana dünyasını terk etti ve evrende bir fark yaratmak için çalışan yeni bir hayata başladı.</FrontierMarshal27.description>
+  <FrontierMarshal27.description>[PAWN_nameDef] kolonisinin mareşaliydi. Yasayı onurlu bir şekilde savunmaya çalıştı, ancak yozlaşmış yerel belediye başkanı ailesini öldürdü ve onu ölüme terk etti.\n\n[PAWN_nameDef] sağlığına kavuştuktan sonra belediye başkanını tutukladı. Ana dünyasını terk etti ve evrende bir fark yaratmak için çalışan yeni bir hayata başladı.</FrontierMarshal27.description>
   <!-- EN: frontier marshal -->
   <FrontierMarshal27.title>sınır mareşali</FrontierMarshal27.title>
   <!-- EN: marshal -->
   <FrontierMarshal27.titleShort>mareşal</FrontierMarshal27.titleShort>
   
   <!-- EN: [PAWN_nameDef] rebelled against the corporation [PAWN_pronoun] worked for. [PAWN_pronoun] failed, and was forced [PAWN_objective] to go on the run.\n\n[PAWN_pronoun] was always on the move, always leaving everything behind. [PAWN_pronoun] tried to gain supporters for [PAWN_possessive] cause, but failed due to [PAWN_possessive] poor social skills. -->
-  <Fugitive4.description>[PAWN_nameDef] çalıştığı emperyalistlere isyan etti. Başarısız oldu ve kaçmak zorunda kaldı.\n\n Her zaman hareket halindeydi, her şeyi her zaman geride bıraktı. Davası için taraftar toplamaya çalıştı, ancak zayıf sosyal becerileri nedeniyle başarısız oldu.</Fugitive4.description>
+  <Fugitive4.description>[PAWN_nameDef] çalıştığı emperyalistlere isyan etti. Başarısız oldu ve kaçmak zorunda kaldı.\n\nHer zaman hareket halindeydi, her şeyi her zaman geride bıraktı. Davası için taraftar toplamaya çalıştı, ancak zayıf sosyal becerileri nedeniyle başarısız oldu.</Fugitive4.description>
   <!-- EN: fugitive -->
   <Fugitive4.title>firari</Fugitive4.title>
   <Fugitive4.titleFemale>firari</Fugitive4.titleFemale>
@@ -893,7 +893,7 @@
   <Fugitive4.titleShortFemale>firari</Fugitive4.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was an independent game developer.\n\nAfter an early success, [PAWN_possessive] career quickly degenerated into a circus of misguided ideas, deals gone wrong, and desperate, failed PR stunts. -->
-  <GameDeveloper95.description>[PAWN_nameDef] bağımsız bir oyun geliştiricisiydi.\n\n Erken bir başarıdan sonra, kariyeri hızla yanlış yönlendirilmiş fikirler, yanlış giden anlaşmalar,umutsuz ve başarısız PR gösterileri sirkine dönüştü.</GameDeveloper95.description>
+  <GameDeveloper95.description>[PAWN_nameDef] bağımsız bir oyun geliştiricisiydi.\n\nErken bir başarıdan sonra, kariyeri hızla yanlış yönlendirilmiş fikirler, yanlış giden anlaşmalar,umutsuz ve başarısız PR gösterileri sirkine dönüştü.</GameDeveloper95.description>
   <!-- EN: game developer -->
   <GameDeveloper95.title>oyun geliştiricisi</GameDeveloper95.title>
   <GameDeveloper95.titleFemale>oyun geliştiricisi</GameDeveloper95.titleFemale>
@@ -901,7 +901,7 @@
   <GameDeveloper95.titleShort>oyun geliştiricisi</GameDeveloper95.titleShort>
   
   <!-- EN: Making a new life on a barely-livable planet after nuclear war, [PAWN_nameDef] was able to fulfill [PAWN_possessive] desires with money borrowed from [PAWN_possessive] father.\n\n[PAWN_pronoun] loved playing a particular colony simulator. [PAWN_possessive] favorite thing to do in the game was to build elaborate hospitals. Spending most of [PAWN_possessive] time playing, [PAWN_pronoun] forgot horrors of war and [PAWN_possessive] need for revenge. -->
-  <GameTester77.description>Nükleer savaştan sonra zar zor yaşanabilir bir gezegende yeni bir hayat kuran [PAWN_nameDef], babasından ödünç aldığı parayla arzularını gerçekleştirmeyi başardı.\n\n Belirli bir koloni simülatörü oynamayı çok severdi. Oyunda yapmayı en sevdiği şey ayrıntılı hastaneler inşa etmekti. Zamanının çoğunu oyun oynayarak geçirerek, savaşın dehşetini ve intikam ihtiyacını unuttu.</GameTester77.description>
+  <GameTester77.description>Nükleer savaştan sonra zar zor yaşanabilir bir gezegende yeni bir hayat kuran [PAWN_nameDef], babasından ödünç aldığı parayla arzularını gerçekleştirmeyi başardı.\n\nBelirli bir koloni simülatörü oynamayı çok severdi. Oyunda yapmayı en sevdiği şey ayrıntılı hastaneler inşa etmekti. Zamanının çoğunu oyun oynayarak geçirerek, savaşın dehşetini ve intikam ihtiyacını unuttu.</GameTester77.description>
   <!-- EN: game tester -->
   <GameTester77.title>oyun testçisi</GameTester77.title>
   <GameTester77.titleFemale>oyun testçisi</GameTester77.titleFemale>
@@ -910,7 +910,7 @@
   <GameTester77.titleShortFemale>testçi</GameTester77.titleShortFemale>
   
   <!-- EN: To survive, [PAWN_nameDef]'s gang often had to rob trade ships for food and supplies. Sometimes [PAWN_pronoun] had to kill the guards. Sometimes [PAWN_pronoun] had to kill the police who arrived to stop him.\n\nAfter years of this, [PAWN_pronoun] became one of the most-wanted criminals in the local empire. -->
-  <GangBoss49.description>[PAWN_nameDef]ve çetesi hayatta kalabilmek için genellikle ticaret gemilerini yiyecek ve erzak için soymak zorunda kaldı. Bazen gardiyanları öldürmek zorunda kaldı. Bazen onu durdurmak için gelen polisleri öldürmek zorunda kaldı.\n\n Bundan yıllar sonra, yerel imparatorlukta en çok aranan suçlulardan biri oldu.</GangBoss49.description>
+  <GangBoss49.description>[PAWN_nameDef]ve çetesi hayatta kalabilmek için genellikle ticaret gemilerini yiyecek ve erzak için soymak zorunda kaldı. Bazen gardiyanları öldürmek zorunda kaldı. Bazen onu durdurmak için gelen polisleri öldürmek zorunda kaldı.\n\nBundan yıllar sonra, yerel imparatorlukta en çok aranan suçlulardan biri oldu.</GangBoss49.description>
   <!-- EN: gang boss -->
   <GangBoss49.title>geng patronu</GangBoss49.title>
   <GangBoss49.titleFemale>geng patronu</GangBoss49.titleFemale>
@@ -919,7 +919,7 @@
   <GangBoss49.titleShortFemale>patron</GangBoss49.titleShortFemale>
   
   <!-- EN: Living for many years between three raider settlements, [PAWN_nameDef] persevered through many challenges: a spacecraft implosion, cryptostasis, crashlanding on a miserable dustball of a planet, and nursing an old man back to health, and many of battles.\n\n[PAWN_pronoun] eventually took control of a violent gang. -->
-  <GangSoldier39.description>Uzun yıllar boyunca üç akıncı yerleşimi arasında yaşayan [PAWN_nameDef] birçok zorluğun üstesinden geldi: bir uzay aracının patlaması; kriptostaz; bir gezegenin sefil çöplüklerinde yaşam ; yaşlı bir adamı sağlığına kavuşturma ve birçok savaş...\n\n Sonunda azılı bir çetenin kontrolünü ele geçirdi.</GangSoldier39.description>
+  <GangSoldier39.description>Uzun yıllar boyunca üç akıncı yerleşimi arasında yaşayan [PAWN_nameDef] birçok zorluğun üstesinden geldi: bir uzay aracının patlaması; kriptostaz; bir gezegenin sefil çöplüklerinde yaşam ; yaşlı bir adamı sağlığına kavuşturma ve birçok savaş...\n\nSonunda azılı bir çetenin kontrolünü ele geçirdi.</GangSoldier39.description>
   <!-- EN: gang soldier -->
   <GangSoldier39.title>geng askeri</GangSoldier39.title>
   <GangSoldier39.titleFemale>geng askeri</GangSoldier39.titleFemale>
@@ -928,7 +928,7 @@
   <GangSoldier39.titleShortFemale>asker</GangSoldier39.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] carried out [PAWN_possessive] first genetic experiments on farm animals. [PAWN_pronoun] soon grew to become quite skilled in all forms of genetic engineering.\n\nA horrifying lab accident left [PAWN_objective] with a mortal fear of rodents. -->
-  <GeneticEngineer89.description>[PAWN_nameDef] ilk genetik deneylerini çiftlik hayvanları üzerinde gerçekleştirdi. Kısa süre sonra genetik mühendisliğinin her türünde oldukça yetenekli hale geldi.\n\n Korkunç bir laboratuvar kazası, onu kemirgenlere karşı ölümcül bir korkuya kaptırdı.</GeneticEngineer89.description>
+  <GeneticEngineer89.description>[PAWN_nameDef] ilk genetik deneylerini çiftlik hayvanları üzerinde gerçekleştirdi. Kısa süre sonra genetik mühendisliğinin her türünde oldukça yetenekli hale geldi.\n\nKorkunç bir laboratuvar kazası, onu kemirgenlere karşı ölümcül bir korkuya kaptırdı.</GeneticEngineer89.description>
   <!-- EN: genetic engineer -->
   <GeneticEngineer89.title>genetik mühendisi</GeneticEngineer89.title>
   <GeneticEngineer89.titleFemale>genetik mühendisi</GeneticEngineer89.titleFemale>
@@ -946,7 +946,7 @@
   <GeneticScientist66.titleShortFemale>genetikçi</GeneticScientist66.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] sold [PAWN_objective]self into slavery for money to purchase boomrat pizza. [PAWN_pronoun] was then traded to the Zeglar colonies, where [PAWN_pronoun] worked as a male prostitute.\n\nIn a fluke event, [PAWN_pronoun] managed to join other escaping slaves as they hijacked a ship. After fighting with the captain of the slave crew over the last piece of boomrat pizza, [PAWN_nameDef] was sent off the ship in an escape pod. -->
-  <Gigolo68.description>[PAWN_nameDef], boomrat pizza satın almak ve para için kendini sattı. Daha sonra bir jigolo olarak çalıştığı Zeglar kolonilerine takas edildi.\n\n Şans eseri bir olayda, bir gemiyi kaçırırken kaçan diğer kölelere katılmayı başardı. Boomrat pizzanın son parçası için köle mürettebatın kaptanıyla kavga ettikten sonra, [PAWN_nameDef] bir kaçış kapsülünde gemiden gönderildi.</Gigolo68.description>
+  <Gigolo68.description>[PAWN_nameDef], boomrat pizza satın almak ve para için kendini sattı. Daha sonra bir jigolo olarak çalıştığı Zeglar kolonilerine takas edildi.\n\nŞans eseri bir olayda, bir gemiyi kaçırırken kaçan diğer kölelere katılmayı başardı. Boomrat pizzanın son parçası için köle mürettebatın kaptanıyla kavga ettikten sonra, [PAWN_nameDef] bir kaçış kapsülünde gemiden gönderildi.</Gigolo68.description>
   <!-- EN: gigolo -->
   <Gigolo68.title>jigolo</Gigolo68.title>
   <Gigolo68.titleFemale>fahişe</Gigolo68.titleFemale>
@@ -955,7 +955,7 @@
   <Gigolo68.titleShortFemale>fahişe</Gigolo68.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was a xenobiology professor in a glitterworld university. [PAWN_pronoun] went to conferences and managed an art gallery.\n\nHowever, [PAWN_pronoun] never stopped sculpting yard gnomes, and considers this to be [PAWN_possessive] true profession. -->
-  <Gnomebiologist96.description>[PAWN_nameDef] bir glitterworld üniversitesinde xenobiyoloji profesörüydü. Konferanslara gitti ve bir sanat galerisi yönetti.\n\n Ancak, bahçesini şekillendirmeyi asla bırakmadı ve bunu gerçek mesleği olarak görüyor.</Gnomebiologist96.description>
+  <Gnomebiologist96.description>[PAWN_nameDef] bir glitterworld üniversitesinde xenobiyoloji profesörüydü. Konferanslara gitti ve bir sanat galerisi yönetti.\n\nAncak, bahçesini şekillendirmeyi asla bırakmadı ve bunu gerçek mesleği olarak görüyor.</Gnomebiologist96.description>
   <!-- EN: gnomebiologist -->
   <Gnomebiologist96.title>gnome biyolog</Gnomebiologist96.title>
   <Gnomebiologist96.titleFemale>gnome biyolog</Gnomebiologist96.titleFemale>
@@ -964,7 +964,7 @@
   <Gnomebiologist96.titleShortFemale>biolog</Gnomebiologist96.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] worked for the government against rebel groups and excelled in this capacity. During [PAWN_possessive] training [PAWN_pronoun] was taught firearms, melee combat and medical skills.\n\nHaving grown up in a war-ravaged city, dirt, blood and dead bodies don't bother [PAWN_objective] and [PAWN_pronoun] sees no reason to clean them up. -->
-  <GovernmentAgent61.description>[PAWN_nameDef] hükümet için isyancı gruplara karşı çalıştı ve bu operasyonlarda başarılı oldu. Eğitimi sırasında kendisine ateşli silahlar, yakın dövüş ve tıbbi beceriler öğretildi.\n\n Savaşın yıktığı bir şehirde büyüdüğü için kir, kan ve cesetler onu rahatsız etmiyor ve onları temizlemek için hiçbir neden görmüyor.</GovernmentAgent61.description>
+  <GovernmentAgent61.description>[PAWN_nameDef] hükümet için isyancı gruplara karşı çalıştı ve bu operasyonlarda başarılı oldu. Eğitimi sırasında kendisine ateşli silahlar, yakın dövüş ve tıbbi beceriler öğretildi.\n\nSavaşın yıktığı bir şehirde büyüdüğü için kir, kan ve cesetler onu rahatsız etmiyor ve onları temizlemek için hiçbir neden görmüyor.</GovernmentAgent61.description>
   <!-- EN: government agent -->
   <GovernmentAgent61.title>hükümet ajanı</GovernmentAgent61.title>
   <GovernmentAgent61.titleFemale>hükümet ajanı</GovernmentAgent61.titleFemale>
@@ -982,7 +982,7 @@
   <GraphicDesigner33.titleShortFemale>tasarımcı</GraphicDesigner33.titleShortFemale>
   
   <!-- EN: After [PAWN_pronoun] learned what truly matters in life, [PAWN_nameDef] changed for the better. [PAWN_pronoun] learned to work hard and protect the things that matter - not money or material things, but friends and loved ones.\n\n[PAWN_pronoun] became a professional guardian. -->
-  <Guardian55.description>Hayatta gerçekten neyin önemli olduğunu öğrendikten sonra [PAWN_nameDef] iyiye doğru değişti. Çok çalışmayı ve önemli olan şeyleri korumayı öğrendi - para veya maddi şeyleri değil, arkadaşları ve sevdiklerini.\n\n Profesyonel bir gardiyan oldu.</Guardian55.description>
+  <Guardian55.description>Hayatta gerçekten neyin önemli olduğunu öğrendikten sonra [PAWN_nameDef] iyiye doğru değişti. Çok çalışmayı ve önemli olan şeyleri korumayı öğrendi - para veya maddi şeyleri değil, arkadaşları ve sevdiklerini.\n\nProfesyonel bir gardiyan oldu.</Guardian55.description>
   <!-- EN: guardian -->
   <Guardian55.title>gardiyan</Guardian55.title>
   <Guardian55.titleFemale>gardiyan</Guardian55.titleFemale>
@@ -991,7 +991,7 @@
   <Guardian55.titleShortFemale>gardiyan</Guardian55.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] traded high-tech firearms between warring factions.\n\nOver time, [PAWN_pronoun] became very skilled at conducting product demonstrations and negotiating profitable deals. -->
-  <GunDealer14.description>[PAWN_nameDef], savaşan gruplar arasında yüksek teknolojili ateşli silahların ticareti yaptı.\n\n Zamanla, ürün tanıtımları yapma ve karlı anlaşmalar müzakere etme konusunda çok yetenekli oldu.</GunDealer14.description>
+  <GunDealer14.description>[PAWN_nameDef], savaşan gruplar arasında yüksek teknolojili ateşli silahların ticareti yaptı.\n\nZamanla, ürün tanıtımları yapma ve karlı anlaşmalar müzakere etme konusunda çok yetenekli oldu.</GunDealer14.description>
   <!-- EN: gun dealer -->
   <GunDealer14.title>silah taciri</GunDealer14.title>
   <GunDealer14.titleFemale>silah taciri</GunDealer14.titleFemale>
@@ -1000,7 +1000,7 @@
   <GunDealer14.titleShortFemale>silah taciri</GunDealer14.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was a deadly shot. Peace wasn't for him. [PAWN_pronoun] found [PAWN_possessive] family among the brothers and sisters that [PAWN_pronoun] spent years fighting alongside.\n\nAfter most of those close to [PAWN_objective] died, [PAWN_pronoun] once again set off to lend [PAWN_possessive] gun to those who needed it - or those who could pay. -->
-  <Gunfighter51.description>[PAWN_nameDef] ölümcül bir silahsördü. Barış ona göre değildi. Ailesini, yıllarca yan yana savaştığı erkek ve kız kardeşlerin arasında buldu.\n\n Yakınlarının çoğu öldükten sonra, silahını ihtiyacı olanlara veya ödeyebilecek olanlara ödünç vermek için bir kez daha yola çıktı.</Gunfighter51.description>
+  <Gunfighter51.description>[PAWN_nameDef] ölümcül bir silahsördü. Barış ona göre değildi. Ailesini, yıllarca yan yana savaştığı erkek ve kız kardeşlerin arasında buldu.\n\nYakınlarının çoğu öldükten sonra, silahını ihtiyacı olanlara veya ödeyebilecek olanlara ödünç vermek için bir kez daha yola çıktı.</Gunfighter51.description>
   <!-- EN: gunfighter -->
   <Gunfighter51.title>silahşör</Gunfighter51.title>
   <Gunfighter51.titleFemale>silahşör</Gunfighter51.titleFemale>
@@ -1018,7 +1018,7 @@
   <Healer35.titleShortFemale>şifacı</Healer35.titleShortFemale>
   
   <!-- EN: A top hedge fund manager on a teeming urbworld, [PAWN_nameDef]'s portfolio grew rapidly as [PAWN_pronoun] charmed clients with a sweet voice and devious intent. When the deal turned out too good to be true, [PAWN_pronoun] was forced to flee the planet with a bounty on [PAWN_possessive] head.\n\nAs [PAWN_pronoun] traveled the stars [PAWN_pronoun] found a passion in the arts, making masterpieces fit for high society customers. -->
-  <HedgeFundManager54.description>Kalabalık bir urbworld'de üst düzey bir yatırım fonu yöneticisi olan [PAWN_nameDef]'nin portföyü, müşterileri tatlı bir ses ve sinsi bir niyetle cezbettikçe hızla büyüdü. Anlaşma gerçek olamayacak kadar iyi olduğunda, kafasında bir ödülle gezegeni terk etmeye zorlandı.\n\n Yıldızları gezerken, sanatta bir tutku buldu ve başyapıtlarını sosyeteden müşterilere uygun hale getirdi.</HedgeFundManager54.description>
+  <HedgeFundManager54.description>Kalabalık bir urbworld'de üst düzey bir yatırım fonu yöneticisi olan [PAWN_nameDef]'nin portföyü, müşterileri tatlı bir ses ve sinsi bir niyetle cezbettikçe hızla büyüdü. Anlaşma gerçek olamayacak kadar iyi olduğunda, kafasında bir ödülle gezegeni terk etmeye zorlandı.\n\nYıldızları gezerken, sanatta bir tutku buldu ve başyapıtlarını sosyeteden müşterilere uygun hale getirdi.</HedgeFundManager54.description>
   <!-- EN: hedge fund manager -->
   <HedgeFundManager54.title>yatırım fonu yöneticisi</HedgeFundManager54.title>
   <HedgeFundManager54.titleFemale>yatırım fonu yöneticisi</HedgeFundManager54.titleFemale>
@@ -1027,7 +1027,7 @@
   <HedgeFundManager54.titleShortFemale>banker</HedgeFundManager54.titleShortFemale>
   
   <!-- EN: After a terrible mining accident, [PAWN_nameDef] set off into space in search of exotic new animal species.\n\n[PAWN_pronoun] hoped to leave [PAWN_possessive] past behind and find long-lived companions. [PAWN_pronoun] knew the pain of loss too well. -->
-  <Herpetologist3.description>Korkunç bir maden kazasının ardından [PAWN_nameDef] egzotik yeni hayvan türleri aramak için uzaya doğru yola çıktı.\n\n Geçmişini geride bırakıp uzun ömürlü yol arkadaşları bulmayı umuyordu. Kaybetmenin acısını çok iyi biliyordu.</Herpetologist3.description>
+  <Herpetologist3.description>Korkunç bir maden kazasının ardından [PAWN_nameDef] egzotik yeni hayvan türleri aramak için uzaya doğru yola çıktı.\n\nGeçmişini geride bırakıp uzun ömürlü yol arkadaşları bulmayı umuyordu. Kaybetmenin acısını çok iyi biliyordu.</Herpetologist3.description>
   <!-- EN: herpetologist -->
   <Herpetologist3.title>herpetolog</Herpetologist3.title>
   <Herpetologist3.titleFemale>herpetolog</Herpetologist3.titleFemale>
@@ -1045,7 +1045,7 @@
   <HiredAssassin37.titleShortFemale>suikatçi</HiredAssassin37.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] always wanted to prove [PAWN_pronoun] could make a living without [PAWN_possessive] parents' help. [PAWN_pronoun] did shady jobs that often involved pointing guns at innocent people.\n\n[PAWN_pronoun] eventually made enough money to board a cheap freighter. [PAWN_pronoun] discovered why it was so cheap when it crashed. -->
-  <HiredGun70.description>[PAWN_nameDef] her zaman ailesinin yardımı olmadan geçimini sağlayabileceğini kanıtlamak istemiştir. Masum insanlara sık sık silah doğrultmayı içeren karanlık işler yaptı.\n\n Sonunda ucuz bir yük gemisine binecek kadar para kazandı. Neden bu kadar ucuz olduğunu kaza yapınca keşfetti.</HiredGun70.description>
+  <HiredGun70.description>[PAWN_nameDef] her zaman ailesinin yardımı olmadan geçimini sağlayabileceğini kanıtlamak istemiştir. Masum insanlara sık sık silah doğrultmayı içeren karanlık işler yaptı.\n\nSonunda ucuz bir yük gemisine binecek kadar para kazandı. Neden bu kadar ucuz olduğunu kaza yapınca keşfetti.</HiredGun70.description>
   <!-- EN: hired gun -->
   <HiredGun70.title>tetikçi</HiredGun70.title>
   <HiredGun70.titleFemale>tetikçi</HiredGun70.titleFemale>
@@ -1063,16 +1063,16 @@
   <HiredMuscle5.titleShortFemale>kabadayı</HiredMuscle5.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] stole children from their homes to sell them to interested buyers.\n\nOver time, [PAWN_pronoun] lost what little moral sense [PAWN_pronoun] had left. -->
-  <HumanTrafficker35.description>[PAWN_nameDef], ilgilenen alıcılara satmak için çocukları evlerinden kaçırdı.\n\n Zamanla, geride kalan ahlaki duygusunu da kaybetti.</HumanTrafficker35.description>
+  <HumanTrafficker35.description>[PAWN_nameDef], ilgilenen alıcılara satmak için çocukları evlerinden kaçırdı.\n\nZamanla, geride kalan ahlaki duygusunu da kaybetti.</HumanTrafficker35.description>
   <!-- EN: human trafficker -->
-  <HumanTrafficker35.title>insan kaçakçısı</HumanTrafficker35.title>
-  <HumanTrafficker35.titleFemale>insan kaçakçısı</HumanTrafficker35.titleFemale>
+  <HumanTrafficker35.title>İnsan kaçakçısı</HumanTrafficker35.title>
+  <HumanTrafficker35.titleFemale>İnsan kaçakçısı</HumanTrafficker35.titleFemale>
   <!-- EN: trafficker -->
   <HumanTrafficker35.titleShort>kaçakçı</HumanTrafficker35.titleShort>
   <HumanTrafficker35.titleShortFemale>kaçakçı</HumanTrafficker35.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was a master hunter.\n\n[PAWN_pronoun] learned to track and trap any animal in the most dangerous of places, and had deep knowledge of many ingenious methods for taking down specific large animals. -->
-  <Hunter73.description>[PAWN_nameDef] usta bir avcıydı.\n\n Herhangi bir hayvanı en tehlikeli yerlerde izlemeyi ve tuzağa düşürmeyi öğrendi ve belirli büyük hayvanları alt etmek için birçok ustaca yöntem hakkında derin bilgiye sahipti.</Hunter73.description>
+  <Hunter73.description>[PAWN_nameDef] usta bir avcıydı.\n\nHerhangi bir hayvanı en tehlikeli yerlerde izlemeyi ve tuzağa düşürmeyi öğrendi ve belirli büyük hayvanları alt etmek için birçok ustaca yöntem hakkında derin bilgiye sahipti.</Hunter73.description>
   <!-- EN: hunter -->
   <Hunter73.title>avcı</Hunter73.title>
   <Hunter73.titleFemale>avcı</Hunter73.titleFemale>
@@ -1081,7 +1081,7 @@
   <Hunter73.titleShortFemale>avcı</Hunter73.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was forced to protect [PAWN_possessive] colony in the name of the king after a mysterious outbreak of murderous genetically-modified wildlife.\n\nDespite [PAWN_possessive] best efforts, [PAWN_possessive] kingdom was destroyed. [PAWN_nameDef] developed PTSD, a hatred of animals and a bad case of technophobia. [PAWN_pronoun] was named for the place they found him. -->
-  <HunterOfTheKing53.description>[PAWN_nameDef], genetiği değiştirilmiş vahşi yaşamın gizemli bir şekilde ortaya çıkmasından sonra kolonisini kral adına korumak zorunda kaldı.\n\n En iyi çabalarına rağmen krallığı yok edildi. [PAWN_nameDef] hayvanlardan nefret eden ve kötü bir teknofobi vakası olan travma sonrası stres bozukluğuna yakalandı. Onu buldukları yere bıraktılar.</HunterOfTheKing53.description>
+  <HunterOfTheKing53.description>[PAWN_nameDef], genetiği değiştirilmiş vahşi yaşamın gizemli bir şekilde ortaya çıkmasından sonra kolonisini kral adına korumak zorunda kaldı.\n\nEn iyi çabalarına rağmen krallığı yok edildi. [PAWN_nameDef] hayvanlardan nefret eden ve kötü bir teknofobi vakası olan travma sonrası stres bozukluğuna yakalandı. Onu buldukları yere bıraktılar.</HunterOfTheKing53.description>
   <!-- EN: hunter of the king -->
   <HunterOfTheKing53.title>kralın avıcı</HunterOfTheKing53.title>
   <HunterOfTheKing53.titleFemale>kralın avıcı</HunterOfTheKing53.titleFemale>
@@ -1099,16 +1099,16 @@
   <HypnocultLeader61.titleShortFemale>tarikatçı</HypnocultLeader61.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef]'s thirst for power defined [PAWN_objective]. [PAWN_pronoun] quickly rose through the military ranks and soon attained the rank of general.\n\n[PAWN_pronoun] was given the most challenging task - conquering distant and unexplored rimworlds. Victory here could even position [PAWN_objective] as a successor to the emperor. -->
-  <ImperialGeneral27.description>[PAWN_nameDef]'in güce olan susuzluğu onu tanımlardı. Hızla askeri rütbeleri aştı ve kısa sürede general rütbesine ulaştı.\n\n Ona en zorlu görev verildi - uzak ve keşfedilmemiş çevre dünyalarını fethetmek. Buradaki zafer, onu imparatorun halefi olarak bile konumlandırabilirdi.</ImperialGeneral27.description>
+  <ImperialGeneral27.description>[PAWN_nameDef]'in güce olan susuzluğu onu tanımlardı. Hızla askeri rütbeleri aştı ve kısa sürede general rütbesine ulaştı.\n\nOna en zorlu görev verildi - uzak ve keşfedilmemiş çevre dünyalarını fethetmek. Buradaki zafer, onu imparatorun halefi olarak bile konumlandırabilirdi.</ImperialGeneral27.description>
   <!-- EN: imperial general -->
-  <ImperialGeneral27.title>imparatorluk generali</ImperialGeneral27.title>
-  <ImperialGeneral27.titleFemale>imparatorluk generali</ImperialGeneral27.titleFemale>
+  <ImperialGeneral27.title>İmparatorluk generali</ImperialGeneral27.title>
+  <ImperialGeneral27.titleFemale>İmparatorluk generali</ImperialGeneral27.titleFemale>
   <!-- EN: general -->
   <ImperialGeneral27.titleShort>general</ImperialGeneral27.titleShort>
   <ImperialGeneral27.titleShortFemale>general</ImperialGeneral27.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] caught a ship to the next star system and began a life of travel and learning, quickly collecting a massive bank of knowledge from people of all shapes and sizes.\n\n[PAWN_pronoun] learned to sell this knowledge for great profit, and became a powerful broker of information. -->
-  <InformationBroker77.description>[PAWN_nameDef] bir sonraki yıldız sistemine giden bir gemiye bindi.Her türdeki insandan hızla bilgi  toplayarak seyahat etme ve öğrenme fısrsatı yakaladı.\n\n Bu bilgiyi kar etmek için satmayı öğrendi ve güçlü bir bilgi simsarı oldu.</InformationBroker77.description>
+  <InformationBroker77.description>[PAWN_nameDef] bir sonraki yıldız sistemine giden bir gemiye bindi.Her türdeki insandan hızla bilgi  toplayarak seyahat etme ve öğrenme fısrsatı yakaladı.\n\nBu bilgiyi kar etmek için satmayı öğrendi ve güçlü bir bilgi simsarı oldu.</InformationBroker77.description>
   <!-- EN: information broker -->
   <InformationBroker77.title>bilgi simsarı</InformationBroker77.title>
   <InformationBroker77.titleFemale>bilgi simsarı</InformationBroker77.titleFemale>
@@ -1117,16 +1117,16 @@
   <InformationBroker77.titleShortFemale>simsar</InformationBroker77.titleShortFemale>
   
   <!-- EN: Because of [PAWN_possessive] hacking skills, [PAWN_nameDef] was recruited by [PAWN_possessive] home planet's governing body to serve as an intelligence agent. The government trained [PAWN_objective] in combat, but [PAWN_pronoun] prefers psychological warfare.\n\nGovernment rules proved too strict for [PAWN_objective], so [PAWN_pronoun] went rogue. [PAWN_possessive] current activities are unknown. -->
-  <IntelligenceAgent10.description>Bilgisayar korsanlığı becerileri nedeniyle [PAWN_nameDef], kendi gezegeninin yönetim organı tarafından bir istihbarat ajanı olarak görev yapmak üzere işe alındı. Hükümet onu muharebe konusunda eğitti, ama o psikolojik savaşı tercih ediyor.\n\n Hükümetin kurallarının onun için çok katı olduğu ortaya çıktı, bu yüzden haydut oldu. Şu anki faaliyetleri bilinmiyor.</IntelligenceAgent10.description>
+  <IntelligenceAgent10.description>Bilgisayar korsanlığı becerileri nedeniyle [PAWN_nameDef], kendi gezegeninin yönetim organı tarafından bir istihbarat ajanı olarak görev yapmak üzere işe alındı. Hükümet onu muharebe konusunda eğitti, ama o psikolojik savaşı tercih ediyor.\n\nHükümetin kurallarının onun için çok katı olduğu ortaya çıktı, bu yüzden haydut oldu. Şu anki faaliyetleri bilinmiyor.</IntelligenceAgent10.description>
   <!-- EN: intelligence agent -->
-  <IntelligenceAgent10.title>istihbarat ajanı</IntelligenceAgent10.title>
-  <IntelligenceAgent10.titleFemale>istihbarat ajanı</IntelligenceAgent10.titleFemale>
+  <IntelligenceAgent10.title>İstihbarat ajanı</IntelligenceAgent10.title>
+  <IntelligenceAgent10.titleFemale>İstihbarat ajanı</IntelligenceAgent10.titleFemale>
   <!-- EN: agent -->
   <IntelligenceAgent10.titleShort>ajan</IntelligenceAgent10.titleShort>
   <IntelligenceAgent10.titleShortFemale>ajan</IntelligenceAgent10.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was a professional assassin. [PAWN_pronoun] was sadistic, calculating, and appeared utterly harmless.\n\n[PAWN_pronoun] preferred using intimate means to dispatch [PAWN_possessive] targets. This fulfilled both [PAWN_possessive] contracts and [PAWN_possessive] own personal desire for control. -->
-  <IntimateAssassin35.description>[PAWN_nameDef] profesyonel bir suikastçıydı. Sadistti, hesapçıydı ve tamamen zararsız görünüyordu.\n\n Hedeflerini şaşırtmak için samimi yöntemler kullanmayı tercih etti. Bu, hem sözleşmelerini hem de kendi kişisel kontrol arzusunu yerine getirdi.</IntimateAssassin35.description>
+  <IntimateAssassin35.description>[PAWN_nameDef] profesyonel bir suikastçıydı. Sadistti, hesapçıydı ve tamamen zararsız görünüyordu.\n\nHedeflerini şaşırtmak için samimi yöntemler kullanmayı tercih etti. Bu, hem sözleşmelerini hem de kendi kişisel kontrol arzusunu yerine getirdi.</IntimateAssassin35.description>
   <!-- EN: intimate assassin -->
   <IntimateAssassin35.title>sıkı fıkı suikastçi</IntimateAssassin35.title>
   <IntimateAssassin35.titleFemale>sıkı fıkı suikastçi</IntimateAssassin35.titleFemale>
@@ -1153,7 +1153,7 @@
   <KingOfPirates25.titleShortFemale>korsan</KingOfPirates25.titleShortFemale>
   
   <!-- EN: After war broke out on [PAWN_possessive] homeworld, [PAWN_nameDef] was conscripted as a linguist. [PAWN_pronoun] spent [PAWN_possessive] days in a space station, decoding enemy communications and tending the hydroponic crops.\n\nAfter a meteorite damaged the station, [PAWN_pronoun] was forced to enter cryptosleep and hope for rescue. -->
-  <LanguageAnalyst27.description>Ana gezegeninde savaş patlak verdikten sonra, [PAWN_nameDef] bir dilbilimci olarak askere alındı. Günlerini bir uzay istasyonunda, düşman iletişiminin şifresini çözerek ve hidroponik ekinlerle ilgilenerek geçirdi.\n\n Bir göktaşı istasyona zarar verdikten sonra, kripto uykusuna girmek ve kurtarılmayı ummak zorunda kaldı.</LanguageAnalyst27.description>
+  <LanguageAnalyst27.description>Ana gezegeninde savaş patlak verdikten sonra, [PAWN_nameDef] bir dilbilimci olarak askere alındı. Günlerini bir uzay istasyonunda, düşman iletişiminin şifresini çözerek ve hidroponik ekinlerle ilgilenerek geçirdi.\n\nBir göktaşı istasyona zarar verdikten sonra, kripto uykusuna girmek ve kurtarılmayı ummak zorunda kaldı.</LanguageAnalyst27.description>
   <!-- EN: language analyst -->
   <LanguageAnalyst27.title>dil analisti</LanguageAnalyst27.title>
   <LanguageAnalyst27.titleFemale>dil analisti</LanguageAnalyst27.titleFemale>
@@ -1162,7 +1162,7 @@
   <LanguageAnalyst27.titleShortFemale>dilbilimci</LanguageAnalyst27.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] independently developed software that had a competitive edge against local urbworld corporations.\n\n[PAWN_possessive] legally questionable methods lead to a growing number in unsolved claims of intellectual property theft. -->
-  <LazyProgrammer3.description>[PAWN_nameDef] yerel urbworld şirketlerine karşı rekabet avantajı olan bağımsız yazılımcıydı.\n\n Yasal olarak sorgulanabilir yöntemlerin ve patent hırsızlığı iddialarının sayısının giderek artmasına neden oluyordu.</LazyProgrammer3.description>
+  <LazyProgrammer3.description>[PAWN_nameDef] yerel urbworld şirketlerine karşı rekabet avantajı olan bağımsız yazılımcıydı.\n\nYasal olarak sorgulanabilir yöntemlerin ve patent hırsızlığı iddialarının sayısının giderek artmasına neden oluyordu.</LazyProgrammer3.description>
   <!-- EN: lazy programmer -->
   <LazyProgrammer3.title>tembel programcı</LazyProgrammer3.title>
   <LazyProgrammer3.titleFemale>tembel programcı</LazyProgrammer3.titleFemale>
@@ -1171,7 +1171,7 @@
   <LazyProgrammer3.titleShortFemale>programcı</LazyProgrammer3.titleShortFemale>
   
   <!-- EN: After escaping [PAWN_possessive] homeworld on a jury-rigged ship, [PAWN_nameDef] traveled to new worlds to experience their beauty.\n\n[PAWN_pronoun] joined resistance groups and applied the skills [PAWN_pronoun] cultivated on [PAWN_possessive] homeworld. [PAWN_pronoun] often warned of the nuclear horror [PAWN_pronoun] saw as a child. -->
-  <LoneTraveler95.description>[PAWN_nameDef], jürili bir gemide kendi gezegeninden kaçtıktan sonra  diğer gezegenlerin güzelliğini deneyimlemek için yeni dünyalara gitti.\n\n Direniş gruplarına katıldı ve geliştirdiği becerileri kendi gezegeninde uyguladı. Çocukken gördüğü nükleer dehşet konusunda sık sık uyarıda bulundu.</LoneTraveler95.description>
+  <LoneTraveler95.description>[PAWN_nameDef], jürili bir gemide kendi gezegeninden kaçtıktan sonra  diğer gezegenlerin güzelliğini deneyimlemek için yeni dünyalara gitti.\n\nDireniş gruplarına katıldı ve geliştirdiği becerileri kendi gezegeninde uyguladı. Çocukken gördüğü nükleer dehşet konusunda sık sık uyarıda bulundu.</LoneTraveler95.description>
   <!-- EN: lone traveler -->
   <LoneTraveler95.title>yalnız gezgin</LoneTraveler95.title>
   <LoneTraveler95.titleFemale>yalnız gezgin</LoneTraveler95.titleFemale>
@@ -1180,7 +1180,7 @@
   <LoneTraveler95.titleShortFemale>gezgin</LoneTraveler95.titleShortFemale>
   
   <!-- EN: Shortly after being promoted to a respected position in [PAWN_possessive] planet's military, [PAWN_nameDef] disappeared without a trace.\n\nLater, [PAWN_pronoun] reappeared at the head of [PAWN_possessive] own military force. No one knows why [PAWN_pronoun] became who [PAWN_pronoun] was. -->
-  <LostMarine81.description>[PAWN_nameDef], gezegeninin ordusunda saygın bir konuma terfi ettikten kısa bir süre sonra iz bırakmadan ortadan kayboldu.\n\n Daha sonra, kendi askeri gücünün başında yeniden ortaya çıktı. Kimse neden bu hale geldiğini bilmiyor.</LostMarine81.description>
+  <LostMarine81.description>[PAWN_nameDef], gezegeninin ordusunda saygın bir konuma terfi ettikten kısa bir süre sonra iz bırakmadan ortadan kayboldu.\n\nDaha sonra, kendi askeri gücünün başında yeniden ortaya çıktı. Kimse neden bu hale geldiğini bilmiyor.</LostMarine81.description>
   <!-- EN: lost marine -->
   <LostMarine81.title>kayıp denizci</LostMarine81.title>
   <LostMarine81.titleFemale>vkayıp denizci</LostMarine81.titleFemale>
@@ -1189,7 +1189,7 @@
   <LostMarine81.titleShortFemale>hain</LostMarine81.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef]'s childhood soldier conditioning failed, and the experiment was shut down. [PAWN_pronoun] was abandoned, purposeless, friendless.\n\n[PAWN_nameDef] eventually found solace in physically demanding work. [PAWN_pronoun] especially liked building houses and crafting heavy armor. -->
-  <LostSoldier13.description>[PAWN_nameDef]'in çocukluktaki asker yoklaması başarısız oldu ve askere alınmadı. Terk edilmiş, amaçsız, arkadaşsızdı.\n\n [PAWN_nameDef] sonunda fiziksel olarak zorlayıcı işlerde teselli buldu. Özellikle evler inşa etmeyi ve ağır zırhlar yapmayı severdi.</LostSoldier13.description>
+  <LostSoldier13.description>[PAWN_nameDef]'in çocukluktaki asker yoklaması başarısız oldu ve askere alınmadı. Terk edilmiş, amaçsız, arkadaşsızdı.\n\n[PAWN_nameDef] sonunda fiziksel olarak zorlayıcı işlerde teselli buldu. Özellikle evler inşa etmeyi ve ağır zırhlar yapmayı severdi.</LostSoldier13.description>
   <!-- EN: lost soldier -->
   <LostSoldier13.title>kayıp asker</LostSoldier13.title>
   <LostSoldier13.titleFemale>kayıp asker</LostSoldier13.titleFemale>
@@ -1198,7 +1198,7 @@
   <LostSoldier13.titleShortFemale>kayıp</LostSoldier13.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was adept at dealing with mechanical problems, as long as the problem didn't involve the kitchen.\n\nAfter a life spent around dangerous machinery and flammable chemicals, [PAWN_pronoun] learned how to patch [PAWN_objective]self up pretty well. Despite the pain, [PAWN_pronoun] never learned to dislike fire. -->
-  <MachineFixer31.description>[PAWN_nameDef], mutfakla ilgili olmadığı sürece mekanik sorunlarla başa çıkmakta ustaydı.\n\n Tehlikeli makineler ve yanıcı kimyasallarla geçen bir yaşamdan sonra, kendini nasıl düzelteceğini oldukça iyi öğrendi. Acıya rağmen, ateşten hoşlanmamayı asla öğrenemedi.</MachineFixer31.description>
+  <MachineFixer31.description>[PAWN_nameDef], mutfakla ilgili olmadığı sürece mekanik sorunlarla başa çıkmakta ustaydı.\n\nTehlikeli makineler ve yanıcı kimyasallarla geçen bir yaşamdan sonra, kendini nasıl düzelteceğini oldukça iyi öğrendi. Acıya rağmen, ateşten hoşlanmamayı asla öğrenemedi.</MachineFixer31.description>
   <!-- EN: machine fixer -->
   <MachineFixer31.title>makine fiksatörü</MachineFixer31.title>
   <MachineFixer31.titleFemale>makine fiksatörü</MachineFixer31.titleFemale>
@@ -1207,7 +1207,7 @@
   <MachineFixer31.titleShortFemale>fiksatör</MachineFixer31.titleShortFemale>
   
   <!-- EN: As an accountant, [PAWN_nameDef] often socialized with colleagues, and made many friends in upper management.\n\nOne day, [PAWN_nameDef] discovered a corruption racket run by some of [PAWN_possessive] bosses. After reporting this, [PAWN_pronoun] was fired. Wishing to hunt down those responsible, [PAWN_pronoun] went on a mass murder spree. -->
-  <MadAccountant61.description>Bir muhasebeci olarak [PAWN_nameDef] sık sık iş arkadaşlarıyla sosyalleşir ve üst yönetimde birçok arkadaş edinir.\n\n Bir gün, patronlarından bazıları tarafından yürütülen bir yolsuzluğu keşfetti. Bunu bildirdikten sonra kovuldu. Sorumluların peşine düşmek için toplu katliamlar yaptı.</MadAccountant61.description>
+  <MadAccountant61.description>Bir muhasebeci olarak [PAWN_nameDef] sık sık iş arkadaşlarıyla sosyalleşir ve üst yönetimde birçok arkadaş edinir.\n\nBir gün, patronlarından bazıları tarafından yürütülen bir yolsuzluğu keşfetti. Bunu bildirdikten sonra kovuldu. Sorumluların peşine düşmek için toplu katliamlar yaptı.</MadAccountant61.description>
   <!-- EN: mad accountant -->
   <MadAccountant61.title>deli muhasebeci</MadAccountant61.title>
   <MadAccountant61.titleFemale>deli muhasebeci</MadAccountant61.titleFemale>
@@ -1216,7 +1216,7 @@
   <MadAccountant61.titleShortFemale>muhasebeci</MadAccountant61.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef]'s lust for knowledge was only matched by [PAWN_possessive] disdain for anyone who would stand in the way of [PAWN_possessive] research.\n\nTraveling from world to world, [PAWN_pronoun] sought answers to questions few dared to ask. -->
-  <MadScientist2.description>[PAWN_nameDef]'in bilgi hırsı,araştırmasının önünde duracak herkese karşı olan küçümsemesiyle eşleşiyordu. \n\n Dünyadan dünyaya seyahat ederek çok az kişinin sormaya cesaret edebildiği soruların yanıtlarını aradı.</MadScientist2.description>
+  <MadScientist2.description>[PAWN_nameDef]'in bilgi hırsı,araştırmasının önünde duracak herkese karşı olan küçümsemesiyle eşleşiyordu.\n\nDünyadan dünyaya seyahat ederek çok az kişinin sormaya cesaret edebildiği soruların yanıtlarını aradı.</MadScientist2.description>
   <!-- EN: mad scientist -->
   <MadScientist2.title>çılgın bilimci</MadScientist2.title>
   <MadScientist2.titleFemale>çılgın bilimci</MadScientist2.titleFemale>
@@ -1225,7 +1225,7 @@
   <MadScientist2.titleShortFemale>bilimadamı</MadScientist2.titleShortFemale>
   
   <!-- EN: Stripped of [PAWN_possessive] life's work and exiled after [PAWN_possessive] unethical experiments on the survivors of the Callos IX incident were published, [PAWN_nameDef] learned the skills necessary to survive in the outer rim.\n\nContinuing [PAWN_possessive] research with nothing left to lose, [PAWN_pronoun] made minions to carry out the tasks that bored him. -->
-  <MadScientist22.description>Hayatının emeğini elinden alan ve Callos IX olayından kurtulanlar üzerinde yaptığı etik olmayan deneyler yayınlandıktan sonra sürgüne gönderilen [PAWN_nameDef], dış çemberde hayatta kalmak için gerekli becerileri öğrendi.\n\n Kaybedecek hiçbir şeyi olmadan araştırmasına devam ederek, canını sıkan işleri yapmak için köleler yaptı.</MadScientist22.description>
+  <MadScientist22.description>Hayatının emeğini elinden alan ve Callos IX olayından kurtulanlar üzerinde yaptığı etik olmayan deneyler yayınlandıktan sonra sürgüne gönderilen [PAWN_nameDef], dış çemberde hayatta kalmak için gerekli becerileri öğrendi.\n\nKaybedecek hiçbir şeyi olmadan araştırmasına devam ederek, canını sıkan işleri yapmak için köleler yaptı.</MadScientist22.description>
   <!-- EN: mad scientist -->
   <MadScientist22.title>çılgın bilimci</MadScientist22.title>
   <MadScientist22.titleFemale>çılgın bilimci</MadScientist22.titleFemale>
@@ -1234,7 +1234,7 @@
   <MadScientist22.titleShortFemale>bilimadamı</MadScientist22.titleShortFemale>
   
   <!-- EN: After finishing [PAWN_possessive] education, [PAWN_nameDef] was hired by the planet's leading genetic researcher. Later, [PAWN_pronoun] was caught running illegal, inhumane experiments.\n\nDespite [PAWN_possessive] family's influence, [PAWN_pronoun] was convicted and sentenced to hard labor on a penal colony. -->
-  <MadScientist31.description>Eğitimini bitirdikten sonra, [PAWN_nameDef] gezegenin önde gelen genetik araştırmacısı tarafından işe alındı. Daha sonra yasadışı, insanlık dışı deneyler yaparken yakalandı.\n\n Ailesinin etkisine rağmen mahkum edildi ve bir ceza kolonisinde ağır çalışmaya mahkûm edildi.</MadScientist31.description>
+  <MadScientist31.description>Eğitimini bitirdikten sonra, [PAWN_nameDef] gezegenin önde gelen genetik araştırmacısı tarafından işe alındı. Daha sonra yasadışı, insanlık dışı deneyler yaparken yakalandı.\n\nAilesinin etkisine rağmen mahkum edildi ve bir ceza kolonisinde ağır çalışmaya mahkûm edildi.</MadScientist31.description>
   <!-- EN: mad scientist -->
   <MadScientist31.title>çılgın bilimci</MadScientist31.title>
   <MadScientist31.titleFemale>çılgın bilimci</MadScientist31.titleFemale>
@@ -1243,10 +1243,10 @@
   <MadScientist31.titleShortFemale>bilimadamı</MadScientist31.titleShortFemale>
   
   <!-- EN: On a bomb-blasted world, first aid is often the only aid.\n\n[PAWN_nameDef] used [PAWN_possessive] medical skills to help the injured and the sick. [PAWN_pronoun] believed that while guns and machines may be powerful, a doctor is even more so. -->
-  <MarbleDoctor99.description>Bombalanmış bir dünyada ilk yardım genellikle tek yardımdır.\n\n [PAWN_nameDef] tıbbi becerilerini yaralılara ve hastalara yardım etmek için kullandı. Silahlar ve makineler güçlü olsa da bir doktorun daha güçlü olduğuna inanıyordu.</MarbleDoctor99.description>
+  <MarbleDoctor99.description>Bombalanmış bir dünyada ilk yardım genellikle tek yardımdır.\n\n[PAWN_nameDef] tıbbi becerilerini yaralılara ve hastalara yardım etmek için kullandı. Silahlar ve makineler güçlü olsa da bir doktorun daha güçlü olduğuna inanıyordu.</MarbleDoctor99.description>
   <!-- EN: marble doctor -->
-  <MarbleDoctor99.title>ilkyardım doktoru</MarbleDoctor99.title>
-  <MarbleDoctor99.titleFemale>ilkyardım doktoru</MarbleDoctor99.titleFemale>
+  <MarbleDoctor99.title>İlkyardım doktoru</MarbleDoctor99.title>
+  <MarbleDoctor99.titleFemale>İlkyardım doktoru</MarbleDoctor99.titleFemale>
   <!-- EN: doctor -->
   <MarbleDoctor99.titleShort>doktor</MarbleDoctor99.titleShort>
   <MarbleDoctor99.titleShortFemale>doktor</MarbleDoctor99.titleShortFemale>
@@ -1270,7 +1270,7 @@
   <MasterTrader65.titleShortFemale>tüccar</MasterTrader65.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] loved solving problems and, with [PAWN_possessive] steady hands and a reputation for quality work, earned a job as a mechanical engineer. [PAWN_pronoun] built and redesigned devices of all shapes and sizes.\n\nEventually, [PAWN_pronoun] was able to pick and choose [PAWN_possessive] corporate clients. [PAWN_pronoun] made several wealthy friends, as well as a few powerful enemies. -->
-  <MechanicsEngineer64.description>[PAWN_nameDef] sorunları çözmeyi çok severdi ve istikrarlı elleri ve kaliteli işleriyle ilgili ün ile makine mühendisi olarak işe başladı. Her şekil ve boyutta cihazlar üretip yeniden tasarladı.\n\n Sonunda kurumsal rakipleri geçmeyi başardı. Birkaç güçlü düşmanın yanı sıra birkaç zengin arkadaş edindi.</MechanicsEngineer64.description>
+  <MechanicsEngineer64.description>[PAWN_nameDef] sorunları çözmeyi çok severdi ve istikrarlı elleri ve kaliteli işleriyle ilgili ün ile makine mühendisi olarak işe başladı. Her şekil ve boyutta cihazlar üretip yeniden tasarladı.\n\nSonunda kurumsal rakipleri geçmeyi başardı. Birkaç güçlü düşmanın yanı sıra birkaç zengin arkadaş edindi.</MechanicsEngineer64.description>
   <!-- EN: mechanics engineer -->
   <MechanicsEngineer64.title>Mekanik mühendis</MechanicsEngineer64.title>
   <MechanicsEngineer64.titleFemale>Mekanik mühendis</MechanicsEngineer64.titleFemale>
@@ -1297,7 +1297,7 @@
   <MedicalScientist16.titleShortFemale>bilimadamı</MedicalScientist16.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] enrolled in [PAWN_possessive] planetary army as a frontline medic. [PAWN_pronoun] soon knew the horrors of war and was deeply marked by them.\n\n[PAWN_pronoun] left the military and [PAWN_possessive] homeworld and began researching medicine and helping those [PAWN_pronoun] came across. -->
-  <MedicSoldier54.description>[PAWN_nameDef] gezegen ordusuna cephede bir sağlık görevlisi olarak kaydoldu. Kısa süre sonra savaşın dehşetini anladı ve derinden etkilendi.\n\n Orduyu ve anavatanını terk etti. Tıp araştırmalarına ve karşılaştığı insanlara yardım etmeye başladı.</MedicSoldier54.description>
+  <MedicSoldier54.description>[PAWN_nameDef] gezegen ordusuna cephede bir sağlık görevlisi olarak kaydoldu. Kısa süre sonra savaşın dehşetini anladı ve derinden etkilendi.\n\nOrduyu ve anavatanını terk etti. Tıp araştırmalarına ve karşılaştığı insanlara yardım etmeye başladı.</MedicSoldier54.description>
   <!-- EN: medic soldier -->
   <MedicSoldier54.title>sıhhıye askeri</MedicSoldier54.title>
   <MedicSoldier54.titleFemale>sıhhıye askeri</MedicSoldier54.titleFemale>
@@ -1315,7 +1315,7 @@
   <MedievalKnight26.titleShortFemale>şovalye</MedievalKnight26.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was placed in a psychiatric hospital. There, [PAWN_pronoun] spent [PAWN_possessive] time engaged in the calming activities of the asylum.\n\n[PAWN_pronoun] was eventually released, but [PAWN_pronoun] retained [PAWN_possessive] emotional distance, [PAWN_possessive] curiosity about human anatomy, and [PAWN_possessive] namesake manic giggling. -->
-  <MentalPatient69.description>[PAWN_nameDef] bir psikiyatri hastanesine yerleştirildi. Orada zamanını akıl hastanesinin sakinleştirici faaliyetleriyle geçirdi.\n\n Sonunda serbest bırakıldı ancak sosyal yetersizliği ve insanlara olan merakı yüzünden kikirdeme huyunu korudu.</MentalPatient69.description>
+  <MentalPatient69.description>[PAWN_nameDef] bir psikiyatri hastanesine yerleştirildi. Orada zamanını akıl hastanesinin sakinleştirici faaliyetleriyle geçirdi.\n\nSonunda serbest bırakıldı ancak sosyal yetersizliği ve insanlara olan merakı yüzünden kikirdeme huyunu korudu.</MentalPatient69.description>
   <!-- EN: mental patient -->
   <MentalPatient69.title>akıl hastası</MentalPatient69.title>
   <MentalPatient69.titleFemale>akıl hastası</MentalPatient69.titleFemale>
@@ -1324,7 +1324,7 @@
   <MentalPatient69.titleShortFemale>deli</MentalPatient69.titleShortFemale>
   
   <!-- EN: After escaping [PAWN_possessive] home planet, [PAWN_nameDef] fell in with a band of mercenaries. [PAWN_pronoun] fought alongside [PAWN_possessive] brothers and sisters in arms for many years.\n\nOne day, they were caught in a fight they couldn't win. Refusing to retreat, [PAWN_nameDef] was shot down by [PAWN_possessive] enemies. [PAWN_pronoun] was alarmed to awake in a heap of corpses, mysteriously unharmed. -->
-  <Mercenary20.description>[PAWN_nameDef], kendi gezegeninden kaçtıktan sonra bir grup paralı askerle anlaşmaya vardı. Uzun yıllar silah arkadaşlarının yanında savaştı.\n\n Bir gün kazanamayacakları bir savaşa girdiler. Geri çekilmeyi reddeden [PAWN_nameDef] düşmanları tarafından vuruldu. Gizemli bir şekilde zarar görmemiş halde bir ceset yığınının içinde uyandı.</Mercenary20.description>
+  <Mercenary20.description>[PAWN_nameDef], kendi gezegeninden kaçtıktan sonra bir grup paralı askerle anlaşmaya vardı. Uzun yıllar silah arkadaşlarının yanında savaştı.\n\nBir gün kazanamayacakları bir savaşa girdiler. Geri çekilmeyi reddeden [PAWN_nameDef] düşmanları tarafından vuruldu. Gizemli bir şekilde zarar görmemiş halde bir ceset yığınının içinde uyandı.</Mercenary20.description>
   <!-- EN: mercenary -->
   <Mercenary20.title>paralı asker</Mercenary20.title>
   <Mercenary20.titleFemale>paralı asker</Mercenary20.titleFemale>
@@ -1351,7 +1351,7 @@
   <Mercenary55.titleShortFemale>paralı asker</Mercenary55.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was in the crew of a mercenary ship. Disciplined and confident, [PAWN_pronoun] quickly rose through the ranks and gained friends.\n\nIn [PAWN_possessive] time as a mercenary captain, [PAWN_pronoun] was known for being gregarious and calm - possibly thanks to the joywires. -->
-  <MercenaryCaptain98.description>[PAWN_nameDef] bir paralı asker gemisinin mürettebatındaydı. Disiplinli ve kendinden emin birisiydi, hızla yükseldi ve arkadaşlar edindi.\n\n Paralı bir yüzbaşı olarak zamanında, girişken ve sakin biri olarak biliniyordu. - muhtemelen joywires sayesinde.</MercenaryCaptain98.description>
+  <MercenaryCaptain98.description>[PAWN_nameDef] bir paralı asker gemisinin mürettebatındaydı. Disiplinli ve kendinden emin birisiydi, hızla yükseldi ve arkadaşlar edindi.\n\nParalı bir yüzbaşı olarak zamanında, girişken ve sakin biri olarak biliniyordu. - muhtemelen joywires sayesinde.</MercenaryCaptain98.description>
   <!-- EN: mercenary captain -->
   <MercenaryCaptain98.title>paralı asker kaptanı</MercenaryCaptain98.title>
   <MercenaryCaptain98.titleFemale>paralı asker kaptanı</MercenaryCaptain98.titleFemale>
@@ -1360,7 +1360,7 @@
   <MercenaryCaptain98.titleShortFemale>kaptan</MercenaryCaptain98.titleShortFemale>
   
   <!-- EN: Following in [PAWN_possessive] family's footsteps, [PAWN_nameDef] was a soldier for hire.\n\n[PAWN_pronoun] was a naturally gifted sharpshooter. However, [PAWN_possessive] real passion is in perfecting a new recipe or dissecting a new gadget. -->
-  <MercenaryChef44.description>Ailesinin ayak izlerini takip eden [PAWN_nameDef], kiralık bir askerdi.\n\n Doğuştan yetenekli bir keskin nişancıydı. Ancak asıl tutkusu, yeni bir tarifi mükemmelleştirmek veya yeni bir aygıtı parçalara ayırmaktır.</MercenaryChef44.description>
+  <MercenaryChef44.description>Ailesinin ayak izlerini takip eden [PAWN_nameDef], kiralık bir askerdi.\n\nDoğuştan yetenekli bir keskin nişancıydı. Ancak asıl tutkusu, yeni bir tarifi mükemmelleştirmek veya yeni bir aygıtı parçalara ayırmaktır.</MercenaryChef44.description>
   <!-- EN: mercenary chef -->
   <MercenaryChef44.title>paralı asker şefi</MercenaryChef44.title>
   <MercenaryChef44.titleFemale>paralı asker şefi</MercenaryChef44.titleFemale>
@@ -1369,7 +1369,7 @@
   <MercenaryChef44.titleShortFemale>paralı asker</MercenaryChef44.titleShortFemale>
   
   <!-- EN: Alone, [PAWN_nameDef] set out to rebuild [PAWN_possessive] father's life's work. [PAWN_pronoun] challenged the leader of a small band of mercenaries and took control, then led the band as they hijacked trade ships and stole valuable cargo.\n\n[PAWN_possessive] men mutinied. [PAWN_pronoun] was abandoned, arrested, and sentenced to death. -->
-  <MercenaryLeader28.description>[PAWN_nameDef] tek başına babasının yolundan hayatını yeniden inşa etmeye başladı. Küçük bir paralı asker çetesinin liderine meydan okudu ve kontrolü ele geçirdi, ardından ticaret gemilerini ve değerli kargoları çalan çeteye önderlik etti.\n\n Adamları isyan etti. Terk edildi, tutuklandı ve ölüme mahkum edildi.</MercenaryLeader28.description>
+  <MercenaryLeader28.description>[PAWN_nameDef] tek başına babasının yolundan hayatını yeniden inşa etmeye başladı. Küçük bir paralı asker çetesinin liderine meydan okudu ve kontrolü ele geçirdi, ardından ticaret gemilerini ve değerli kargoları çalan çeteye önderlik etti.\n\nAdamları isyan etti. Terk edildi, tutuklandı ve ölüme mahkum edildi.</MercenaryLeader28.description>
   <!-- EN: mercenary leader -->
   <MercenaryLeader28.title>paralı asker lideri</MercenaryLeader28.title>
   <MercenaryLeader28.titleFemale>paralı asker lideri</MercenaryLeader28.titleFemale>
@@ -1378,7 +1378,7 @@
   <MercenaryLeader28.titleShortFemale>paralı asker</MercenaryLeader28.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] formed a mercenary company out of freelancers who wanted to make good money while also making slightly better-than-average moral choices. [PAWN_pronoun] called it the Ashmarines.\n\nTo avoid the coreworlds' military forces, [PAWN_pronoun] moved [PAWN_possessive] company to the rimworlds. There, [PAWN_pronoun] established bases and communities. In ruling, [PAWN_pronoun] maintained a form of order among the raiders and madmen of deep space. -->
-  <MercenaryLord13.description>[PAWN_nameDef], iyi para kazanmak ve aynı zamanda ortalamadan biraz daha iyi ahlaki seçimler yapmak isteyen serbest çalışanlardan paralı bir şirket kurdu. Ona Ashmarines adını verdi.\n\n Çekirdek dünyaların askeri güçlerinden kaçınmak için şirketini rimworlds'e taşıdı. Orada üsler ve topluluklar kurdu. Hükümdar olurken, derin uzayın akıncıları ve delileri arasında bir tür düzen sağladı.</MercenaryLord13.description>
+  <MercenaryLord13.description>[PAWN_nameDef], iyi para kazanmak ve aynı zamanda ortalamadan biraz daha iyi ahlaki seçimler yapmak isteyen serbest çalışanlardan paralı bir şirket kurdu. Ona Ashmarines adını verdi.\n\nÇekirdek dünyaların askeri güçlerinden kaçınmak için şirketini rimworlds'e taşıdı. Orada üsler ve topluluklar kurdu. Hükümdar olurken, derin uzayın akıncıları ve delileri arasında bir tür düzen sağladı.</MercenaryLord13.description>
   <!-- EN: mercenary lord -->
   <MercenaryLord13.title>paralı asker lordu</MercenaryLord13.title>
   <MercenaryLord13.titleFemale>paralı asker lordu</MercenaryLord13.titleFemale>
@@ -1387,7 +1387,7 @@
   <MercenaryLord13.titleShortFemale>paralı asker lordu</MercenaryLord13.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] convinced [PAWN_possessive] squadron to abscond with their ships and make a course for the rimworlds. There they could fight for the causes they believed in.\n\n[PAWN_possessive] men were loyal and fought hard, but their ideals soon faded away and their cause became that of the highest bidder. -->
-  <MercenaryPilot63.description>[PAWN_nameDef] filosunu gemileriyle birlikte kaçmaya ve çevre dünyalarına doğru bir rota çizmeye ikna etti. Orada inandıkları davalar için savaşabilirlerdi.\n\n Adamları sadıktı ve çok savaştı, ancak idealleri kısa sürede yok oldu ve davaları en yüksek fiyatı verenin davası oldu.</MercenaryPilot63.description>
+  <MercenaryPilot63.description>[PAWN_nameDef] filosunu gemileriyle birlikte kaçmaya ve çevre dünyalarına doğru bir rota çizmeye ikna etti. Orada inandıkları davalar için savaşabilirlerdi.\n\nAdamları sadıktı ve çok savaştı, ancak idealleri kısa sürede yok oldu ve davaları en yüksek fiyatı verenin davası oldu.</MercenaryPilot63.description>
   <!-- EN: mercenary pilot -->
   <MercenaryPilot63.title>paralı asker pilotu</MercenaryPilot63.title>
   <MercenaryPilot63.titleFemale>paralı asker pilotu</MercenaryPilot63.titleFemale>
@@ -1396,7 +1396,7 @@
   <MercenaryPilot63.titleShortFemale>paralı pilot</MercenaryPilot63.titleShortFemale>
   
   <!-- EN: A plague struck [PAWN_nameDef]'s native urbworld. [PAWN_nameDef] and other researchers revealed that the illness was a bioweapon, but the people turned on them, blaming them for the sickness.\n\n[PAWN_nameDef] barely escaped [PAWN_possessive] homeworld as it fell into chaos. -->
-  <Microbiologist12.description>[PAWN_nameDef]'in yerel urbworld'unu bir veba vurdu. [PAWN_nameDef] ve diğer araştırmacılar, hastalığın bir biyolojik silah olduğunu ortaya çıkardı, ancak insanlar hastalık için onları suçladılar.\n\n [PAWN_nameDef], kaosa düşen anavatanından zar zor kaçtı.</Microbiologist12.description>
+  <Microbiologist12.description>[PAWN_nameDef]'in yerel urbworld'unu bir veba vurdu. [PAWN_nameDef] ve diğer araştırmacılar, hastalığın bir biyolojik silah olduğunu ortaya çıkardı, ancak insanlar hastalık için onları suçladılar.\n\n[PAWN_nameDef], kaosa düşen anavatanından zar zor kaçtı.</Microbiologist12.description>
   <!-- EN: microbiologist -->
   <Microbiologist12.title>mikrobiyolog</Microbiologist12.title>
   <Microbiologist12.titleFemale>mikrobiyolog</Microbiologist12.titleFemale>
@@ -1405,7 +1405,7 @@
   <Microbiologist12.titleShortFemale>biyolog</Microbiologist12.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] joined [PAWN_possessive] country's Royal Navy. After years as a non-commissioned officer, [PAWN_pronoun] eventually cracked and used the skills [PAWN_pronoun] had acquired to start a mutiny on [PAWN_possessive] ship.\n\nIn the end, [PAWN_nameDef] was the leader of a large group of trained and dangerous pirates. [PAWN_pronoun] henceforth always had chefs to cook for him. -->
-  <MidworldSailor91.description>[PAWN_nameDef] ülkesinin Kraliyet Donanmasına katıldı. Yıllarca astsubay olarak çalıştıktan sonra, sonunda çatladı ve kazandığı becerileri gemisinde bir isyan başlatmak için kullandı. \n\n Sonuç olarak [PAWN_nameDef], eğitimli ve tehlikeli korsanlardan oluşan büyük bir grubun lideriydi. Bundan böyle onun için her zaman yemek pişirecek şefleri oldu.</MidworldSailor91.description>
+  <MidworldSailor91.description>[PAWN_nameDef] ülkesinin Kraliyet Donanmasına katıldı. Yıllarca astsubay olarak çalıştıktan sonra, sonunda çatladı ve kazandığı becerileri gemisinde bir isyan başlatmak için kullandı.\n\nSonuç olarak [PAWN_nameDef], eğitimli ve tehlikeli korsanlardan oluşan büyük bir grubun lideriydi. Bundan böyle onun için her zaman yemek pişirecek şefleri oldu.</MidworldSailor91.description>
   <!-- EN: midworld sailor -->
   <MidworldSailor91.title>ortadünya bahriyeli</MidworldSailor91.title>
   <MidworldSailor91.titleFemale>ortadünya bahriyeli</MidworldSailor91.titleFemale>
@@ -1414,7 +1414,7 @@
   <MidworldSailor91.titleShortFemale>bahriyeli</MidworldSailor91.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] worked as an engineer for a colonial military. [PAWN_pronoun] got to play with weapons, murder-drones, and other 'fun' stuff.\n\n[PAWN_pronoun] specialized in repairing and modifying mechanoids' tools. Sometimes [PAWN_pronoun] tested them [PAWN_objective]self. -->
-  <MilitaryEngineer45.description>[PAWN_nameDef] bir sömürge ordusunda mühendis olarak çalıştı. Silahlarla, cinayet dronlarıyla ve diğer 'eğlenceli' şeylerle ilgilenmesi gerekiyordu. \n\nMekanoid aletlerini tamir etme ve değiştirme konusunda uzmandı. Bazen onları kendisi test etti.</MilitaryEngineer45.description>
+  <MilitaryEngineer45.description>[PAWN_nameDef] bir sömürge ordusunda mühendis olarak çalıştı. Silahlarla, cinayet dronlarıyla ve diğer 'eğlenceli' şeylerle ilgilenmesi gerekiyordu.\n\nMekanoid aletlerini tamir etme ve değiştirme konusunda uzmandı. Bazen onları kendisi test etti.</MilitaryEngineer45.description>
   <!-- EN: military engineer -->
   <MilitaryEngineer45.title>askeri mühendis</MilitaryEngineer45.title>
   <MilitaryEngineer45.titleFemale>askeri mühendis</MilitaryEngineer45.titleFemale>
@@ -1423,7 +1423,7 @@
   <MilitaryEngineer45.titleShortFemale>mühendis</MilitaryEngineer45.titleShortFemale>
   
   <!-- EN: When [PAWN_possessive] world was thrown into conflict, [PAWN_nameDef] was conscripted along with many of [PAWN_possessive] peers into the war machine that tore across the planet.\n\nWith [PAWN_possessive] particular expertise, [PAWN_pronoun] was lucky enough to find a position serving as small arms mechanic rather than on the front line. -->
-  <MilitaryGunsmith27.description>Dünyası çatışmaya girdiğinde [PAWN_nameDef] akranlarının çoğuyla birlikte gezegenin ordusuna alındı. \n\nÖzel uzmanlığıyla, ön saflardan ziyade hafif silah tamircisi olarak hizmet veren bir pozisyon bulabilecek kadar şanslıydı.</MilitaryGunsmith27.description>
+  <MilitaryGunsmith27.description>Dünyası çatışmaya girdiğinde [PAWN_nameDef] akranlarının çoğuyla birlikte gezegenin ordusuna alındı.\n\nÖzel uzmanlığıyla, ön saflardan ziyade hafif silah tamircisi olarak hizmet veren bir pozisyon bulabilecek kadar şanslıydı.</MilitaryGunsmith27.description>
   <!-- EN: military gunsmith -->
   <MilitaryGunsmith27.title>askeri silahçı</MilitaryGunsmith27.title>
   <MilitaryGunsmith27.titleFemale>askeri silahçı</MilitaryGunsmith27.titleFemale>
@@ -1432,7 +1432,7 @@
   <MilitaryGunsmith27.titleShortFemale>silahçı</MilitaryGunsmith27.titleShortFemale>
   
   <!-- EN: Jackson, in a final act of rebellion, left [PAWN_possessive] father's lab and joined the local Imperial military.\n\n[PAWN_pronoun] used [PAWN_possessive] laboratory skills to design machines of war. At this [PAWN_pronoun] was one of the best on [PAWN_possessive] planet. -->
-  <MilitaryInventor35.description>[PAWN_nameDef] bir isyanla babasının laboratuvarından kaçtı ve yerel imparatorluk ordusuna katıldı. \n\nLaboratuvar becerilerini savaş makineleri tasarlamak için kullandı. Bu konuda gezegendeki en iyilerden biriydi.</MilitaryInventor35.description>
+  <MilitaryInventor35.description>[PAWN_nameDef] bir isyanla babasının laboratuvarından kaçtı ve yerel imparatorluk ordusuna katıldı.\n\nLaboratuvar becerilerini savaş makineleri tasarlamak için kullandı. Bu konuda gezegendeki en iyilerden biriydi.</MilitaryInventor35.description>
   <!-- EN: military inventor -->
   <MilitaryInventor35.title>askeri mucit</MilitaryInventor35.title>
   <MilitaryInventor35.titleFemale>askeri mucit</MilitaryInventor35.titleFemale>
@@ -1441,7 +1441,7 @@
   <MilitaryInventor35.titleShortFemale>mucit</MilitaryInventor35.titleShortFemale>
   
   <!-- EN: Obsessed with interstellar travel, [PAWN_nameDef] left [PAWN_possessive] desolate life behind to join a military academy in hopes of becoming a pilot.\n\n[PAWN_pronoun] was trained in advanced combat and survival skills. While [PAWN_pronoun] excelled in [PAWN_possessive] studies, [PAWN_nameDef] was a loner and never cared about [PAWN_possessive] crewmates. -->
-  <MilitaryOfficer17.description>Yıldızlararası seyahate takıntılı olan [PAWN_nameDef], pilot olma umuduyla bir askeri akademiye katılmak için ıssız hayatını geride bıraktı. \n\nİleri dövüş ve hayatta kalma becerileri konusunda eğitim aldı. [PAWN_nameDef] derslerinde başarılı olsa da yalnızdı ve ekip arkadaşlarını asla umursamadı.</MilitaryOfficer17.description>
+  <MilitaryOfficer17.description>Yıldızlararası seyahate takıntılı olan [PAWN_nameDef], pilot olma umuduyla bir askeri akademiye katılmak için ıssız hayatını geride bıraktı.\n\nİleri dövüş ve hayatta kalma becerileri konusunda eğitim aldı. [PAWN_nameDef] derslerinde başarılı olsa da yalnızdı ve ekip arkadaşlarını asla umursamadı.</MilitaryOfficer17.description>
   <!-- EN: military officer -->
   <MilitaryOfficer17.title>askeri subay</MilitaryOfficer17.title>
   <MilitaryOfficer17.titleFemale>askeri subay</MilitaryOfficer17.titleFemale>
@@ -1450,7 +1450,7 @@
   <MilitaryOfficer17.titleShortFemale>subay</MilitaryOfficer17.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] joined the militia forces and fought for rights and peace.\n\nAfter [PAWN_possessive] homeworld was unexpectedly destroyed in the wars, [PAWN_pronoun] traveled great distances, seeking a refuge where [PAWN_pronoun] could build a new, free way of life. -->
-  <MilitiaSoldier79.description>[PAWN_nameDef] milis kuvvetlerine katıldı ve haklar ve barış için savaştı. \n\nAnavatanı savaşlarda beklenmedik bir şekilde yok edildikten sonra, yeni ve özgür bir yaşam tarzı inşa edebileceği bir sığınak arayarak uzun mesafeler kat etti.</MilitiaSoldier79.description>
+  <MilitiaSoldier79.description>[PAWN_nameDef] milis kuvvetlerine katıldı ve haklar ve barış için savaştı.\n\nAnavatanı savaşlarda beklenmedik bir şekilde yok edildikten sonra, yeni ve özgür bir yaşam tarzı inşa edebileceği bir sığınak arayarak uzun mesafeler kat etti.</MilitiaSoldier79.description>
   <!-- EN: militia soldier -->
   <MilitiaSoldier79.title>milis askeri</MilitiaSoldier79.title>
   <MilitiaSoldier79.titleFemale>milis askeri</MilitiaSoldier79.titleFemale>
@@ -1459,7 +1459,7 @@
   <MilitiaSoldier79.titleShortFemale>asker</MilitiaSoldier79.titleShortFemale>
   
   <!-- EN: The corporation took and remade [PAWN_nameDef]. They trained [PAWN_objective] into an tool of destruction and subversion. [PAWN_pronoun] took to [PAWN_possessive] new life, finding satisfaction in the jobs they sent [PAWN_objective] on.\n\nWhen [PAWN_pronoun] learned that they planned on disposing of [PAWN_objective], [PAWN_nameDef] turned on [PAWN_possessive] masters, killing several and fleeing the planet. -->
-  <MindwipedAssassin50.description>Şirket [PAWN_nameDef]'i alıp hafızasını silip yeniden yaptılar. Onu bir yıkım ve ölüm aracı olarak eğittiler. Yeni hayatına atıldı ve onu gönderdikleri işlerde tatmin buldu. \n\nOnu ortadan kaldırmayı planladıklarını öğrendiğinde, [PAWN_nameDef] efendilerine saldırdı, birkaçını öldürdü ve gezegenden kaçtı.</MindwipedAssassin50.description>
+  <MindwipedAssassin50.description>Şirket [PAWN_nameDef]'i alıp hafızasını silip yeniden yaptılar. Onu bir yıkım ve ölüm aracı olarak eğittiler. Yeni hayatına atıldı ve onu gönderdikleri işlerde tatmin buldu.\n\nOnu ortadan kaldırmayı planladıklarını öğrendiğinde, [PAWN_nameDef] efendilerine saldırdı, birkaçını öldürdü ve gezegenden kaçtı.</MindwipedAssassin50.description>
   <!-- EN: mindwiped assassin -->
   <MindwipedAssassin50.title>hafızası silinen suikastçi</MindwipedAssassin50.title>
   <MindwipedAssassin50.titleFemale>hafızası silinen suikastçi</MindwipedAssassin50.titleFemale>
@@ -1504,16 +1504,16 @@
   <MuffaloResearcher67.titleShortFemale>araştırmacı</MuffaloResearcher67.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was taken to the stars by slavers after [PAWN_possessive] tribe was decimated in a raid. Over the years [PAWN_pronoun] learned the language of [PAWN_possessive] captors, eventually working for them as an interpreter and diplomat.\n\nThe captain only learned of [PAWN_nameDef]'s true cunning when revenge was taken by form of mutiny. -->
-  <MutinousCaptain52.description>[PAWN_nameDef], kabilesi bir baskınla yok edildikten sonra köle tacirleri tarafından yıldızlara götürüldü. Yıllar içinde kendisini kaçıranların dilini öğrendi ve sonunda onlar için tercüman ve diplomat olarak çalıştı.\n\n Kaptan, [PAWN_nameDef]'in gerçek kurnazlığını ancak isyan yoluyla intikam aldığında öğrendi.</MutinousCaptain52.description>
+  <MutinousCaptain52.description>[PAWN_nameDef], kabilesi bir baskınla yok edildikten sonra köle tacirleri tarafından yıldızlara götürüldü. Yıllar içinde kendisini kaçıranların dilini öğrendi ve sonunda onlar için tercüman ve diplomat olarak çalıştı.\n\nKaptan, [PAWN_nameDef]'in gerçek kurnazlığını ancak isyan yoluyla intikam aldığında öğrendi.</MutinousCaptain52.description>
   <!-- EN: mutinous captain -->
-  <MutinousCaptain52.title>isyankar kaptan</MutinousCaptain52.title>
-  <MutinousCaptain52.titleFemale>isyankar kaptan</MutinousCaptain52.titleFemale>
+  <MutinousCaptain52.title>İsyankar kaptan</MutinousCaptain52.title>
+  <MutinousCaptain52.titleFemale>İsyankar kaptan</MutinousCaptain52.titleFemale>
   <!-- EN: captain -->
   <MutinousCaptain52.titleShort>kaptan</MutinousCaptain52.titleShort>
   <MutinousCaptain52.titleShortFemale>kaptan</MutinousCaptain52.titleShortFemale>
   
   <!-- EN: After repairing a fleet admiral's holoscreen with nothing but a pair of rusty pliers and scrap wire, [PAWN_nameDef] was invited to the Federation Naval Academy.\n\n[PAWN_pronoun] received an excellent technical education and extensive firearms training, but had no interest in studying more menial skills. -->
-  <NavyTechOfficer0.description>[PAWN_nameDef], bir çift paslı pense ve hurda telden başka bir şey olmayan bir filo amiralinin sanal ekranını tamir ettikten sonra, Federasyon Deniz Harp Okulu'na davet edildi.\n\n Mükemmel bir teknik eğitim ve kapsamlı bir ateşli silah eğitimi aldı, ancak daha fazla beceri üzerinde çalışmakla ilgilenmedi.</NavyTechOfficer0.description>
+  <NavyTechOfficer0.description>[PAWN_nameDef], bir çift paslı pense ve hurda telden başka bir şey olmayan bir filo amiralinin sanal ekranını tamir ettikten sonra, Federasyon Deniz Harp Okulu'na davet edildi.\n\nMükemmel bir teknik eğitim ve kapsamlı bir ateşli silah eğitimi aldı, ancak daha fazla beceri üzerinde çalışmakla ilgilenmedi.</NavyTechOfficer0.description>
   <!-- EN: navy tech officer -->
   <NavyTechOfficer0.title>donanma teknik subayı</NavyTechOfficer0.title>
   <NavyTechOfficer0.titleFemale>donanma teknik subayı</NavyTechOfficer0.titleFemale>
@@ -1522,7 +1522,7 @@
   <NavyTechOfficer0.titleShortFemale>donanma teknikeri</NavyTechOfficer0.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] spent all [PAWN_possessive] time working on computer networking systems.\n\n[PAWN_pronoun] lived without a care in the world - other than uptime and dropped packets. -->
-  <NetworkEngineer34.description>[PAWN_nameDef] tüm zamanını bilgisayar ağ sistemleri üzerinde çalışarak geçirdi.\n\n Dünyada bir şeyleri umursamadan yaşadı - çalışmak ve giren droplar dışında.</NetworkEngineer34.description>
+  <NetworkEngineer34.description>[PAWN_nameDef] tüm zamanını bilgisayar ağ sistemleri üzerinde çalışarak geçirdi.\n\nDünyada bir şeyleri umursamadan yaşadı - çalışmak ve giren droplar dışında.</NetworkEngineer34.description>
   <!-- EN: network engineer -->
   <NetworkEngineer34.title>network mühendisi</NetworkEngineer34.title>
   <NetworkEngineer34.titleFemale>network mühendisi</NetworkEngineer34.titleFemale>
@@ -1531,7 +1531,7 @@
   <NetworkEngineer34.titleShortFemale>mühendis</NetworkEngineer34.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] worked for a long time to improve mankind's understanding of the human brain.\n\nAfter succeeding in mapping the whole brain, [PAWN_nameDef] joined a team of scientists on a quest to map the brains of the most exotic altered humans. -->
-  <NeuroScientist19.description>[PAWN_nameDef] uzun bir süre insanlığın insan beyni anlayışını geliştirmek için çalıştı.\n\n [PAWN_nameDef], tüm beynin haritasını çıkarmayı başardıktan sonra, eegzotik veya değişik insanların beyinlerini haritalamak için bir araştırma ekibine katıldı.</NeuroScientist19.description>
+  <NeuroScientist19.description>[PAWN_nameDef] uzun bir süre insanlığın insan beyni anlayışını geliştirmek için çalıştı.\n\n[PAWN_nameDef], tüm beynin haritasını çıkarmayı başardıktan sonra, eegzotik veya değişik insanların beyinlerini haritalamak için bir araştırma ekibine katıldı.</NeuroScientist19.description>
   <!-- EN: neuro scientist -->
   <NeuroScientist19.title>nörolog</NeuroScientist19.title>
   <NeuroScientist19.titleFemale>nörolog</NeuroScientist19.titleFemale>
@@ -1540,7 +1540,7 @@
   <NeuroScientist19.titleShortFemale>bilimadamı</NeuroScientist19.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] performed stiletto-precise assassinations for an interplanetary conglomerate. [PAWN_pronoun] was assigned the most complex missions involving disguise, deception, subterfuge, and efficient violence.\n\nA nasty incident with a potted plant and an assassination gone wrong left [PAWN_objective] with an aversion to plant life. -->
-  <NinjaAssassin31.description>[PAWN_nameDef], gezegenler arası bir holding için hançerle hassas suikastler gerçekleştirdi. Kılık değiştirme, aldatma, hile ve etkili şiddet içeren en karmaşık görevlere atandı.\n\n Saksıdaki bir bitkiyle ilgili kötü bir olay ve ters giden bir suikast, onu bitki yaşamına karşı bir isteksizliğe sürükledi.</NinjaAssassin31.description>
+  <NinjaAssassin31.description>[PAWN_nameDef], gezegenler arası bir holding için hançerle hassas suikastler gerçekleştirdi. Kılık değiştirme, aldatma, hile ve etkili şiddet içeren en karmaşık görevlere atandı.\n\nSaksıdaki bir bitkiyle ilgili kötü bir olay ve ters giden bir suikast, onu bitki yaşamına karşı bir isteksizliğe sürükledi.</NinjaAssassin31.description>
   <!-- EN: ninja assassin -->
   <NinjaAssassin31.title>ninja suikastçi</NinjaAssassin31.title>
   <NinjaAssassin31.titleFemale>ninja suikastçi</NinjaAssassin31.titleFemale>
@@ -1548,16 +1548,16 @@
   <NinjaAssassin31.titleShort>ninja</NinjaAssassin31.titleShort>
   
   <!-- EN: When the government declared that it would strengthen its military defenses, [PAWN_nameDef] was drafted and trained.\n\n[PAWN_pronoun] was stationed on an orbital base, manning the defense systems and, in dire situations, descending in a dropship to the surface. -->
-  <OrbitalReservist22.description>Hükümet askeri savunmasını güçlendireceğini ilan ettiğinde [PAWN_nameDef] askere alındı ve eğitildi.\n\n Bir yörünge üssüne konuşlandı, savunma sistemlerini yönetti ve korkunç durumlarda bir indirme gemisiyle yüzeye indi.</OrbitalReservist22.description>
+  <OrbitalReservist22.description>Hükümet askeri savunmasını güçlendireceğini ilan ettiğinde [PAWN_nameDef] askere alındı ve eğitildi.\n\nBir yörünge üssüne konuşlandı, savunma sistemlerini yönetti ve korkunç durumlarda bir indirme gemisiyle yüzeye indi.</OrbitalReservist22.description>
   <!-- EN: orbital reservist -->
   <OrbitalReservist22.title>yörünge ihtiyat personeli</OrbitalReservist22.title>
   <OrbitalReservist22.titleFemale>yörünge ihtiyat personeli</OrbitalReservist22.titleFemale>
   <!-- EN: reservist -->
-  <OrbitalReservist22.titleShort>ihtiyat personeli</OrbitalReservist22.titleShort>
-  <OrbitalReservist22.titleShortFemale>ihtiyat personeli</OrbitalReservist22.titleShortFemale>
+  <OrbitalReservist22.titleShort>İhtiyat personeli</OrbitalReservist22.titleShort>
+  <OrbitalReservist22.titleShortFemale>İhtiyat personeli</OrbitalReservist22.titleShortFemale>
   
   <!-- EN: After graduating university at the top of [PAWN_possessive] class, [PAWN_nameDef] quickly became a well-known and athletic college professor.\n\nWith [PAWN_possessive] new found fame and fitness came a sudden reluctance to preform menial labor - such tasks are better left to graduate students. -->
-  <Osteologist74.description>[PAWN_nameDef] üniversiteyi sınıfının zirvesinde bitirdikten sonra kısa sürede tanınmış ve atletik bir üniversite profesörü oldu.\n\n Şöhreti ve zindeliği yüzünden yeni keşfedilen şeylere karşı ani bir isteksizlik geldi - bu tür görevler lisansüstü öğrencilere bırakılsa daha iyi olur.</Osteologist74.description>
+  <Osteologist74.description>[PAWN_nameDef] üniversiteyi sınıfının zirvesinde bitirdikten sonra kısa sürede tanınmış ve atletik bir üniversite profesörü oldu.\n\nŞöhreti ve zindeliği yüzünden yeni keşfedilen şeylere karşı ani bir isteksizlik geldi - bu tür görevler lisansüstü öğrencilere bırakılsa daha iyi olur.</Osteologist74.description>
   <!-- EN: osteologist -->
   <Osteologist74.title>osteolog</Osteologist74.title>
   <Osteologist74.titleFemale>osteolog</Osteologist74.titleFemale>
@@ -1566,7 +1566,7 @@
   <Osteologist74.titleShortFemale>akademisyen</Osteologist74.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] didn't know why [PAWN_pronoun] joined the military, but [PAWN_pronoun] stayed to protect [PAWN_possessive] fellow soldiers.\n\nArmy life broke [PAWN_objective] down and built [PAWN_objective] back up. It taught [PAWN_objective] marksmanship, hand to hand combat and how to patch a bullet wound in a hurry. -->
-  <OverwatchSniper42.description>[PAWN_nameDef] neden orduya katıldığını bilmiyordu ama asker arkadaşlarını korumak için burada kaldı.\n\n Asker yaşantısı eski hayatını yıkıp yeni hayatını oluşturmasında yardımcı oldu. Ona nişancılığı, göğüs göğüse çarpışmayı ve aceleyle kurşun yarasını nasıl dağlanacağını öğretti.</OverwatchSniper42.description>
+  <OverwatchSniper42.description>[PAWN_nameDef] neden orduya katıldığını bilmiyordu ama asker arkadaşlarını korumak için burada kaldı.\n\nAsker yaşantısı eski hayatını yıkıp yeni hayatını oluşturmasında yardımcı oldu. Ona nişancılığı, göğüs göğüse çarpışmayı ve aceleyle kurşun yarasını nasıl dağlanacağını öğretti.</OverwatchSniper42.description>
   <!-- EN: overwatch sniper -->
   <OverwatchSniper42.title>overwatch nişançısı</OverwatchSniper42.title>
   <OverwatchSniper42.titleFemale>overwatch nişançısı</OverwatchSniper42.titleFemale>
@@ -1593,7 +1593,7 @@
   <ParticlePhysicist44.titleShortFemale>fizikçi</ParticlePhysicist44.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef]'s thirst for archaeo-technological knowledge drove [PAWN_objective] to spend years surveying abandoned data centers and studying ancient coding languages.\n\n[PAWN_pronoun] claimed to be one of the few who could piece together the tragedy of the past - and offer a path to the future. -->
-  <Philosopher97.description>[PAWN_nameDef]'in arkeo-teknolojik bilgiye olan açlığı, onu yıllarını terk edilmiş veri merkezlerini araştırmak ve eski kodlama dillerini incelemek için harcamaya yöneltti.\n\n Geçmişin trajedisini bir araya getirebilecek ve geleceğe bir yol sunabilecek birkaç kişiden biri olduğunu iddia etti.</Philosopher97.description>
+  <Philosopher97.description>[PAWN_nameDef]'in arkeo-teknolojik bilgiye olan açlığı, onu yıllarını terk edilmiş veri merkezlerini araştırmak ve eski kodlama dillerini incelemek için harcamaya yöneltti.\n\nGeçmişin trajedisini bir araya getirebilecek ve geleceğe bir yol sunabilecek birkaç kişiden biri olduğunu iddia etti.</Philosopher97.description>
   <!-- EN: philosopher -->
   <Philosopher97.title>filozof</Philosopher97.title>
   <Philosopher97.titleFemale>filozof</Philosopher97.titleFemale>
@@ -1602,7 +1602,7 @@
   <Philosopher97.titleShortFemale>pir</Philosopher97.titleShortFemale>
   
   <!-- EN: As a pirate leader, [PAWN_nameDef] was well-known for [PAWN_possessive] cunning plans and chess-like traps. [PAWN_pronoun] was never afraid to sacrifice a few pawns to capture an important target.\n\n[PAWN_possessive] name has been linked more then once to strategies that overcame overwhelming odds. -->
-  <Pirate56.description>Bir korsan lideri olarak [PAWN_nameDef] kurnaz planları ve satranç taktiklerine benzeyen tuzaklarıyla tanınırdı. Önemli bir hedefi ele geçirmek için birkaç piyon feda etmekten asla korkmadı.\n\n Adı, ezici ihtimalleri aşan stratejilerle bir kereden fazla ilişkilendirildi.</Pirate56.description>
+  <Pirate56.description>Bir korsan lideri olarak [PAWN_nameDef] kurnaz planları ve satranç taktiklerine benzeyen tuzaklarıyla tanınırdı. Önemli bir hedefi ele geçirmek için birkaç piyon feda etmekten asla korkmadı.\n\nAdı, ezici ihtimalleri aşan stratejilerle bir kereden fazla ilişkilendirildi.</Pirate56.description>
   <!-- EN: pirate -->
   <Pirate56.title>korsan</Pirate56.title>
   <Pirate56.titleFemale>korsan</Pirate56.titleFemale>
@@ -1620,7 +1620,7 @@
   <PirateCaptain69.titleShortFemale>kaptan</PirateCaptain69.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] had a passion for medicine, but never bothered to get a medical degree. Only underfunded pirates and terrorists were desperate enough to hire [PAWN_possessive] services, and [PAWN_possessive] surgical patients had about a 50% survival rate.\n\nDespite this, [PAWN_possessive] optimistic attitude drove [PAWN_objective] to keep trying to heal those in need. As long as they paid up front. -->
-  <PirateDoctor0.description>[PAWN_nameDef] tıp için bir tutkuya sahipti, ancak hiçbir zaman tıp diploması alma zahmetine girmedi. Yalnızca parası yetersiz korsanlar ve teröristler onun hizmetlerini alacak kadar çaresizdi ve cerrahi hastalarının hayatta kalma oranı yaklaşık %50'ydi.\n\n Buna rağmen, iyimser tavrı onu ihtiyacı olanları iyileştirmeye çalışmaya devam etti. Peşin ödedikleri sürece.</PirateDoctor0.description>
+  <PirateDoctor0.description>[PAWN_nameDef] tıp için bir tutkuya sahipti, ancak hiçbir zaman tıp diploması alma zahmetine girmedi. Yalnızca parası yetersiz korsanlar ve teröristler onun hizmetlerini alacak kadar çaresizdi ve cerrahi hastalarının hayatta kalma oranı yaklaşık %50'ydi.\n\nBuna rağmen, iyimser tavrı onu ihtiyacı olanları iyileştirmeye çalışmaya devam etti. Peşin ödedikleri sürece.</PirateDoctor0.description>
   <!-- EN: pirate doctor -->
   <PirateDoctor0.title>korsan doktoru</PirateDoctor0.title>
   <PirateDoctor0.titleFemale>korsan doktoru</PirateDoctor0.titleFemale>
@@ -1637,7 +1637,7 @@
   <PirateKing69.titleShortFemale>korsan</PirateKing69.titleShortFemale>
   
   <!-- EN: From [PAWN_possessive] youth, [PAWN_nameDef] developed connections in the underworld. There [PAWN_pronoun] trained in melee combat and became a trusted underworld advisor.\n\nAfter participating in a failed rebellion, [PAWN_pronoun] fled [PAWN_possessive] homeworld to travel with a pirate band. -->
-  <PirateSympathizer24.description>[PAWN_nameDef] gençliğinden itibaren yeraltı dünyasında bağlantılar geliştirdi. Orada yakın dövüş eğitimi aldı ve güvenilir bir yeraltı danışmanı oldu.\n\n Başarısız bir isyana katıldıktan sonra, bir korsan grubuyla seyahat etmek için anavatanından kaçtı.</PirateSympathizer24.description>
+  <PirateSympathizer24.description>[PAWN_nameDef] gençliğinden itibaren yeraltı dünyasında bağlantılar geliştirdi. Orada yakın dövüş eğitimi aldı ve güvenilir bir yeraltı danışmanı oldu.\n\nBaşarısız bir isyana katıldıktan sonra, bir korsan grubuyla seyahat etmek için anavatanından kaçtı.</PirateSympathizer24.description>
   <!-- EN: pirate sympathizer -->
   <PirateSympathizer24.title>korsan sempatizanı</PirateSympathizer24.title>
   <PirateSympathizer24.titleFemale>korsan sempatizanı</PirateSympathizer24.titleFemale>
@@ -1646,7 +1646,7 @@
   <PirateSympathizer24.titleShortFemale>korsan</PirateSympathizer24.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] joined a renowned interstellar criminal organization, and was often part of shock-assault boarding parties during starship raids.\n\nThough [PAWN_possessive] combat experience made [PAWN_objective] a good fighter, the ruthlessness of the job left [PAWN_objective] cold-hearted and unenthusiastic about social interaction. -->
-  <PirateTrooper73.description>[PAWN_nameDef] ünlü bir yıldızlararası suç örgütüne katıldı ve genellikle yıldız gemisi baskınları sırasında şok-saldırı biniş partilerinin bir parçasıydı.\n\n. Dövüş tecrübesi onu iyi bir dövüşçü yapsa da, işin acımasızlığı onu soğukkanlı ve sosyal etkileşim konusunda isteksiz bıraktı.</PirateTrooper73.description>
+  <PirateTrooper73.description>[PAWN_nameDef] ünlü bir yıldızlararası suç örgütüne katıldı ve genellikle yıldız gemisi baskınları sırasında şok-saldırı biniş partilerinin bir parçasıydı.\n\nDövüş tecrübesi onu iyi bir dövüşçü yapsa da, işin acımasızlığı onu soğukkanlı ve sosyal etkileşim konusunda isteksiz bıraktı.</PirateTrooper73.description>
   <!-- EN: pirate trooper -->
   <PirateTrooper73.title>korsan süvari</PirateTrooper73.title>
   <PirateTrooper73.titleFemale>korsan süvari</PirateTrooper73.titleFemale>
@@ -1655,7 +1655,7 @@
   <PirateTrooper73.titleShortFemale>süvari</PirateTrooper73.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] provided medical care on multiple plague-wracked worlds, always working under the Hippocratic oath. [PAWN_pronoun] improved conditions for those under quarantine while administering complex medical treatments and developing medicines.\n\n[PAWN_pronoun] never had time to enjoy a normal life outside of work. -->
-  <PlagueDoctor31.description>[PAWN_nameDef], her zaman Hipokrat yemini altında çalışarak, vebayla dolu birçok dünyada tıbbi bakım sağladı. Karmaşık tıbbi tedavileri uygularken ve ilaçlar geliştirirken karantina altındakilerin koşullarını iyileştirdi.\n\n İş dışında normal bir hayatın tadını çıkarmaya hiç vakti olmamıştı.</PlagueDoctor31.description>
+  <PlagueDoctor31.description>[PAWN_nameDef], her zaman Hipokrat yemini altında çalışarak, vebayla dolu birçok dünyada tıbbi bakım sağladı. Karmaşık tıbbi tedavileri uygularken ve ilaçlar geliştirirken karantina altındakilerin koşullarını iyileştirdi.\n\nİş dışında normal bir hayatın tadını çıkarmaya hiç vakti olmamıştı.</PlagueDoctor31.description>
   <!-- EN: plague doctor -->
   <PlagueDoctor31.title>veba doktoru</PlagueDoctor31.title>
   <PlagueDoctor31.titleFemale>veba doktoru</PlagueDoctor31.titleFemale>
@@ -1673,7 +1673,7 @@
   <PlanetaryDiplomat7.titleShortFemale>diplomat</PlanetaryDiplomat7.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] spent almost all [PAWN_possessive] time tending to a poison garden and became withdrawn from society.\n\nIn that time [PAWN_pronoun] learnt a few safe culinary and medicinal uses for the otherwise deadly plants. -->
-  <PoisonGardener29.description>[PAWN_nameDef] neredeyse tüm zamanını zehirli bir bahçeyle ilgilenerek geçirdi ve toplumdan çekildi.\n\n Bu süre zarfında ölümcül olan bitkiler için birkaç güvenli tarif ve tıbbi kullanım öğrendi.</PoisonGardener29.description>
+  <PoisonGardener29.description>[PAWN_nameDef] neredeyse tüm zamanını zehirli bir bahçeyle ilgilenerek geçirdi ve toplumdan çekildi.\n\nBu süre zarfında ölümcül olan bitkiler için birkaç güvenli tarif ve tıbbi kullanım öğrendi.</PoisonGardener29.description>
   <!-- EN: poison gardener -->
   <PoisonGardener29.title>zehir bahçıvanı</PoisonGardener29.title>
   <PoisonGardener29.titleFemale>zehir bahçıvanı</PoisonGardener29.titleFemale>
@@ -1682,7 +1682,7 @@
   <PoisonGardener29.titleShortFemale>botanist</PoisonGardener29.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was involved with a radical political faction which worked against [PAWN_possessive] homeworld's government.\n\nThe guerilla tactics training that [PAWN_nameDef] received from [PAWN_possessive] associates gave [PAWN_objective] the skills to fight, but also drove [PAWN_objective] to compromise [PAWN_possessive] own beliefs. -->
-  <PoliticalActivist20.description>[PAWN_nameDef], anavatanının hükümetine karşı çalışan radikal bir siyasi hizipte yer aldı.\n\n [PAWN_nameDef]'nin ortaklarından aldığı gerilla taktik eğitimi, ona savaşma becerisi kazandırdı, ama aynı zamanda onu kendi inançlarından ödün vermeye itti.</PoliticalActivist20.description>
+  <PoliticalActivist20.description>[PAWN_nameDef], anavatanının hükümetine karşı çalışan radikal bir siyasi hizipte yer aldı.\n\n[PAWN_nameDef]'nin ortaklarından aldığı gerilla taktik eğitimi, ona savaşma becerisi kazandırdı, ama aynı zamanda onu kendi inançlarından ödün vermeye itti.</PoliticalActivist20.description>
   <!-- EN: political activist -->
   <PoliticalActivist20.title>politik aktivist</PoliticalActivist20.title>
   <PoliticalActivist20.titleFemale>politik aktivist</PoliticalActivist20.titleFemale>
@@ -1691,7 +1691,7 @@
   <PoliticalActivist20.titleShortFemale>aktivist</PoliticalActivist20.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] realized that [PAWN_possessive] true calling was in physical solutions to diplomatic problems. [PAWN_pronoun] sought training from the assassins guild on Ceti V.\n\n[PAWN_pronoun] was a quick study at the arts of subterfuge and death. [PAWN_pronoun] soon earned the guild rank of Deathjack. -->
-  <PoliticalAssassin46.description>[PAWN_nameDef] asıl görevinin diplomatik sorunlara fiziksel çözümler bulmak olduğunu fark etti. Ceti V'deki suikastçılar loncasından eğitim aldı.\n\n Hile ve ölüm sanatlarında hızlı bir şekilde öğrendi. Kısa süre sonra "Deathjack" lonca rütbesini kazandı.</PoliticalAssassin46.description>
+  <PoliticalAssassin46.description>[PAWN_nameDef] asıl görevinin diplomatik sorunlara fiziksel çözümler bulmak olduğunu fark etti. Ceti V'deki suikastçılar loncasından eğitim aldı.\n\nHile ve ölüm sanatlarında hızlı bir şekilde öğrendi. Kısa süre sonra "Deathjack" lonca rütbesini kazandı.</PoliticalAssassin46.description>
   <!-- EN: political assassin -->
   <PoliticalAssassin46.title>politik suikastçi</PoliticalAssassin46.title>
   <PoliticalAssassin46.titleFemale>politik suikastçi</PoliticalAssassin46.titleFemale>
@@ -1699,7 +1699,7 @@
   <PoliticalAssassin46.titleShort>Deathjack</PoliticalAssassin46.titleShort>
   
   <!-- EN: [PAWN_nameDef] was an activist in a powerful political faction. There [PAWN_pronoun] learned the art of persuasion and speech.\n\n[PAWN_pronoun] had many enemies, so [PAWN_pronoun] took secret courses in shooting and hand-to-hand combat. -->
-  <Politician57.description>[PAWN_nameDef] güçlü bir siyasi fraksiyonda bir aktivistti. Orada ikna ve konuşma sanatını öğrendi.\n\n. Pek çok düşmanı vardı, bu yüzden atış ve göğüs göğüse çarpışmalarda gizli kurslar aldı.</Politician57.description>
+  <Politician57.description>[PAWN_nameDef] güçlü bir siyasi fraksiyonda bir aktivistti. Orada ikna ve konuşma sanatını öğrendi.\n\nPek çok düşmanı vardı, bu yüzden atış ve göğüs göğüse çarpışmalarda gizli kurslar aldı.</Politician57.description>
   <!-- EN: politician -->
   <Politician57.title>politikacı</Politician57.title>
   <Politician57.titleFemale>politikacı</Politician57.titleFemale>
@@ -1715,7 +1715,7 @@
   <PopIdol59.titleShort>pop idol</PopIdol59.titleShort>
   
   <!-- EN: [PAWN_nameDef] and [PAWN_possessive] fans set out as a space pirate crew. [PAWN_pronoun] raided corporations for money and staged performances to spread [PAWN_possessive] name.\n\n[PAWN_nameDef] became afraid of fire when a rival burned [PAWN_possessive] stage down. [PAWN_pronoun] relied on [PAWN_possessive] fans to do the work [PAWN_pronoun] found unappealing. -->
-  <PopIdolPirate39.description>[PAWN_nameDef] ve hayranları bir uzay korsanı ekibi olarak yola çıktı. Şirketleri para için bastı ve adını yaymak için gösteriler yaptı.\n\n [PAWN_nameDef], bir rakibi sahnesini yaktığında ateşten korkmaya başladı. Çekici bulmadığı işleri yapmak için hayranlarına güvendi.</PopIdolPirate39.description>
+  <PopIdolPirate39.description>[PAWN_nameDef] ve hayranları bir uzay korsanı ekibi olarak yola çıktı. Şirketleri para için bastı ve adını yaymak için gösteriler yaptı.\n\n[PAWN_nameDef], bir rakibi sahnesini yaktığında ateşten korkmaya başladı. Çekici bulmadığı işleri yapmak için hayranlarına güvendi.</PopIdolPirate39.description>
   <!-- EN: pop idol pirate -->
   <PopIdolPirate39.title>korsan pop idolü</PopIdolPirate39.title>
   <PopIdolPirate39.titleFemale>korsan pop idolü</PopIdolPirate39.titleFemale>
@@ -1724,7 +1724,7 @@
   <PopIdolPirate39.titleShortFemale>korsan</PopIdolPirate39.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was captured and put on death row for war crimes.\n\nFortunately for [PAWN_objective], someone cut the power to [PAWN_possessive] cell block. Riots ignited. Guards and trained wargs were deployed to quell the uprising. Organizing a few other inmates, [PAWN_nameDef] escaped in a small spacecraft. -->
-  <PrisonerOfWar2.description>[PAWN_nameDef] yakalandı ve savaş suçlarından idam cezasına çarptırıldı.\n\n Neyse ki onun için biri hücre bloğunun elektriğini kesti. Ayaklanmaları ateşledi. Ayaklanmayı bastırmak için muhafızlar ve eğitimli warglar görevlendirildi. [PAWN_nameDef] birkaç mahkûmu organize ederek küçük bir uzay aracıyla kaçtı.</PrisonerOfWar2.description>
+  <PrisonerOfWar2.description>[PAWN_nameDef] yakalandı ve savaş suçlarından idam cezasına çarptırıldı.\n\nNeyse ki onun için biri hücre bloğunun elektriğini kesti. Ayaklanmaları ateşledi. Ayaklanmayı bastırmak için muhafızlar ve eğitimli warglar görevlendirildi. [PAWN_nameDef] birkaç mahkûmu organize ederek küçük bir uzay aracıyla kaçtı.</PrisonerOfWar2.description>
   <!-- EN: prisoner of war -->
   <PrisonerOfWar2.title>savaş suçlusu</PrisonerOfWar2.title>
   <PrisonerOfWar2.titleFemale>savaş suçlusu</PrisonerOfWar2.titleFemale>
@@ -1751,9 +1751,9 @@
   <ProstheticSurgeon0.titleShortFemale>cerrah</ProstheticSurgeon0.titleShortFemale>
   
   <!-- EN: After [PAWN_possessive] father was deposed, [PAWN_nameDef]'s beauty led [PAWN_objective] to be forced into pornography to survive.\n\nOver years of difficult treatments, [PAWN_possessive] body was remodeled to appear temporarily ageless. Sold to an orbital brothel, [PAWN_pronoun] became popular, with a steady stream of clients from all over the planet. -->
-  <ProstituteIdol28.description>Babası görevden alındıktan sonra, [PAWN_nameDef]'in güzelliği, hayatta kalabilmek için pornografiye zorlanmasına neden oldu.\n\n. Yıllarca süren zorlu tedaviler sonucunda, vücudu geçici olarak yaşlanmayacak şekilde yeniden şekillendirildi. Yörüngesel bir geneleve satıldığında, gezegenin her yerinden sürekli bir müşteri akışıyla popüler oldu.</ProstituteIdol28.description>
+  <ProstituteIdol28.description>Babası görevden alındıktan sonra, [PAWN_nameDef]'in güzelliği, hayatta kalabilmek için pornografiye zorlanmasına neden oldu.\n\nYıllarca süren zorlu tedaviler sonucunda, vücudu geçici olarak yaşlanmayacak şekilde yeniden şekillendirildi. Yörüngesel bir geneleve satıldığında, gezegenin her yerinden sürekli bir müşteri akışıyla popüler oldu.</ProstituteIdol28.description>
   <!-- EN: prostitute idol -->
-  <ProstituteIdol28.title>idol fahişe</ProstituteIdol28.title>
+  <ProstituteIdol28.title>İdol fahişe</ProstituteIdol28.title>
   <!-- EN: prostitute -->
   <ProstituteIdol28.titleShort>fahişe</ProstituteIdol28.titleShort>
   <ProstituteIdol28.titleShortFemale>fahişe</ProstituteIdol28.titleShortFemale>
@@ -1777,7 +1777,7 @@
   <Ranger6.titleShortFemale>korucu</Ranger6.titleShortFemale>
   
   <!-- EN: When civil war broke out [PAWN_nameDef] remained neutral, until [PAWN_possessive] home was firebombed by a loyalist militia.\n\nLater, [PAWN_possessive] unit gave [PAWN_objective] the nickname "Rare" after [PAWN_pronoun] burnt down the luxury villa of a loyalist leader, with them still inside it. -->
-  <RebelFighter39.description>İç savaş patlak verdiğinde [PAWN_nameDef] evi sadık bir milis tarafından ateşe verilene kadar tarafsız kaldı.\n\n. Daha sonra,bir liderin lüks villasını yaktıktan sonra, birliği ona "az pişmiş" takma adını verdi, hala asiler.</RebelFighter39.description>
+  <RebelFighter39.description>İç savaş patlak verdiğinde [PAWN_nameDef] evi sadık bir milis tarafından ateşe verilene kadar tarafsız kaldı.\n\nDaha sonra,bir liderin lüks villasını yaktıktan sonra, birliği ona "az pişmiş" takma adını verdi, hala asiler.</RebelFighter39.description>
   <!-- EN: rebel fighter -->
   <RebelFighter39.title>asi dövüşçü</RebelFighter39.title>
   <RebelFighter39.titleFemale>asi dövüşçü</RebelFighter39.titleFemale>
@@ -1786,7 +1786,7 @@
   <RebelFighter39.titleShortFemale>asi</RebelFighter39.titleShortFemale>
   
   <!-- EN: Ordained as a priest in [PAWN_possessive] local community, [PAWN_nameDef] used intrigue and diplomacy to rise to the higher echelon of the clergy. [PAWN_pronoun] held numerous titles and lands.\n\nOne day, a merchant landed [PAWN_possessive] spaceship near [PAWN_nameDef]'s home. [PAWN_pronoun] decided to accompany the merchant in search for new worlds and challenges. -->
-  <ReligiousHierarch16.description>Yerel topluluğunda rahip olarak atanan [PAWN_nameDef], din adamlarının daha yüksek kademesine yükselmek için entrika ve diplomasi kullandı. Çok sayıda unvan ve arazi sahibiydi.\n\n. Bir gün, bir tüccar uzay gemisini [PAWN_nameDef]'nin evinin yakınına indirdi. Yeni dünyalar ve zorluklar arayışında tüccara eşlik etmeye karar verdi.</ReligiousHierarch16.description>
+  <ReligiousHierarch16.description>Yerel topluluğunda rahip olarak atanan [PAWN_nameDef], din adamlarının daha yüksek kademesine yükselmek için entrika ve diplomasi kullandı. Çok sayıda unvan ve arazi sahibiydi.\n\nBir gün, bir tüccar uzay gemisini [PAWN_nameDef]'nin evinin yakınına indirdi. Yeni dünyalar ve zorluklar arayışında tüccara eşlik etmeye karar verdi.</ReligiousHierarch16.description>
   <!-- EN: religious hierarch -->
   <ReligiousHierarch16.title>mutaassıp baş piskopos</ReligiousHierarch16.title>
   <ReligiousHierarch16.titleFemale>mutaassıp baş piskopos</ReligiousHierarch16.titleFemale>
@@ -1795,7 +1795,7 @@
   <ReligiousHierarch16.titleShortFemale>baş piskopos</ReligiousHierarch16.titleShortFemale>
   
   <!-- EN: After a daring escape from the prison planet with a small crew of fellow inmates, [PAWN_nameDef] set [PAWN_possessive] gaze on [PAWN_possessive] homeworld.\n\n[PAWN_pronoun] traveled there, recruited more followers, hijacked a space cruiser, and launched into the void. -->
-  <RenegadeEngineer43.description>[PAWN_nameDef], mahkûmlardan oluşan küçük bir ekiple hapishane gezegeninden cüretkar bir kaçışın ardından bakışlarını ana gezegenine dikti.\n\n Oraya gitti ve daha fazla takipçi topladı, bir uzay kruvazörü kaçırdı ve boşluğa fırlatıldı.</RenegadeEngineer43.description>
+  <RenegadeEngineer43.description>[PAWN_nameDef], mahkûmlardan oluşan küçük bir ekiple hapishane gezegeninden cüretkar bir kaçışın ardından bakışlarını ana gezegenine dikti.\n\nOraya gitti ve daha fazla takipçi topladı, bir uzay kruvazörü kaçırdı ve boşluğa fırlatıldı.</RenegadeEngineer43.description>
   <!-- EN: renegade engineer -->
   <RenegadeEngineer43.title>hain mühendis</RenegadeEngineer43.title>
   <RenegadeEngineer43.titleFemale>hain mühendis</RenegadeEngineer43.titleFemale>
@@ -1804,7 +1804,7 @@
   <RenegadeEngineer43.titleShortFemale>mühendis</RenegadeEngineer43.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef]'s bottomless compassion and love of knowledge drove [PAWN_objective] to a life of teaching. [PAWN_pronoun] became one of the best-known names in academia throughout the urbworld bubble.\n\n[PAWN_possessive] holo-lectures were revered by all that watched, and the few students [PAWN_pronoun] accepted into [PAWN_possessive] seminars spoke widely of [PAWN_possessive] kindness and patience. -->
-  <RenownedProfessor51.description>[PAWN_nameDef]'in dipsiz şefkati ve eğitme sevgisi onu bir öğretmenlik hayatına sürükledi. Urbworld ortamı boyunca akademinin en tanınmış isimlerinden biri oldu.\n\n Hologram konferansları izleyen herkes tarafından saygıyla karşılandı ve seminerlerine kabul ettiği birkaç öğrenci nezaketinden ve sabrından çokça bahsetti.</RenownedProfessor51.description>
+  <RenownedProfessor51.description>[PAWN_nameDef]'in dipsiz şefkati ve eğitme sevgisi onu bir öğretmenlik hayatına sürükledi. Urbworld ortamı boyunca akademinin en tanınmış isimlerinden biri oldu.\n\nHologram konferansları izleyen herkes tarafından saygıyla karşılandı ve seminerlerine kabul ettiği birkaç öğrenci nezaketinden ve sabrından çokça bahsetti.</RenownedProfessor51.description>
   <!-- EN: renowned professor -->
   <RenownedProfessor51.title>meşhur profesör</RenownedProfessor51.title>
   <RenownedProfessor51.titleFemale>meşhur profesör</RenownedProfessor51.titleFemale>
@@ -1813,7 +1813,7 @@
   <RenownedProfessor51.titleShortFemale>profesör</RenownedProfessor51.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] spent many years as an investigative reporter. [PAWN_pronoun] was notorious for making chaotic reports from exotic locations.\n\nAlthough seen as a lightweight by [PAWN_possessive] critics, [PAWN_pronoun] managed to break several high-profile stories after lengthy investigations. -->
-  <Reporter71.description>[PAWN_nameDef] uzun yıllar araştırmacı muhabir olarak çalıştı. Egzotik yerlerden kaotik raporlar yapmasıyla ünlüydü.\n\n Eleştirmenler tarafından hafife alınsa da uzun araştırmalardan sonra birkaç yüksek profilli haber yazmayı başardı.</Reporter71.description>
+  <Reporter71.description>[PAWN_nameDef] uzun yıllar araştırmacı muhabir olarak çalıştı. Egzotik yerlerden kaotik raporlar yapmasıyla ünlüydü.\n\nEleştirmenler tarafından hafife alınsa da uzun araştırmalardan sonra birkaç yüksek profilli haber yazmayı başardı.</Reporter71.description>
   <!-- EN: reporter -->
   <Reporter71.title>muhabir</Reporter71.title>
   <Reporter71.titleFemale>muhabir</Reporter71.titleFemale>
@@ -1822,7 +1822,7 @@
   <Reporter71.titleShortFemale>muhabir</Reporter71.titleShortFemale>
   
   <!-- EN: After leaving [PAWN_possessive] parents' vineyard, [PAWN_nameDef] traveled across much of known space, and learned many skills along the way.\n\n[PAWN_pronoun] spent most of [PAWN_possessive] time researching and interacting with reptile species. [PAWN_pronoun] was renowned for making several breakthroughs, and for discovering the "Thorny Devil". -->
-  <ReptileResearcher37.description>[PAWN_nameDef], ailesinin bağından ayrıldıktan sonra bilinen alanların çoğunu gezdi ve yol boyunca birçok beceri öğrendi.\n\n. Zamanının çoğunu araştırma ve sürüngen türleri ile etkileşim içinde geçirdi. Birkaç atılım yapması ve "Dikenli Şeytan" ı keşfetmesiyle ünlüydü.</ReptileResearcher37.description>
+  <ReptileResearcher37.description>[PAWN_nameDef], ailesinin bağından ayrıldıktan sonra bilinen alanların çoğunu gezdi ve yol boyunca birçok beceri öğrendi.\n\nZamanının çoğunu araştırma ve sürüngen türleri ile etkileşim içinde geçirdi. Birkaç atılım yapması ve "Dikenli Şeytan" ı keşfetmesiyle ünlüydü.</ReptileResearcher37.description>
   <!-- EN: reptile researcher -->
   <ReptileResearcher37.title>sürüngen bilimci</ReptileResearcher37.title>
   <ReptileResearcher37.titleFemale>sürüngen bilimci</ReptileResearcher37.titleFemale>
@@ -1849,7 +1849,7 @@
   <RimworldExile32.titleShortFemale>sürgün</RimworldExile32.titleShortFemale>
   
   <!-- EN: Sailors often died on the dangerous waters of [PAWN_nameDef]'s ocean planet. [PAWN_pronoun] created robots to replace them.\n\nOver time, [PAWN_pronoun] collected a small crew of robots to do [PAWN_possessive] bidding. [PAWN_pronoun] became proficient at mechanics and engineering, but lost the taste for manual labor. -->
-  <Roboticist1.description>Denizciler genellikle [PAWN_nameDef]'nin okyanus gezegeninin tehlikeli sularında ölürlerdi. Onların yerini almak için robotlar yarattı.\n\n. Zamanla emirlerini yerine getirmek için küçük bir robot ekibi oluşturdu. Mekanik ve mühendislikte uzmanlaştı, ancak el emeği zevkini kaybetti.</Roboticist1.description>
+  <Roboticist1.description>Denizciler genellikle [PAWN_nameDef]'nin okyanus gezegeninin tehlikeli sularında ölürlerdi. Onların yerini almak için robotlar yarattı.\n\nZamanla emirlerini yerine getirmek için küçük bir robot ekibi oluşturdu. Mekanik ve mühendislikte uzmanlaştı, ancak el emeği zevkini kaybetti.</Roboticist1.description>
   <!-- EN: roboticist -->
   <Roboticist1.title>Robotikerin</Roboticist1.title>
   <Roboticist1.titleFemale>Robotikerin</Roboticist1.titleFemale>
@@ -1884,7 +1884,7 @@
   <RocketPioneer19.titleShort>roket pilotu</RocketPioneer19.titleShort>
   
   <!-- EN: After years of addiction to virtual reality games, [PAWN_nameDef] was saved when the doctors unplugged him.\n\nUnfortunately, they unplugged [PAWN_objective] during a match of Rugby Rampage 4. The mental backlash merged [PAWN_possessive] real identity and [PAWN_possessive] virtual identity, leaving [PAWN_objective] with the personality and skills of a rugby player. -->
-  <RugbyPlayer71.description>Yıllarca sanal gerçeklik oyunlarına bağımlı hale gelen [PAWN_nameDef]'yi doktorlar fişi çekince kurtardı.\n\n Ne yazık ki, bir Rugby Rampage 4 maçı sırasında fişini çektiler. Zihinsel sarsıntı, gerçek kimliğiyle sanal kimliğini birleştirdi ve onu bir rugby oyuncusunun kişiliği ve becerileriyle baş başa bıraktı.</RugbyPlayer71.description>
+  <RugbyPlayer71.description>Yıllarca sanal gerçeklik oyunlarına bağımlı hale gelen [PAWN_nameDef]'yi doktorlar fişi çekince kurtardı.\n\nNe yazık ki, bir Rugby Rampage 4 maçı sırasında fişini çektiler. Zihinsel sarsıntı, gerçek kimliğiyle sanal kimliğini birleştirdi ve onu bir rugby oyuncusunun kişiliği ve becerileriyle baş başa bıraktı.</RugbyPlayer71.description>
   <!-- EN: rugby player -->
   <RugbyPlayer71.title>rugbi oyuncusu</RugbyPlayer71.title>
   <RugbyPlayer71.titleFemale>rugbi oyuncusu</RugbyPlayer71.titleFemale>
@@ -1893,7 +1893,7 @@
   <RugbyPlayer71.titleShortFemale>kanat oyuncusu</RugbyPlayer71.titleShortFemale>
   
   <!-- EN: Grown by and for science, [PAWN_nameDef] gave it up. Instead, [PAWN_pronoun] wanted to dance for crowds across many worlds, from the glamor of the glitterworlds to the dangers of the rim.\n\nSuch work required wearing a smile on [PAWN_possessive] face and a pistol under [PAWN_possessive] costume. -->
-  <RunawayDancer35.description>Bilim camiası tarafından bilim için yetiştirilen [PAWN_nameDef] bundan kaçtı. Bunun yerine glitterworld'lerin ihtişamınından tehlikeli çukurlarına kadar birçok dünyada kalabalıklar için dans etmek istedi.\n\n Böyle bir iş için yüzünde bir gülümseme ve kostümünün altına bir tabancayla yaşaması gerektiriyordu.</RunawayDancer35.description>
+  <RunawayDancer35.description>Bilim camiası tarafından bilim için yetiştirilen [PAWN_nameDef] bundan kaçtı. Bunun yerine glitterworld'lerin ihtişamınından tehlikeli çukurlarına kadar birçok dünyada kalabalıklar için dans etmek istedi.\n\nBöyle bir iş için yüzünde bir gülümseme ve kostümünün altına bir tabancayla yaşaması gerektiriyordu.</RunawayDancer35.description>
   <!-- EN: runaway dancer -->
   <RunawayDancer35.title>kaçak dansçı</RunawayDancer35.title>
   <RunawayDancer35.titleFemale>kaçak dansçı</RunawayDancer35.titleFemale>
@@ -1902,7 +1902,7 @@
   <RunawayDancer35.titleShortFemale>dansçı</RunawayDancer35.titleShortFemale>
   
   <!-- EN: After graduating officer training school, [PAWN_nameDef] was assigned to main battle deck on the Thunder-Child. [PAWN_pronoun] served there for a year before [PAWN_possessive] "gallant" actions saw [PAWN_objective] reassigned to the maintenance corps.\n\nIt was with the maintenance corps [PAWN_pronoun] was dubbed [PAWN_nameDef] on account of [PAWN_possessive] legs. -->
-  <SanitationCaptain29.description>Subay eğitim okulundan mezun olduktan sonra [PAWN_nameDef] Thunder-Child ana muharebe güvertesine atandı. "gözü pek" davranışları onu bakım birliklerine yeniden atanana kadar orada bir yıl görev yapmasına neden oldu.\n\n. Bacakları nedeniyle ona [PAWN_nameDef] lakabı verdiler.</SanitationCaptain29.description>
+  <SanitationCaptain29.description>Subay eğitim okulundan mezun olduktan sonra [PAWN_nameDef] Thunder-Child ana muharebe güvertesine atandı. "gözü pek" davranışları onu bakım birliklerine yeniden atanana kadar orada bir yıl görev yapmasına neden oldu.\n\nBacakları nedeniyle ona [PAWN_nameDef] lakabı verdiler.</SanitationCaptain29.description>
   <!-- EN: sanitation captain -->
   <SanitationCaptain29.title>sanitasyon kaptanı</SanitationCaptain29.title>
   <SanitationCaptain29.titleFemale>sanitasyon kaptanı</SanitationCaptain29.titleFemale>
@@ -1911,7 +1911,7 @@
   <SanitationCaptain29.titleShortFemale>hademe</SanitationCaptain29.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was a hunter of mysterious creatures that many didn't even believe existed. Sometimes the people were right - and sometimes they were wrong.\n\nAlong the way, [PAWN_pronoun] helped people in need. -->
-  <SelflessHunter61.description>[PAWN_nameDef], birçoğunun var olduğuna bile inanmadığı gizemli yaratıkların avcısıydı. Bazen insanlar haklıydı - ve bazen de haksızlardı.\n\n. Bu arada ihtiyaç sahiplerine yardım etti.</SelflessHunter61.description>
+  <SelflessHunter61.description>[PAWN_nameDef], birçoğunun var olduğuna bile inanmadığı gizemli yaratıkların avcısıydı. Bazen insanlar haklıydı - ve bazen de haksızlardı.\n\nBu arada ihtiyaç sahiplerine yardım etti.</SelflessHunter61.description>
   <!-- EN: selfless hunter -->
   <SelflessHunter61.title>özverili avcı</SelflessHunter61.title>
   <SelflessHunter61.titleFemale>özverili avcı</SelflessHunter61.titleFemale>
@@ -1920,7 +1920,7 @@
   <SelflessHunter61.titleShortFemale>avcı</SelflessHunter61.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] started to enjoy killing people, so [PAWN_pronoun] did more often and perfected [PAWN_possessive] methods. [PAWN_pronoun] lurked in the darkest streets, stalking prey for hours.\n\n[PAWN_pronoun] enjoyed making artworks of [PAWN_possessive] victims, and was known for leaving [PAWN_possessive] signature on the bodies of those [PAWN_pronoun] killed. -->
-  <SerialMurderer47.description>[PAWN_nameDef] insanları öldürmekten zevk almaya başladı, bu yüzden daha sık yaptı ve yöntemlerini kusursuzlaştırdı. En karanlık sokaklarda pusuya yattı, saatlerce avını takip etti.\n\n. Kurbanlarından sanat eserleri yapmaktan zevk alırdı ve öldürdüğü kişilerin cesetlerine imzasını bırakmasıyla tanınırdı.</SerialMurderer47.description>
+  <SerialMurderer47.description>[PAWN_nameDef] insanları öldürmekten zevk almaya başladı, bu yüzden daha sık yaptı ve yöntemlerini kusursuzlaştırdı. En karanlık sokaklarda pusuya yattı, saatlerce avını takip etti.\n\nKurbanlarından sanat eserleri yapmaktan zevk alırdı ve öldürdüğü kişilerin cesetlerine imzasını bırakmasıyla tanınırdı.</SerialMurderer47.description>
   <!-- EN: serial murderer -->
   <SerialMurderer47.title>seri katil</SerialMurderer47.title>
   <SerialMurderer47.titleFemale>seri katil</SerialMurderer47.titleFemale>
@@ -1929,7 +1929,7 @@
   <SerialMurderer47.titleShortFemale>katil</SerialMurderer47.titleShortFemale>
   
   <!-- EN: After perfecting [PAWN_possessive] skills as a pathfinder, [PAWN_nameDef] left [PAWN_possessive] unit to put [PAWN_possessive] skills to use on the planets [PAWN_pronoun] helped chart.\n\nFamiliar with orbital trade routes, [PAWN_pronoun] was able to get onto and off any planet without being detected. -->
-  <ShadowMarine63.description>Kılavuz olarak becerilerini mükemmelleştirdikten sonra [PAWN_nameDef], yeteneklerini haritalamaya yardım ettiği gezegenlerde kullanmak için biriminden ayrıldı.\n\n Yörünge ticaret yollarına aşina olduğu için, tespit edilmeden herhangi bir gezegene girip çıkabiliyordu.</ShadowMarine63.description>
+  <ShadowMarine63.description>Kılavuz olarak becerilerini mükemmelleştirdikten sonra [PAWN_nameDef], yeteneklerini haritalamaya yardım ettiği gezegenlerde kullanmak için biriminden ayrıldı.\n\nYörünge ticaret yollarına aşina olduğu için, tespit edilmeden herhangi bir gezegene girip çıkabiliyordu.</ShadowMarine63.description>
   <!-- EN: shadow marine -->
   <ShadowMarine63.title>gölge bahriyeli</ShadowMarine63.title>
   <ShadowMarine63.titleFemale>gölge bahriyeli</ShadowMarine63.titleFemale>
@@ -1937,7 +1937,7 @@
   <ShadowMarine63.titleShort>bahriyeli</ShadowMarine63.titleShort>
   
   <!-- EN: When the monsters of fire came from the sky, [PAWN_nameDef] was called upon by [PAWN_possessive] tribe to guide them into battle.\n\n[PAWN_nameDef] made use of medicines and rituals to inspire and lead the warriors of many tribes against the invaders. The pirates were forced to retreat without capturing a single slave. -->
-  <ShamanOfShadows47.description>Ateş canavarları gökten geldiğinde, [PAWN_nameDef], onlara savaşta rehberlik etmesi için kabile tarafından çağrıldı.\n\n [PAWN_nameDef] istilacılara karşı birçok kabilenin savaşçılarına ilham vermek ve onlara önderlik etmek için ilaçlardan ve ritüellerden faydalandı. Korsanlar tek bir köle bile yakalamadan geri çekilmek zorunda kaldılar.</ShamanOfShadows47.description>
+  <ShamanOfShadows47.description>Ateş canavarları gökten geldiğinde, [PAWN_nameDef], onlara savaşta rehberlik etmesi için kabile tarafından çağrıldı.\n\n[PAWN_nameDef] istilacılara karşı birçok kabilenin savaşçılarına ilham vermek ve onlara önderlik etmek için ilaçlardan ve ritüellerden faydalandı. Korsanlar tek bir köle bile yakalamadan geri çekilmek zorunda kaldılar.</ShamanOfShadows47.description>
   <!-- EN: shaman of shadows -->
   <ShamanOfShadows47.title>gölgelerin şamanı</ShamanOfShadows47.title>
   <ShamanOfShadows47.titleFemale>gölgelerin şamanı</ShamanOfShadows47.titleFemale>
@@ -1946,7 +1946,7 @@
   <ShamanOfShadows47.titleShortFemale>şaman</ShamanOfShadows47.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was in a deep space shock troop unit deployed on multiple planets in various wars.\n\nDuring a risky assault, [PAWN_possessive] whole unit was wiped out. Nobody else knew what happened on the field that day, but [PAWN_nameDef] will carry the burden forever. -->
-  <ShockTrooper15.description>[PAWN_nameDef] çeşitli savaşlarda birden fazla gezegende konuşlandırılmış bir derin uzay şok birliği birimindeydi.\n\n Riskli bir saldırı sırasında tüm birimi yok edildi. O gün sahada ne olduğunu kimse bilmiyordu.[PAWN_nameDef] bu yükü sonsuza kadar taşıyacak.</ShockTrooper15.description>
+  <ShockTrooper15.description>[PAWN_nameDef] çeşitli savaşlarda birden fazla gezegende konuşlandırılmış bir derin uzay şok birliği birimindeydi.\n\nRiskli bir saldırı sırasında tüm birimi yok edildi. O gün sahada ne olduğunu kimse bilmiyordu.[PAWN_nameDef] bu yükü sonsuza kadar taşıyacak.</ShockTrooper15.description>
   <!-- EN: shock trooper -->
   <ShockTrooper15.title>Baskın Birliği</ShockTrooper15.title>
   <ShockTrooper15.titleFemale>Baskın Birliği</ShockTrooper15.titleFemale>
@@ -1955,7 +1955,7 @@
   <ShockTrooper15.titleShortFemale>baskın askeri</ShockTrooper15.titleShortFemale>
   
   <!-- EN: As a lawyer, [PAWN_nameDef] could convict a deaf man for stealing music. [PAWN_possessive] sharp mind and lack of empathy let [PAWN_objective] say anything to get the other person to talk. With the right amount of money, [PAWN_pronoun] knew, any case can be won.\n\n[PAWN_possessive] childhood cough never went away. -->
-  <SicklyLawyer49.description>Bir avukat olarak [PAWN_nameDef], sağır bir adamı müzik çaldığı için mahkum edebilir. Keskin zekası ve empati eksikliği, karşısındaki kişinin konuşmasını sağlamak için her şeyi söylemesine izin verir. Doğru miktarda parayla her davanın kazanılabileceğini biliyordu.\n\n Çocukluk öksürüğü hiç geçmedi.</SicklyLawyer49.description>
+  <SicklyLawyer49.description>Bir avukat olarak [PAWN_nameDef], sağır bir adamı müzik çaldığı için mahkum edebilir. Keskin zekası ve empati eksikliği, karşısındaki kişinin konuşmasını sağlamak için her şeyi söylemesine izin verir. Doğru miktarda parayla her davanın kazanılabileceğini biliyordu.\n\nÇocukluk öksürüğü hiç geçmedi.</SicklyLawyer49.description>
   <!-- EN: sickly lawyer -->
   <SicklyLawyer49.title>hasta avukat</SicklyLawyer49.title>
   <SicklyLawyer49.titleFemale>hasta avuka</SicklyLawyer49.titleFemale>
@@ -1964,7 +1964,7 @@
   <SicklyLawyer49.titleShortFemale>avukat</SicklyLawyer49.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] traveled the stars. [PAWN_pronoun] could barely scrape together travel costs doing odd-jobs, but it was all worth it.\n\n[PAWN_pronoun] loved camping in exotic places and learning the patterns of strange wildlife. [PAWN_pronoun] never could focus on intellectual endeavors, as [PAWN_possessive] sightseeing distracted [PAWN_objective] far too much. -->
-  <Sightseer70.description>[PAWN_nameDef] yıldızları gezdi. Garip işler yaparak seyahat masraflarını zar zor toparlayabiliyordu ama buna değdi.\n\n Egzotik yerlerde kamp yapmayı ve garip vahşi yaşam kalıplarını öğrenmeyi severdi. Gezip görmesi dikkatini çok fazla dağıttığı için asla entelektüel çabalara odaklanamadı.</Sightseer70.description>
+  <Sightseer70.description>[PAWN_nameDef] yıldızları gezdi. Garip işler yaparak seyahat masraflarını zar zor toparlayabiliyordu ama buna değdi.\n\nEgzotik yerlerde kamp yapmayı ve garip vahşi yaşam kalıplarını öğrenmeyi severdi. Gezip görmesi dikkatini çok fazla dağıttığı için asla entelektüel çabalara odaklanamadı.</Sightseer70.description>
   <!-- EN: sightseer -->
   <Sightseer70.title>turist</Sightseer70.title>
   <Sightseer70.titleFemale>turist</Sightseer70.titleFemale>
@@ -1982,7 +1982,7 @@
   <SlaveChemist84.titleShortFemale>eczacı</SlaveChemist84.titleShortFemale>
   
   <!-- EN: As a contract pilot, [PAWN_nameDef] had a knack for stealing goods and trafficking contraband without getting caught.\n\n[PAWN_pronoun] eventually saved up enough to buy [PAWN_possessive] own ship, and used it to travel from world to world dealing [PAWN_possessive] goods in person. -->
-  <Smuggler23.description>Bir sözleşmeli pilot olarak [PAWN_nameDef], yakalanmadan mal çalma ve kaçak mal ticareti yapma becerisine sahipti.\n\n Sonunda kendi gemisini satın alacak kadar biriktirdi ve mallarını şahsen satmak için dünyadan dünyaya seyahat etmek için kullandı.</Smuggler23.description>
+  <Smuggler23.description>Bir sözleşmeli pilot olarak [PAWN_nameDef], yakalanmadan mal çalma ve kaçak mal ticareti yapma becerisine sahipti.\n\nSonunda kendi gemisini satın alacak kadar biriktirdi ve mallarını şahsen satmak için dünyadan dünyaya seyahat etmek için kullandı.</Smuggler23.description>
   <!-- EN: smuggler -->
   <Smuggler23.title>kaçakçı</Smuggler23.title>
   <Smuggler23.titleFemale>kaçakçı</Smuggler23.titleFemale>
@@ -2009,7 +2009,7 @@
   <SoleSurvivor85.titleShortFemale>kurtulan</SoleSurvivor85.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] became a bartender on a space station. [PAWN_pronoun] interacted with and befriended many strangers.\n\nAs time went on, [PAWN_nameDef] used [PAWN_possessive] knowledge of herbs to craft [PAWN_possessive] own strange concoctions for [PAWN_possessive] customers. -->
-  <SpaceBartender0.description>[PAWN_nameDef] bir uzay istasyonunda barmen oldu. Pek çok yabancıyla etkileşime girdi ve arkadaş oldu.\n\n Zaman geçtikçe [PAWN_nameDef], müşterileri için kendi tuhaf karışımlarını yapmak için bitkiler hakkındaki bilgisini kullandı.</SpaceBartender0.description>
+  <SpaceBartender0.description>[PAWN_nameDef] bir uzay istasyonunda barmen oldu. Pek çok yabancıyla etkileşime girdi ve arkadaş oldu.\n\nZaman geçtikçe [PAWN_nameDef], müşterileri için kendi tuhaf karışımlarını yapmak için bitkiler hakkındaki bilgisini kullandı.</SpaceBartender0.description>
   <!-- EN: space bartender -->
   <SpaceBartender0.title>uzay barmeni</SpaceBartender0.title>
   <SpaceBartender0.titleFemale>uzay barmeni</SpaceBartender0.titleFemale>
@@ -2018,7 +2018,7 @@
   <SpaceBartender0.titleShortFemale>barmen</SpaceBartender0.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] spent years trapped, alone on an unknown planet. [PAWN_pronoun] quickly adapted to the local environment, and learned to communicate with [PAWN_possessive] local enemies.\n\nThis long period alone left [PAWN_objective] without close friends. [PAWN_possessive] heart is sensitive, but [PAWN_pronoun] learned to hide [PAWN_possessive] emotions very well. -->
-  <SpaceExplorer53.description>[PAWN_nameDef] bilinmeyen bir gezegende tek başına kapana kısılmış yıllarını geçirdi. Yerel ortama hızla uyum sağladı ve yerel düşmanlarıyla iletişim kurmayı öğrendi.\n\n Yalnız bu uzun dönem onu yakın arkadaşsız bıraktı. Kalbi hassastır ama duygularını saklamayı çok iyi öğrenmiştir.</SpaceExplorer53.description>
+  <SpaceExplorer53.description>[PAWN_nameDef] bilinmeyen bir gezegende tek başına kapana kısılmış yıllarını geçirdi. Yerel ortama hızla uyum sağladı ve yerel düşmanlarıyla iletişim kurmayı öğrendi.\n\nYalnız bu uzun dönem onu yakın arkadaşsız bıraktı. Kalbi hassastır ama duygularını saklamayı çok iyi öğrenmiştir.</SpaceExplorer53.description>
   <!-- EN: space explorer -->
   <SpaceExplorer53.title>uzay kaşifi</SpaceExplorer53.title>
   <SpaceExplorer53.titleFemale>uzay kaşifi</SpaceExplorer53.titleFemale>
@@ -2053,7 +2053,7 @@
   <SpaceMarine19.titleShort>donanma askeri</SpaceMarine19.titleShort>
   
   <!-- EN: [PAWN_nameDef] joined Interplanetary Marines to travel the stars fight for [PAWN_possessive] planet. [PAWN_pronoun] distinguished [PAWN_objective]self in several battles.\n\n[PAWN_possessive] experiences desensitized [PAWN_objective] to people around [PAWN_objective], and [PAWN_possessive] social skills degraded. But, [PAWN_pronoun] did learn how to fight. -->
-  <SpaceMarine5.description>[PAWN_nameDef] vatanı için yıldız savaşına katılmak üzere Gezegenler Arası Deniz Kuvvetlerine katıldı. Birkaç savaşta öne çıktı.\n\n Deneyimleri onu çevresindeki insanlara karşı duyarsızlaştırdı ve sosyal becerileri azaldı. Ancak savaşmayı öğrendi.</SpaceMarine5.description>
+  <SpaceMarine5.description>[PAWN_nameDef] vatanı için yıldız savaşına katılmak üzere Gezegenler Arası Deniz Kuvvetlerine katıldı. Birkaç savaşta öne çıktı.\n\nDeneyimleri onu çevresindeki insanlara karşı duyarsızlaştırdı ve sosyal becerileri azaldı. Ancak savaşmayı öğrendi.</SpaceMarine5.description>
   <!-- EN: space marine -->
   <SpaceMarine5.title>uzay donanması askeri</SpaceMarine5.title>
   <SpaceMarine5.titleFemale>uzay donanması askeri</SpaceMarine5.titleFemale>
@@ -2069,7 +2069,7 @@
   <SpaceMarine51.titleShort>donanma askeri</SpaceMarine51.titleShort>
   
   <!-- EN: [PAWN_nameDef] was a member of an elite imperial space warrior unit. Subjected to intense training, [PAWN_pronoun] developed remarkable combat skills.\n\n[PAWN_possessive] unit's quasi-religious ceremonies and beliefs helped [PAWN_objective] stay more-or-less sane through the horrors of the war. -->
-  <SpaceMarine9.description>[PAWN_nameDef] seçkin bir imparatorluk uzay savaşçısı biriminin üyesiydi. Yoğun eğitime tabi tutularak olağanüstü dövüş becerileri geliştirdi.\n\n. Birliğinin yarı dini törenleri ve inançları, savaşın dehşeti karşısında az çok aklı başında kalmasına yardımcı oldu.</SpaceMarine9.description>
+  <SpaceMarine9.description>[PAWN_nameDef] seçkin bir imparatorluk uzay savaşçısı biriminin üyesiydi. Yoğun eğitime tabi tutularak olağanüstü dövüş becerileri geliştirdi.\n\nBirliğinin yarı dini törenleri ve inançları, savaşın dehşeti karşısında az çok aklı başında kalmasına yardımcı oldu.</SpaceMarine9.description>
   <!-- EN: space marine -->
   <SpaceMarine9.title>uzay donanma askeri</SpaceMarine9.title>
   <SpaceMarine9.titleFemale>uzay donanma askeri</SpaceMarine9.titleFemale>
@@ -2077,7 +2077,7 @@
   <SpaceMarine9.titleShort>donanma askeri</SpaceMarine9.titleShort>
   
   <!-- EN: [PAWN_nameDef] was a warrior in an Imperial navy.\n\n[PAWN_possessive] job was to punch into enemy starships, gun down the crew, and capture the ship intact. And [PAWN_pronoun] was good at it. -->
-  <SpaceMarine94.description>[PAWN_nameDef] bir İmparatorluk donanmasında bir savaşçıydı.\n\n Görevi düşman yıldız gemilerini yumruklamak, mürettebatı öldürmek ve gemiyi sağlam bir şekilde ele geçirmekti. Ve bunda iyiydi.</SpaceMarine94.description>
+  <SpaceMarine94.description>[PAWN_nameDef] bir İmparatorluk donanmasında bir savaşçıydı.\n\nGörevi düşman yıldız gemilerini yumruklamak, mürettebatı öldürmek ve gemiyi sağlam bir şekilde ele geçirmekti. Ve bunda iyiydi.</SpaceMarine94.description>
   <!-- EN: space marine -->
   <SpaceMarine94.title>uzay donanma askeri</SpaceMarine94.title>
   <SpaceMarine94.titleFemale>uzay donanma askeri</SpaceMarine94.titleFemale>
@@ -2085,7 +2085,7 @@
   <SpaceMarine94.titleShort>donanma askeri</SpaceMarine94.titleShort>
   
   <!-- EN: [PAWN_nameDef] joined a colony contact expeditionary force as a medic. The mission turned bad when the colonists turned out to be suffering from a zombifying disease. [PAWN_pronoun] ran and fought for days.\n\nCornered with wounded men, [PAWN_pronoun] sprayed enough ammunition to wear out four machine gun barrels, and learned the value of high-volume fire. But [PAWN_possessive] nickname, Noob, stuck from that day forward. -->
-  <SpaceMarineMedic10.description>[PAWN_nameDef] bir sağlık görevlisi olarak bir koloni temas seferi kuvvetine katıldı. Sömürgecilerin zombileştirici bir hastalıktan muzdarip olduğu ortaya çıkınca görev kötüye gitti. Günlerce koştu ve savaştı.\n\n. Yaralı adamlarla köşeye sıkıştırılmış, dört makineli tüfek namlusunu aşındıracak kadar mühimmat püskürttü ve yüksek hacimli ateşin değerini öğrendi. Ama lakabı Noob, o günden sonra takılıp kaldı.</SpaceMarineMedic10.description>
+  <SpaceMarineMedic10.description>[PAWN_nameDef] bir sağlık görevlisi olarak bir koloni temas seferi kuvvetine katıldı. Sömürgecilerin zombileştirici bir hastalıktan muzdarip olduğu ortaya çıkınca görev kötüye gitti. Günlerce koştu ve savaştı.\n\nYaralı adamlarla köşeye sıkıştırılmış, dört makineli tüfek namlusunu aşındıracak kadar mühimmat püskürttü ve yüksek hacimli ateşin değerini öğrendi. Ama lakabı Noob, o günden sonra takılıp kaldı.</SpaceMarineMedic10.description>
   <!-- EN: space marine medic -->
   <SpaceMarineMedic10.title>uzay donanma sıhhıye</SpaceMarineMedic10.title>
   <SpaceMarineMedic10.titleFemale>uzay donanma sıhhıye</SpaceMarineMedic10.titleFemale>
@@ -2112,7 +2112,7 @@
   <SpaceNavyDoctor72.titleShortFemale>doktor</SpaceNavyDoctor72.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was in a space navy for the most powerful planet in the local star group. [PAWN_pronoun] developed skills in maintenance, electronic systems, radar and imaging, and logistics management.\n\n[PAWN_pronoun] served with pride and patriotic love for [PAWN_possessive] planet. -->
-  <SpaceNavyTech37.description>[PAWN_nameDef], yerel yıldız grubundaki en güçlü gezegen için bir uzay donanmasının içindeydi. Bakım, elektronik sistemler, radar ve görüntüleme ve lojistik yönetimi alanlarında beceriler geliştirdi.\n\n Gezegeni için gururla ve vatansever sevgiyle hizmet etti.</SpaceNavyTech37.description>
+  <SpaceNavyTech37.description>[PAWN_nameDef], yerel yıldız grubundaki en güçlü gezegen için bir uzay donanmasının içindeydi. Bakım, elektronik sistemler, radar ve görüntüleme ve lojistik yönetimi alanlarında beceriler geliştirdi.\n\nGezegeni için gururla ve vatansever sevgiyle hizmet etti.</SpaceNavyTech37.description>
   <!-- EN: space navy tech -->
   <SpaceNavyTech37.title>uzay donanması teknikeri</SpaceNavyTech37.title>
   <SpaceNavyTech37.titleFemale>uzay donanması teknikeri</SpaceNavyTech37.titleFemale>
@@ -2129,7 +2129,7 @@
   <SpaceRaider71.titleShortFemale>korsan</SpaceRaider71.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] inherited [PAWN_possessive] parents' ship and carried on their research.\n\n[PAWN_possessive] childhood experiences with diverse cultures allowed [PAWN_objective] to preserve [PAWN_possessive] caring nature despite spending most of [PAWN_possessive] life isolated in space. -->
-  <SpaceResearcher25.description>[PAWN_nameDef] ailesinin gemisini devraldı ve araştırmalarını sürdürdü.\n\n Farklı kültürlerle olan çocukluk deneyimleri, hayatının çoğunu uzayda izole edilmiş halde geçirmesine rağmen, sevecen doğasını korumasına izin verdi.</SpaceResearcher25.description>
+  <SpaceResearcher25.description>[PAWN_nameDef] ailesinin gemisini devraldı ve araştırmalarını sürdürdü.\n\nFarklı kültürlerle olan çocukluk deneyimleri, hayatının çoğunu uzayda izole edilmiş halde geçirmesine rağmen, sevecen doğasını korumasına izin verdi.</SpaceResearcher25.description>
   <!-- EN: space researcher -->
   <SpaceResearcher25.title>uzay araştırmacısı</SpaceResearcher25.title>
   <SpaceResearcher25.titleFemale>uzay araştırmacısı</SpaceResearcher25.titleFemale>
@@ -2174,7 +2174,7 @@
   <SpaceTechnician29.titleShortFemale>teknisyen</SpaceTechnician29.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] discovered [PAWN_pronoun] was heir of [PAWN_possessive] distant uncle's weapons-trading business.\n\nTo protect the future of the company [PAWN_pronoun] went through extensive military training, in case of any "unforeseen circumstances". -->
-  <SpaceTrafficker68.description>[PAWN_nameDef], uzaktaki amcasının silah ticareti işinin varisi olduğunu keşfetti.\n\n Şirketin geleceğini korumak için, herhangi bir "öngörülemeyen durum" durumunda kapsamlı askeri eğitimden geçti.</SpaceTrafficker68.description>
+  <SpaceTrafficker68.description>[PAWN_nameDef], uzaktaki amcasının silah ticareti işinin varisi olduğunu keşfetti.\n\nŞirketin geleceğini korumak için, herhangi bir "öngörülemeyen durum" durumunda kapsamlı askeri eğitimden geçti.</SpaceTrafficker68.description>
   <!-- EN: space trafficker -->
   <SpaceTrafficker68.title>space trafficker</SpaceTrafficker68.title>
   <SpaceTrafficker68.titleFemale>space trafficker</SpaceTrafficker68.titleFemale>
@@ -2183,7 +2183,7 @@
   <SpaceTrafficker68.titleShortFemale>tacir</SpaceTrafficker68.titleShortFemale>
   
   <!-- EN: Give me a reason to kill - a good reason.\n\n[PAWN_nameDef] was a soldier and a skilled one - so skilled that [PAWN_pronoun] entered the special forces to battle militants and xenohuman raiders. [PAWN_pronoun] never imagined [PAWN_objective]self as lone hero, but [PAWN_pronoun] played [PAWN_possessive] part in the group well. -->
-  <SpecialForces13.description>Bana öldürmem için bir sebep söyle - iyi bir sebep.\n\n [PAWN_nameDef] bir askerdi ve yetenekliydi - o kadar yetenekliydi ki militanlarla ve xenohuman akıncılarıyla savaşmak için özel kuvvetlere girdi. Kendini asla yalnız bir kahraman olarak düşünmedi ama gruptaki rolünü iyi oynadı.</SpecialForces13.description>
+  <SpecialForces13.description>Bana öldürmem için bir sebep söyle - iyi bir sebep.\n\n[PAWN_nameDef] bir askerdi ve yetenekliydi - o kadar yetenekliydi ki militanlarla ve xenohuman akıncılarıyla savaşmak için özel kuvvetlere girdi. Kendini asla yalnız bir kahraman olarak düşünmedi ama gruptaki rolünü iyi oynadı.</SpecialForces13.description>
   <!-- EN: special forces -->
   <SpecialForces13.title>özel kuvvetler</SpecialForces13.title>
   <SpecialForces13.titleFemale>özel kuvvetler</SpecialForces13.titleFemale>
@@ -2192,7 +2192,7 @@
   <SpecialForces13.titleShortFemale>bordo bereli</SpecialForces13.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] made [PAWN_possessive] mark on the universe as a spice miner assigned to the lucrative mining colony of Rural Pen'The.\n\nLittle did [PAWN_pronoun] know, [PAWN_nameDef] was about to embark on a career path that would change [PAWN_possessive] life. -->
-  <Spiceminer81.description>[PAWN_nameDef], Rural Pen'The'nin kazançlı madencilik kolonisine atanan bir baharat madencisi olarak evrene damgasını vurdu.\n\n [PAWN_nameDef]'nin hayatını değiştirecek bir kariyer yoluna girmek üzere olduğunu bilmiyordu.</Spiceminer81.description>
+  <Spiceminer81.description>[PAWN_nameDef], Rural Pen'The'nin kazançlı madencilik kolonisine atanan bir baharat madencisi olarak evrene damgasını vurdu.\n\n[PAWN_nameDef]'nin hayatını değiştirecek bir kariyer yoluna girmek üzere olduğunu bilmiyordu.</Spiceminer81.description>
   <!-- EN: spiceminer -->
   <Spiceminer81.title>uzay madencisi</Spiceminer81.title>
   <Spiceminer81.titleFemale>uzay madencisi</Spiceminer81.titleFemale>
@@ -2219,7 +2219,7 @@
   <StalwartFarmer21.titleShortFemale>çiftçi</StalwartFarmer21.titleShortFemale>
   
   <!-- EN: With the farm under constant threat from brigands, [PAWN_nameDef] learned to defend [PAWN_objective]self with [PAWN_possessive] father's rifle. [PAWN_pronoun] also mastered how to construct walls to keep livestock in and predators out.\n\n[PAWN_pronoun] once tried to paint a picture of [PAWN_possessive] home, but discovered that [PAWN_pronoun] could only draw scribbles and ducks. -->
-  <StalwartFarmer90.description>Çiftlik, haydutların sürekli tehdidi altındayken, [PAWN_nameDef] babasının tüfeğiyle kendini savunmayı öğrendi. Ayrıca hayvanları içeride ve yırtıcıları dışarıda tutmak için duvarlar inşa etmeyi de öğrendi.\n\n. Bir keresinde evinin resmini çizmeye çalışmış ama sadece karalamalar ve ördekler çizebildiğini keşfetti.</StalwartFarmer90.description>
+  <StalwartFarmer90.description>Çiftlik, haydutların sürekli tehdidi altındayken, [PAWN_nameDef] babasının tüfeğiyle kendini savunmayı öğrendi. Ayrıca hayvanları içeride ve yırtıcıları dışarıda tutmak için duvarlar inşa etmeyi de öğrendi.\n\nBir keresinde evinin resmini çizmeye çalışmış ama sadece karalamalar ve ördekler çizebildiğini keşfetti.</StalwartFarmer90.description>
   <!-- EN: stalwart farmer -->
   <StalwartFarmer90.title>gözü pek çiftçi</StalwartFarmer90.title>
   <StalwartFarmer90.titleFemale>gözü pek çiftçi</StalwartFarmer90.titleFemale>
@@ -2228,7 +2228,7 @@
   <StalwartFarmer90.titleShortFemale>çiftçi</StalwartFarmer90.titleShortFemale>
   
   <!-- EN: After years of training and drilling, [PAWN_nameDef] finally became a starfighter pilot.\n\nHundreds of combat missions later, [PAWN_pronoun] grew bored and started seeking newer thrills. [PAWN_pronoun] joined a band of space pirates, which eagerly welcomed [PAWN_objective] because of [PAWN_possessive] piloting skill. -->
-  <StarfighterPilot79.description>Yıllarca süren eğitim ve sondajdan sonra [PAWN_nameDef] sonunda bir yıldız savaş uçağı pilotu oldu.\n\n. Yüzlerce savaş görevinden sonra sıkıldı ve yeni heyecanlar aramaya başladı. Pilotluk becerisi nedeniyle onu hevesle karşılayan bir uzay korsanları grubuna katıldı.</StarfighterPilot79.description>
+  <StarfighterPilot79.description>Yıllarca süren eğitim ve sondajdan sonra [PAWN_nameDef] sonunda bir yıldız savaş uçağı pilotu oldu.\n\nYüzlerce savaş görevinden sonra sıkıldı ve yeni heyecanlar aramaya başladı. Pilotluk becerisi nedeniyle onu hevesle karşılayan bir uzay korsanları grubuna katıldı.</StarfighterPilot79.description>
   <!-- EN: starfighter pilot -->
   <StarfighterPilot79.title>yıldız savaş uçağı pilotu</StarfighterPilot79.title>
   <StarfighterPilot79.titleFemale>yıldız savaş uçağı pilotu</StarfighterPilot79.titleFemale>
@@ -2237,7 +2237,7 @@
   <StarfighterPilot79.titleShortFemale>pilot</StarfighterPilot79.titleShortFemale>
   
   <!-- EN: Abducted from [PAWN_possessive] medieval homeworld, [PAWN_nameDef] later escaped [PAWN_possessive] captors via an impressive display of swordsmanship.\n\nFor a moment, as [PAWN_pronoun] drifted in the escape pod, [PAWN_possessive] childhood dream of becoming a knight among the stars felt so real. Then [PAWN_pronoun] crash-landed. -->
-  <StarKnight5.description>Orta çağdaki anavatanından kaçırılan [PAWN_nameDef] daha sonra etkileyici bir kılıç ustalığıyla kendisini esir alanlardan kaçtı.\n\n Bir an için, kaçış kapsülünde sürüklenirken, çocukluk hayali olan yıldızlar arasında bir şövalye olma hayali çok gerçekmiş gibi geldi. Sonra acil iniş yaptı.</StarKnight5.description>
+  <StarKnight5.description>Orta çağdaki anavatanından kaçırılan [PAWN_nameDef] daha sonra etkileyici bir kılıç ustalığıyla kendisini esir alanlardan kaçtı.\n\nBir an için, kaçış kapsülünde sürüklenirken, çocukluk hayali olan yıldızlar arasında bir şövalye olma hayali çok gerçekmiş gibi geldi. Sonra acil iniş yaptı.</StarKnight5.description>
   <!-- EN: star knight -->
   <StarKnight5.title>yıldız şovalye</StarKnight5.title>
   <StarKnight5.titleFemale>yıldız şovalye</StarKnight5.titleFemale>
@@ -2255,7 +2255,7 @@
   <StarshipDoctor37.titleShortFemale>doktor</StarshipDoctor37.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] enrolled in the state weapons research program.\n\nWhile brilliant in [PAWN_possessive] work, [PAWN_pronoun] was so enthusiastic in testing [PAWN_possessive] creations that [PAWN_pronoun] accidentally wounded some colleagues and was marked as unfit for service. -->
-  <StateEngineer60.description>[PAWN_nameDef] eyalet silahları araştırma programına kaydoldu.\n\n. İşinde parlak olmasına rağmen -yarattıklarını test etme konusunda o kadar hevesliydi- yanlışlıkla bazı meslektaşlarını yaraladı ve hizmet için uygun değil olarak işaretlendi.</StateEngineer60.description>
+  <StateEngineer60.description>[PAWN_nameDef] eyalet silahları araştırma programına kaydoldu.\n\nİşinde parlak olmasına rağmen -yarattıklarını test etme konusunda o kadar hevesliydi- yanlışlıkla bazı meslektaşlarını yaraladı ve hizmet için uygun değil olarak işaretlendi.</StateEngineer60.description>
   <!-- EN: state engineer -->
   <StateEngineer60.title>devlet mühendisi</StateEngineer60.title>
   <StateEngineer60.titleFemale>devlet mühendisi</StateEngineer60.titleFemale>
@@ -2264,16 +2264,16 @@
   <StateEngineer60.titleShortFemale>mühendis</StateEngineer60.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was commissioned as a special constable on a network of space stations. There [PAWN_pronoun] prevented illegal human trafficking.\n\nOnce, fire broke out on the station, and [PAWN_pronoun] saved many from the flames. Since then, [PAWN_pronoun] has avoided fires. -->
-  <StationSecurity38.description>[PAWN_nameDef], uzay istasyonları ağında özel bir polis memuru olarak görevlendirildi. Orada yasa dışı insan ticaretini engelledi.\n\n. Bir keresinde istasyonda yangın çıktı ve birçoğunu alevlerden kurtardı. O zamandan beri yangınlardan kaçındı.</StationSecurity38.description>
+  <StationSecurity38.description>[PAWN_nameDef], uzay istasyonları ağında özel bir polis memuru olarak görevlendirildi. Orada yasa dışı insan ticaretini engelledi.\n\nBir keresinde istasyonda yangın çıktı ve birçoğunu alevlerden kurtardı. O zamandan beri yangınlardan kaçındı.</StationSecurity38.description>
   <!-- EN: station security -->
-  <StationSecurity38.title>istasyon güvenliği</StationSecurity38.title>
-  <StationSecurity38.titleFemale>istasyon güvenliği</StationSecurity38.titleFemale>
+  <StationSecurity38.title>İstasyon güvenliği</StationSecurity38.title>
+  <StationSecurity38.titleFemale>İstasyon güvenliği</StationSecurity38.titleFemale>
   <!-- EN: security -->
   <StationSecurity38.titleShort>güvenlik</StationSecurity38.titleShort>
   <StationSecurity38.titleShortFemale>güvenlik</StationSecurity38.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was captain of a pirate ship. [PAWN_pronoun] and [PAWN_possessive] crew made their living capturing traders who wandered off-course.\n\n[PAWN_pronoun] was known for [PAWN_possessive] balanced approach to problems, building, fighting, or negotiating as needed. -->
-  <StellarPirate10.description>[PAWN_nameDef] bir korsan gemisinin kaptanıydı. O ve ekibi, rotadan sapan tüccarları yakalayarak geçimlerini sağladılar.\n\n. Sorunlara, inşa etmeye, savaşmaya veya gerektiğinde müzakere etmeye dengeli yaklaşımıyla tanınırdı.</StellarPirate10.description>
+  <StellarPirate10.description>[PAWN_nameDef] bir korsan gemisinin kaptanıydı. O ve ekibi, rotadan sapan tüccarları yakalayarak geçimlerini sağladılar.\n\nSorunlara, inşa etmeye, savaşmaya veya gerektiğinde müzakere etmeye dengeli yaklaşımıyla tanınırdı.</StellarPirate10.description>
   <!-- EN: stellar pirate -->
   <StellarPirate10.title>yıldız korsanı</StellarPirate10.title>
   <StellarPirate10.titleFemale>yıldız korsanı</StellarPirate10.titleFemale>
@@ -2282,7 +2282,7 @@
   <StellarPirate10.titleShortFemale>korsan</StellarPirate10.titleShortFemale>
   
   <!-- EN: Because of [PAWN_possessive] skills, [PAWN_nameDef] developed a sense of superiority. In time, [PAWN_pronoun] lost [PAWN_possessive] sense of empathy. [PAWN_pronoun] often got into fights, and discovered how easy it is to kill a person.\n\nAfter realizing [PAWN_possessive] talents, [PAWN_pronoun] became one of the most efficient assassins in the system. -->
-  <StilettoAssassin34.description>[PAWN_nameDef] yetenekleri nedeniyle bir üstünlük duygusu geliştirdi. Zamanla empati duygusunu kaybetti. Sık sık kavgalara karıştı ve bir insanı öldürmenin ne kadar kolay olduğunu keşfetti.\n\n Yeteneklerini fark ettikten sonra, sistemdeki en verimli suikastçılardan biri oldu.</StilettoAssassin34.description>
+  <StilettoAssassin34.description>[PAWN_nameDef] yetenekleri nedeniyle bir üstünlük duygusu geliştirdi. Zamanla empati duygusunu kaybetti. Sık sık kavgalara karıştı ve bir insanı öldürmenin ne kadar kolay olduğunu keşfetti.\n\nYeteneklerini fark ettikten sonra, sistemdeki en verimli suikastçılardan biri oldu.</StilettoAssassin34.description>
   <!-- EN: stiletto assassin -->
   <StilettoAssassin34.title>stiletto suikastçi</StilettoAssassin34.title>
   <StilettoAssassin34.titleFemale>stiletto suikastçi</StilettoAssassin34.titleFemale>
@@ -2291,7 +2291,7 @@
   <StilettoAssassin34.titleShortFemale>suikastçi</StilettoAssassin34.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] traveled [PAWN_possessive] world recounting the legends that [PAWN_pronoun] had studied.\n\nObsessed with the legends of [PAWN_possessive] people, [PAWN_nameDef] seeks someone who can help [PAWN_objective] grow scales on [PAWN_possessive] skin, so [PAWN_pronoun] too can be as the ancients were. -->
-  <Storyteller63.description>[PAWN_nameDef], öğrendiği efsaneleri anlatarak dünyasını dolaştı.\n\n. Halkının efsanelerine kafayı takmış olan [PAWN_nameDef], eskiler gibi olabilmek için cildinde pullanmalara yardımcı olabilecek birini arıyor.</Storyteller63.description>
+  <Storyteller63.description>[PAWN_nameDef], öğrendiği efsaneleri anlatarak dünyasını dolaştı.\n\nHalkının efsanelerine kafayı takmış olan [PAWN_nameDef], eskiler gibi olabilmek için cildinde pullanmalara yardımcı olabilecek birini arıyor.</Storyteller63.description>
   <!-- EN: storyteller -->
   <Storyteller63.title>meddah</Storyteller63.title>
   <Storyteller63.titleFemale>meddah</Storyteller63.titleFemale>
@@ -2327,7 +2327,7 @@
   <SystemLord77.titleShortFemale>lord</SystemLord77.titleShortFemale>
   
   <!-- EN: Like [PAWN_possessive] father, [PAWN_nameDef] was a systems engineer. [PAWN_pronoun] was qualified in both colony and ship systems.\n\nWhen not working, [PAWN_pronoun] would make mechanical figurines, read old books, or occasionally travel to uncharted worlds. Being introverted, [PAWN_pronoun] did these things mostly alone. -->
-  <SystemsEngineer1.description>[PAWN_nameDef] babası gibi bir sistem mühendisiydi. Hem koloni hem de gemi sistemlerinde yetkindi.\n\n Çalışmadığı zamanlarda mekanik heykelcikler yapar, eski kitapları okur ya da ara sıra keşfedilmemiş dünyalara seyahat ederdi. İçine kapanık olduğundan, bu işleri çoğunlukla yalnız yaptı.</SystemsEngineer1.description>
+  <SystemsEngineer1.description>[PAWN_nameDef] babası gibi bir sistem mühendisiydi. Hem koloni hem de gemi sistemlerinde yetkindi.\n\nÇalışmadığı zamanlarda mekanik heykelcikler yapar, eski kitapları okur ya da ara sıra keşfedilmemiş dünyalara seyahat ederdi. İçine kapanık olduğundan, bu işleri çoğunlukla yalnız yaptı.</SystemsEngineer1.description>
   <!-- EN: systems engineer -->
   <SystemsEngineer1.title>sistem mühendisi</SystemsEngineer1.title>
   <SystemsEngineer1.titleFemale>sistem mühendisi</SystemsEngineer1.titleFemale>
@@ -2344,7 +2344,7 @@
   <Technician9.titleShort>teknoloji kurdu</Technician9.titleShort>
   
   <!-- EN: [PAWN_nameDef] was a farmer on [PAWN_possessive] midworld, and spent [PAWN_possessive] free time practicing with guns. [PAWN_pronoun] knew how important the skills of farming and shooting would be in hard times, and trained to serve in a local militia. -->
-  <TechnologyDoctor35.description>[PAWN_nameDef], itici yakıtlar ve enerji üretimi konusunda araştırma yaptı.\n\n. Teknoloji araştırmalarını seviyordu ve bunu yaparak insan yaşamını iyileştirmeyi umuyordu.</TechnologyDoctor35.description>
+  <TechnologyDoctor35.description>[PAWN_nameDef], itici yakıtlar ve enerji üretimi konusunda araştırma yaptı.\n\nTeknoloji araştırmalarını seviyordu ve bunu yaparak insan yaşamını iyileştirmeyi umuyordu.</TechnologyDoctor35.description>
   <!-- EN: soldier-farmer -->
   <TechnologyDoctor35.title>teknoloji doktoru</TechnologyDoctor35.title>
   <TechnologyDoctor35.titleFemale>teknoloji doktoru</TechnologyDoctor35.titleFemale>
@@ -2366,14 +2366,14 @@
   <TestSubject90.titleShort>denek</TestSubject90.titleShort>
   
   <!-- EN: [PAWN_nameDef]'s tests went from geometry to quantum physics, and [PAWN_pronoun] could run the grand gauntlet without a scratch.\n\nOne day, Mother said that [PAWN_possessive] final test lay beyond the red door, and that even if [PAWN_pronoun] couldn't hear her voice, Mother would always be there. -->
-  <TestSubject92.description>[PAWN_nameDef]'nin testleri geometriden kuantum fiziğine geçti ve büyük sınava zahmetsiz ilerledi.\n\n.Bir gün annem son sınavının kırmızı kapının ötesinde olduğunu ve -esini duymasa bile- annesinin her zaman orada olacağını söyledi.</TestSubject92.description>
+  <TestSubject92.description>[PAWN_nameDef]'nin testleri geometriden kuantum fiziğine geçti ve büyük sınava zahmetsiz ilerledi.\n\nBir gün annem son sınavının kırmızı kapının ötesinde olduğunu ve -esini duymasa bile- annesinin her zaman orada olacağını söyledi.</TestSubject92.description>
   <!-- EN: test subject -->
   <TestSubject92.title>denek</TestSubject92.title>
   <!-- EN: subject -->
   <TestSubject92.titleShort>denek</TestSubject92.titleShort>
   
   <!-- EN: [PAWN_nameDef] spent countless hours behind the scenes of a famous theater. [PAWN_pronoun] built scenery, programmed lights, and monitored the machines that moved the sets.\n\nOff duty, [PAWN_pronoun] would talk with the cast members. Navigating the social drama of the actors helped [PAWN_objective] learn how to communicate well and manipulate others. -->
-  <TheaterTechnician80.description>[PAWN_nameDef] ünlü bir tiyatronun perde arkasında sayısız saatler geçirdi. Sahne inşa etti, ışıkları programladı ve setleri hareket ettiren makineleri izledi.\n\n Görev dışında, oyuncularla konuşurdu. Oyuncularla konuşarak iyi iletişim kurmayı ve başkalarını manipüle etmeyi öğrenmesine yardımcı oldu.</TheaterTechnician80.description>
+  <TheaterTechnician80.description>[PAWN_nameDef] ünlü bir tiyatronun perde arkasında sayısız saatler geçirdi. Sahne inşa etti, ışıkları programladı ve setleri hareket ettiren makineleri izledi.\n\nGörev dışında, oyuncularla konuşurdu. Oyuncularla konuşarak iyi iletişim kurmayı ve başkalarını manipüle etmeyi öğrenmesine yardımcı oldu.</TheaterTechnician80.description>
   <!-- EN: theater technician -->
   <TheaterTechnician80.title>tiyatro teknisyeni</TheaterTechnician80.title>
   <TheaterTechnician80.titleFemale>tiyatro teknisyeni</TheaterTechnician80.titleFemale>
@@ -2382,7 +2382,7 @@
   <TheaterTechnician80.titleShortFemale>teknisyen</TheaterTechnician80.titleShortFemale>
   
   <!-- EN: "How does this work?\n\nWhy does this move?\n\nMaybe if I change this... oops, I hope it works better... or maybe I broke it..." -->
-  <Tinkerer86.description>"Bu nasıl çalışıyor?\n\n. Bu neden hareket ediyor?\n\n. Belki bunu değiştirirsem... oops, umarım daha iyi çalışır... ya da belki kırmışımdır..."</Tinkerer86.description>
+  <Tinkerer86.description>"Bu nasıl çalışıyor?\n\nBu neden hareket ediyor?\n\nBelki bunu değiştirirsem... oops, umarım daha iyi çalışır... ya da belki kırmışımdır..."</Tinkerer86.description>
   <!-- EN: tinkerer -->
   <Tinkerer86.title>tamirci</Tinkerer86.title>
   <Tinkerer86.titleFemale>tamirci</Tinkerer86.titleFemale>
@@ -2391,7 +2391,7 @@
   <Tinkerer86.titleShortFemale>tamirci</Tinkerer86.titleShortFemale>
   
   <!-- EN: Good with [PAWN_possessive] hands and passionate about technology, [PAWN_nameDef] aspired to invent gadgets and machines that would change [PAWN_possessive] home world forever.\n\nA few failed and occasionally disastrous creations later, [PAWN_pronoun] gave up on [PAWN_possessive] dream and took a job more befitting [PAWN_possessive] skill set. -->
-  <ToasterRepairman22.description>Ellerini iyi kullanan ve teknoloji konusunda tutkulu olan [PAWN_nameDef], kendi dünyasını sonsuza dek değiştirecek aygıtlar ve makineler icat etmeye can atıyordu.\n\n Birkaç başarısız ve feci kreasyonlardan sonra hayalinden vazgeçti ve becerilerine daha uygun bir işe girdi.</ToasterRepairman22.description>
+  <ToasterRepairman22.description>Ellerini iyi kullanan ve teknoloji konusunda tutkulu olan [PAWN_nameDef], kendi dünyasını sonsuza dek değiştirecek aygıtlar ve makineler icat etmeye can atıyordu.\n\nBirkaç başarısız ve feci kreasyonlardan sonra hayalinden vazgeçti ve becerilerine daha uygun bir işe girdi.</ToasterRepairman22.description>
   <!-- EN: toaster repairman -->
   <ToasterRepairman22.title>tost makinesi tamircisi</ToasterRepairman22.title>
   <ToasterRepairman22.titleFemale>tost makinesi tamircisi</ToasterRepairman22.titleFemale>
@@ -2400,7 +2400,7 @@
   <ToasterRepairman22.titleShortFemale>tamirci</ToasterRepairman22.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was a famous tool mechanic on a dusty rimworld.\n\nAfter [PAWN_possessive] firm closed due to scandal, [PAWN_pronoun] joined a tribe to survive, crafting fine knives and hammers, traveling, and dealing [PAWN_possessive] wares between settlements. -->
-  <ToolMechanic77.description>[PAWN_nameDef] kirli bir rimworld'de ünlü bir alet edavat mekaniğiydi.\n\n Firması bi skandal nedeniyle kapandıktan sonra hayatta kalmak için bir kabileye katıldı, güzel bıçaklar ve çekiçler yaptı, seyahat etti ve mallarını yerleşimler arasında sattı.</ToolMechanic77.description>
+  <ToolMechanic77.description>[PAWN_nameDef] kirli bir rimworld'de ünlü bir alet edavat mekaniğiydi.\n\nFirması bi skandal nedeniyle kapandıktan sonra hayatta kalmak için bir kabileye katıldı, güzel bıçaklar ve çekiçler yaptı, seyahat etti ve mallarını yerleşimler arasında sattı.</ToolMechanic77.description>
   <!-- EN: tool mechanic -->
   <ToolMechanic77.title>alet edavat mekaniği</ToolMechanic77.title>
   <ToolMechanic77.titleFemale>alet edavat mekaniği</ToolMechanic77.titleFemale>
@@ -2427,7 +2427,7 @@
   <TravelingBard93.titleShortFemale>müzikçi</TravelingBard93.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] explored outlying rimworlds in hopes of finding rare treasures.\n\nAfter succeeding in finding one legendary sculpture, [PAWN_pronoun] was betrayed by [PAWN_possessive] men. [PAWN_pronoun] survived their treasonous attack, but the sculpture was taken.\n\n[PAWN_pronoun] created the Anvil Mercenary Company to help [PAWN_objective] seek revenge. -->
-  <TreasureHunter82.description>[PAWN_nameDef], nadir hazineler bulma umuduyla uzaktaki rimworld'leri keşfetti.\n\n Efsanevi bir heykel bulmayı başardıktan sonra adamları tarafından ihanete uğradı. Onların hain saldırılarından kurtuldu ancak heykel elinden alındı.\n\n Örs Paralı Asker Bölüğü'nü intikam almasına yardım etmesi için kurdu.</TreasureHunter82.description>
+  <TreasureHunter82.description>[PAWN_nameDef], nadir hazineler bulma umuduyla uzaktaki rimworld'leri keşfetti.\n\nEfsanevi bir heykel bulmayı başardıktan sonra adamları tarafından ihanete uğradı. Onların hain saldırılarından kurtuldu ancak heykel elinden alındı.\n\nÖrs Paralı Asker Bölüğü'nü intikam almasına yardım etmesi için kurdu.</TreasureHunter82.description>
   <!-- EN: treasure hunter -->
   <TreasureHunter82.title>hazine avcısı</TreasureHunter82.title>
   <TreasureHunter82.titleFemale>hazine avcısı</TreasureHunter82.titleFemale>
@@ -2445,7 +2445,7 @@
   <Undertaker93.titleShortFemale>mezarcı</Undertaker93.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] became a doctor to save lives and research medicine. [PAWN_pronoun] soon realized the only way to make progress on [PAWN_possessive] research was to perform experiments on human patients.\n\n[PAWN_pronoun] often used patients for [PAWN_possessive] experiments - whether they were willing or not. -->
-  <UnethicalDoctor29.description>[PAWN_nameDef] hayat kurtarmak ve tıp alanında araştırmalar yapmak için doktor oldu. Kısa süre sonra araştırmasında ilerleme kaydetmenin tek yolunun insan hastalar üzerinde deneyler yapmak olduğunu anladı.\n\n Deneyleri için sık sık hastaları kullandı - isteseler de istemeseler de.</UnethicalDoctor29.description>
+  <UnethicalDoctor29.description>[PAWN_nameDef] hayat kurtarmak ve tıp alanında araştırmalar yapmak için doktor oldu. Kısa süre sonra araştırmasında ilerleme kaydetmenin tek yolunun insan hastalar üzerinde deneyler yapmak olduğunu anladı.\n\nDeneyleri için sık sık hastaları kullandı - isteseler de istemeseler de.</UnethicalDoctor29.description>
   <!-- EN: unethical doctor -->
   <UnethicalDoctor29.title>Nazi doktor</UnethicalDoctor29.title>
   <UnethicalDoctor29.titleFemale>Nazi doktor</UnethicalDoctor29.titleFemale>
@@ -2463,7 +2463,7 @@
   <UnstableButcher31.titleShortFemale>kasap</UnstableButcher31.titleShortFemale>
   
   <!-- EN: As a diplomat, [PAWN_nameDef] was assigned to deal with diplomatic tasks in the blood-soaked outer rim sectors.\n\n[PAWN_pronoun] hoped to end the endless wars, until [PAWN_possessive] consularship, the St. Anthem, was attacked by a raider fleet. -->
-  <UprightDiplomat49.description>Bir diplomat olarak [PAWN_nameDef], kana bulanmış dış çember sektörlerinde diplomatik görevlerle ilgilenmek üzere görevlendirildi.\n\n Konsolosluğu, Aziz Martha isimli bir akıncı filosu tarafından saldırıya uğrayana kadar bitmek bilmeyen savaşları sona erdirmeyi umuyordu.</UprightDiplomat49.description>
+  <UprightDiplomat49.description>Bir diplomat olarak [PAWN_nameDef], kana bulanmış dış çember sektörlerinde diplomatik görevlerle ilgilenmek üzere görevlendirildi.\n\nKonsolosluğu, Aziz Martha isimli bir akıncı filosu tarafından saldırıya uğrayana kadar bitmek bilmeyen savaşları sona erdirmeyi umuyordu.</UprightDiplomat49.description>
   <!-- EN: upright diplomat -->
   <UprightDiplomat49.title>namuslu diplomat</UprightDiplomat49.title>
   <UprightDiplomat49.titleFemale>namuslu diplomat</UprightDiplomat49.titleFemale>
@@ -2472,7 +2472,7 @@
   <UprightDiplomat49.titleShortFemale>diplomat</UprightDiplomat49.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was an enforcer of law on an ancient urbworld.\n\n[PAWN_pronoun] dealt with the worst of humanity, from protecting greedy urbworld nobility in their spire palaces to rooting out cannibal cults in the deepest reaches of the underground hive. -->
-  <UrbworldEnforcer11.description>[PAWN_nameDef] eski bir urbworld'de kanun adamıydı.\n\n Açgözlü urbworld soylularını kuleli saraylarında korumaktan, yeraltı dünyasındaki yamyam kültlerinin kökünü kazımaya kadar, insanların en kötüsüyle uğraştı.</UrbworldEnforcer11.description>
+  <UrbworldEnforcer11.description>[PAWN_nameDef] eski bir urbworld'de kanun adamıydı.\n\nAçgözlü urbworld soylularını kuleli saraylarında korumaktan, yeraltı dünyasındaki yamyam kültlerinin kökünü kazımaya kadar, insanların en kötüsüyle uğraştı.</UrbworldEnforcer11.description>
   <!-- EN: urbworld enforcer -->
   <UrbworldEnforcer11.title>urbworld'lü kanun adamı</UrbworldEnforcer11.title>
   <UrbworldEnforcer11.titleFemale>urbworld'lü kanun adamı</UrbworldEnforcer11.titleFemale>
@@ -2481,7 +2481,7 @@
   <UrbworldEnforcer11.titleShortFemale>kanun adamı</UrbworldEnforcer11.titleShortFemale>
   
   <!-- EN: At first, [PAWN_nameDef] made a small profit from selling drugs. Then, [PAWN_pronoun] switched to selling women and made a fortune.\n\n[PAWN_pronoun] developed great skills with [PAWN_possessive] fists. [PAWN_pronoun] also learned to fix up the injuries [PAWN_pronoun] inflicted on the girls. -->
-  <UrbworldPimp93.description>İlk başta, [PAWN_nameDef] uyuşturucu satarak küçük bir kâr elde etti. Ardından kadın satmaya başladı ve servet kazandı.\n\n Yumruklarıyla büyük bir gelişim sağladı. Ayrıca kızlara verdiği yaraları iyileştirmeyi de öğrendi.</UrbworldPimp93.description>
+  <UrbworldPimp93.description>İlk başta, [PAWN_nameDef] uyuşturucu satarak küçük bir kâr elde etti. Ardından kadın satmaya başladı ve servet kazandı.\n\nYumruklarıyla büyük bir gelişim sağladı. Ayrıca kızlara verdiği yaraları iyileştirmeyi de öğrendi.</UrbworldPimp93.description>
   <!-- EN: urbworld pimp -->
   <UrbworldPimp93.title>urbworld'lü pezevenk</UrbworldPimp93.title>
   <UrbworldPimp93.titleFemale>urbworld'lü pezevenk</UrbworldPimp93.titleFemale>
@@ -2490,7 +2490,7 @@
   <UrbworldPimp93.titleShortFemale>pezevenk</UrbworldPimp93.titleShortFemale>
   
   <!-- EN: It's no secret that the Companies own much of the urbworlds, but someone has to take the bribes. [PAWN_nameDef] was one such figurehead.\n\n[PAWN_pronoun] learned how to manipulate the hopes and dreams of the people while living comfortably in a penthouse. -->
-  <UrbworldPolitican92.description>Şirketlerin urbworld'lerin çoğuna sahip olduğu bir yerde birinin rüşvet alması gerekiyor. [PAWN_nameDef] böyle bir figürdü.\n\n Bir çatı katında rahatça yaşarken insanların umutlarını ve hayallerini nasıl manipüle edeceğini öğrendi.</UrbworldPolitican92.description>
+  <UrbworldPolitican92.description>Şirketlerin urbworld'lerin çoğuna sahip olduğu bir yerde birinin rüşvet alması gerekiyor. [PAWN_nameDef] böyle bir figürdü.\n\nBir çatı katında rahatça yaşarken insanların umutlarını ve hayallerini nasıl manipüle edeceğini öğrendi.</UrbworldPolitican92.description>
   <!-- EN: urbworld politican -->
   <UrbworldPolitican92.title>urbworld'lü politikacı</UrbworldPolitican92.title>
   <UrbworldPolitican92.titleFemale>urbworld'lü politikacı</UrbworldPolitican92.titleFemale>
@@ -2499,7 +2499,7 @@
   <UrbworldPolitican92.titleShortFemale>politikacı</UrbworldPolitican92.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef]'s passion for all things militaristic kept with [PAWN_objective] all the way to adulthood.\n\nAfter enrolling as a local policeman, [PAWN_pronoun] was soon promoted to sergeant. -->
-  <UrbworldSergeant50.description>[PAWN_nameDef]'in militarist şeylere karşı olan tutkusu yetişkinliğe kadar devam etti\n\n Yerel bir polis memuru olarak kaydolduktan sonra kısa süre sonra çavuşluğa terfi etti.</UrbworldSergeant50.description>
+  <UrbworldSergeant50.description>[PAWN_nameDef]'in militarist şeylere karşı olan tutkusu yetişkinliğe kadar devam etti\n\nYerel bir polis memuru olarak kaydolduktan sonra kısa süre sonra çavuşluğa terfi etti.</UrbworldSergeant50.description>
   <!-- EN: urbworld sergeant -->
   <UrbworldSergeant50.title>urbworld'lü çavuş</UrbworldSergeant50.title>
   <UrbworldSergeant50.titleFemale>urbworld'lü çavuş</UrbworldSergeant50.titleFemale>
@@ -2526,7 +2526,7 @@
   <Vagabond73.titleShortFemale>berduş</Vagabond73.titleShortFemale>
   
   <!-- EN: A violent drifter without a home, [PAWN_nameDef] and [PAWN_possessive] father fought many battles across hundreds of years. [PAWN_pronoun] became a grizzled fighter and crack shot.\n\nAfter [PAWN_possessive] father's death in battle, [PAWN_nameDef] began exploring the stars alone, seeking [PAWN_possessive] father's killer, on the hunt for revenge. -->
-  <VengefulExplorer54.description>Evi olmayan vahşi bir serseri olan [PAWN_nameDef] ve babası yüzlerce yıl boyunca birçok savaşta savaştı. Kalburlanmış bir dövüşçü ve hızlı silahşördü.\n\n. Babasının savaşta ölümünden sonra [PAWN_nameDef], intikam peşinde babasının katilini arayarak yıldızları tek başına keşfetmeye başladı.</VengefulExplorer54.description>
+  <VengefulExplorer54.description>Evi olmayan vahşi bir serseri olan [PAWN_nameDef] ve babası yüzlerce yıl boyunca birçok savaşta savaştı. Kalburlanmış bir dövüşçü ve hızlı silahşördü.\n\nBabasının savaşta ölümünden sonra [PAWN_nameDef], intikam peşinde babasının katilini arayarak yıldızları tek başına keşfetmeye başladı.</VengefulExplorer54.description>
   <!-- EN: vengeful explorer -->
   <VengefulExplorer54.title>klonoid kaşif</VengefulExplorer54.title>
   <VengefulExplorer54.titleFemale>klonoid kaşif</VengefulExplorer54.titleFemale>
@@ -2544,16 +2544,16 @@
   <VengefulNomad67.titleShortFemale>göçebe</VengefulNomad67.titleShortFemale>
   
   <!-- EN: Spending [PAWN_possessive] later teenage years in a colony of settlers, [PAWN_pronoun] offered what little skills [PAWN_pronoun] had to anyone who would take him.\n\nBeing a quick learner, [PAWN_pronoun] honed many of [PAWN_possessive] skills and, apart from [PAWN_possessive] crippling inability to understand fire, is now a fully functioning adult. -->
-  <VersatileWorker13.description>Gençlik yıllarını bir yerleşimci kolonisinde geçirerek, sahip olduğu küçük becerileri satın alacak herkese sundu.\n\n. Çabuk öğrenen biri olarak birçok becerisini geliştirdi. Ateşi anlama konusundaki kıt beyinliliğin yanı sıra  şimdi tam işlevli bir yetişkin.</VersatileWorker13.description>
+  <VersatileWorker13.description>Gençlik yıllarını bir yerleşimci kolonisinde geçirerek, sahip olduğu küçük becerileri satın alacak herkese sundu.\n\nÇabuk öğrenen biri olarak birçok becerisini geliştirdi. Ateşi anlama konusundaki kıt beyinliliğin yanı sıra  şimdi tam işlevli bir yetişkin.</VersatileWorker13.description>
   <!-- EN: versatile worker -->
   <VersatileWorker13.title>çok yönlü işçi</VersatileWorker13.title>
   <VersatileWorker13.titleFemale>çok yönlü işçi</VersatileWorker13.titleFemale>
   <!-- EN: worker -->
-  <VersatileWorker13.titleShort>işçi</VersatileWorker13.titleShort>
-  <VersatileWorker13.titleShortFemale>işçi</VersatileWorker13.titleShortFemale>
+  <VersatileWorker13.titleShort>İşçi</VersatileWorker13.titleShort>
+  <VersatileWorker13.titleShortFemale>İşçi</VersatileWorker13.titleShortFemale>
   
   <!-- EN: Too awkward to socialize, [PAWN_nameDef] found comfort in the production of videos. Oddly, people enjoyed [PAWN_possessive] videos, calling them "perfect sitcom dramas".\n\n[PAWN_nameDef] took advantage of this and broadcast more, ever hopeful that [PAWN_pronoun] would be contacted by the Wizards. -->
-  <VideoProducer83.description>[PAWN_nameDef] sosyalleşmek için çok garipti birisiydi.Video prodüksiyonunda huzur buluyordu. Garip bir şekilde, insanlar "mükemmel sitcom dramaları" diyerek videolarını beğendi.\n\n [PAWN_nameDef] bundan yararlandı ve Seherbazlar tarafından temasa geçileceğini umarak daha fazla yayın yaptı.</VideoProducer83.description>
+  <VideoProducer83.description>[PAWN_nameDef] sosyalleşmek için çok garipti birisiydi.Video prodüksiyonunda huzur buluyordu. Garip bir şekilde, insanlar "mükemmel sitcom dramaları" diyerek videolarını beğendi.\n\n[PAWN_nameDef] bundan yararlandı ve Seherbazlar tarafından temasa geçileceğini umarak daha fazla yayın yaptı.</VideoProducer83.description>
   <!-- EN: video producer -->
   <VideoProducer83.title>video prodüktörü</VideoProducer83.title>
   <VideoProducer83.titleFemale>video prodüktörü</VideoProducer83.titleFemale>
@@ -2569,13 +2569,13 @@
   <Villain89.titleShort>süper kötü</Villain89.titleShort>
   
   <!-- EN: After prohibition came to Aracena VI, [PAWN_nameDef] expanded [PAWN_possessive] underground liquor business until it dominated the market on two continents. They called [PAWN_objective] the Vinho King.\n\nThough [PAWN_pronoun] mostly controlled [PAWN_possessive] competition by masterful political maneuvering, [PAWN_pronoun] was not above the occasional beat-down or stiletto assassination. -->
-  <VinhoKing98.description>Aracena VI'ya yasak geldikten sonra, [PAWN_nameDef] yeraltı likör işini iki kıtada pazara hakim olana kadar genişletti. Ona Şarap Baronu dediler.\n\n Rekipleri çoğunlukla ustaca siyasi manevralarla kontrol ederdi. Dayak ya da stiletto suikastı kadar etkili değildi.</VinhoKing98.description>
+  <VinhoKing98.description>Aracena VI'ya yasak geldikten sonra, [PAWN_nameDef] yeraltı likör işini iki kıtada pazara hakim olana kadar genişletti. Ona Şarap Baronu dediler.\n\nRekipleri çoğunlukla ustaca siyasi manevralarla kontrol ederdi. Dayak ya da stiletto suikastı kadar etkili değildi.</VinhoKing98.description>
   <!-- EN: vinho king -->
   <VinhoKing98.title>Şarap baronu</VinhoKing98.title>
   <VinhoKing98.titleFemale>Şarap baronu</VinhoKing98.titleFemale>
   <!-- EN: booze king -->
-  <VinhoKing98.titleShort>içki baronu</VinhoKing98.titleShort>
-  <VinhoKing98.titleShortFemale>içki baronu</VinhoKing98.titleShortFemale>
+  <VinhoKing98.titleShort>İçki baronu</VinhoKing98.titleShort>
+  <VinhoKing98.titleShortFemale>İçki baronu</VinhoKing98.titleShortFemale>
   
   <!-- EN: Craving adventure and glory, [PAWN_nameDef] set out across the void with a raider band, swearing [PAWN_possessive] loyalty to [PAWN_possessive] band and brothers, and spreading their glory through the stars with [PAWN_possessive] blade and pistol in hand. -->
   <VoidRaider74.description>Maceraya ve şöhrete can atan [PAWN_nameDef], bir akıncı çetesiyle birlikte boşluğa doğru yola çıktı. Çetesine ve kardeşlerine sadakat yemini etti.Elindeki bıçağı ve tabancasıyla yıldızlarda şanını yaydı.</VoidRaider74.description>
@@ -2586,7 +2586,7 @@
   <VoidRaider74.titleShortFemale>korsan</VoidRaider74.titleShortFemale>
   
   <!-- EN: After years of seeking the assassin that broke up [PAWN_possessive] family, [PAWN_nameDef] was offered a place with a group of space-faring raiders. [PAWN_pronoun] accepted, hoping to find the killer [PAWN_pronoun] sought.\n\nDue to [PAWN_possessive] seemingly-unending ability to narrowly escape danger, [PAWN_pronoun] earned the nickname 'Blackjack' in recognition of [PAWN_possessive] luck. -->
-  <VoidspaceRaider94.description>Ailesini parçalayan suikastçıyı yıllarca aradıktan sonra, [PAWN_nameDef]'ye bir grup uzay akıncısı kendilerine katılmaya davat etti. Aradığı katili bulmayı umarak kabul etti.\n\n. Tehlikeden kıl payı kaçma konusundaki sonsuz yeteneği nedeniyle, şansının tanınmasıyla 'Blackjack' lakabını kazandı.</VoidspaceRaider94.description>
+  <VoidspaceRaider94.description>Ailesini parçalayan suikastçıyı yıllarca aradıktan sonra, [PAWN_nameDef]'ye bir grup uzay akıncısı kendilerine katılmaya davat etti. Aradığı katili bulmayı umarak kabul etti.\n\nTehlikeden kıl payı kaçma konusundaki sonsuz yeteneği nedeniyle, şansının tanınmasıyla 'Blackjack' lakabını kazandı.</VoidspaceRaider94.description>
   <!-- EN: voidspace raider -->
   <VoidspaceRaider94.title>uzay akıncısı</VoidspaceRaider94.title>
   <!-- EN: Pirate -->
@@ -2603,7 +2603,7 @@
   <WanderingCrafter42.titleShortFemale>zanaatçı</WanderingCrafter42.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] studied to be a doctor, but was dissatisfied with [PAWN_possessive] practice on an otherwise peaceful midworld.\n\nInstead, [PAWN_pronoun] chose to pull up roots and travel to the rimworlds in order to care for people who needed [PAWN_objective] most. -->
-  <WanderingHealer52.description>[PAWN_nameDef] doktor olmak için okudu ancak barışçıl bir dünda doktorlara pek ihtiyaç yoktu.\n\n Kendisine ihtiyacı olan insanlarla ilgilenmek için rimworlds'e seyahat etti.</WanderingHealer52.description>
+  <WanderingHealer52.description>[PAWN_nameDef] doktor olmak için okudu ancak barışçıl bir dünda doktorlara pek ihtiyaç yoktu.\n\nKendisine ihtiyacı olan insanlarla ilgilenmek için rimworlds'e seyahat etti.</WanderingHealer52.description>
   <!-- EN: wandering healer -->
   <WanderingHealer52.title>göçebe şifacı</WanderingHealer52.title>
   <WanderingHealer52.titleFemale>göçebe şifacı</WanderingHealer52.titleFemale>
@@ -2637,7 +2637,7 @@
   <Warrior73.titleShortFemale>savaşçı</Warrior73.titleShortFemale>
   
   <!-- EN: Years of being commanding officer of an advanced corvette taught [PAWN_nameDef] the art of leadership, the techniques of higher engineering, and how to stay calm while enemies try to kill you.\n\nUnfortunately, [PAWN_nameDef] only very rarely had contact with nature. -->
-  <WarshipCaptain67.description>Gelişmiş bir korvetin komutanı olarak geçen yıllarda [PAWN_nameDef]'ye liderlik sanatını, yüksek mühendislik tekniklerini ve düşmanlar sizi öldürmeye çalışırken nasıl sakin kalacağınızı öğretildi.\n\n Ne yazık ki [PAWN_nameDef] doğayla çok nadiren temasa geçti.</WarshipCaptain67.description>
+  <WarshipCaptain67.description>Gelişmiş bir korvetin komutanı olarak geçen yıllarda [PAWN_nameDef]'ye liderlik sanatını, yüksek mühendislik tekniklerini ve düşmanlar sizi öldürmeye çalışırken nasıl sakin kalacağınızı öğretildi.\n\nNe yazık ki [PAWN_nameDef] doğayla çok nadiren temasa geçti.</WarshipCaptain67.description>
   <!-- EN: warship captain -->
   <WarshipCaptain67.title>savaş gemisi kaptanı</WarshipCaptain67.title>
   <WarshipCaptain67.titleFemale>savaş gemisi kaptanı</WarshipCaptain67.titleFemale>
@@ -2653,7 +2653,7 @@
   <WhiteHatHacker82.titleShort>hacker</WhiteHatHacker82.titleShort>
   
   <!-- EN: Dismayed at the poachers driving several animal species to near-extinction, [PAWN_nameDef] became a wildlife ranger. [PAWN_pronoun] cared for and protect the animals - by force if necessary.\n\n[PAWN_pronoun] grew to hate people slaughtering animals for luxury and profit. -->
-  <WildlifeRanger99.description>Birkaç hayvan türünü neredeyse yok olmaya sürükleyen kaçak avcılardan korkan [PAWN_nameDef] bir vahşi yaşam korucusu oldu. Hayvanlarla ilgilendi ve onları korudu - gerekirse zorla.\n\n Lüks ve kâr için hayvanları katleden insanlardan nefret etmeye başladı.</WildlifeRanger99.description>
+  <WildlifeRanger99.description>Birkaç hayvan türünü neredeyse yok olmaya sürükleyen kaçak avcılardan korkan [PAWN_nameDef] bir vahşi yaşam korucusu oldu. Hayvanlarla ilgilendi ve onları korudu - gerekirse zorla.\n\nLüks ve kâr için hayvanları katleden insanlardan nefret etmeye başladı.</WildlifeRanger99.description>
   <!-- EN: wildlife ranger -->
   <WildlifeRanger99.title>vahşi yaşam korucusu</WildlifeRanger99.title>
   <WildlifeRanger99.titleFemale>vahşi yaşam korucusu</WildlifeRanger99.titleFemale>

--- a/Core/DefInjected/BackstoryDef/Solid_Child.xml
+++ b/Core/DefInjected/BackstoryDef/Solid_Child.xml
@@ -10,7 +10,7 @@
   <AbandonedChild30.titleShortFemale>terk edilmiş</AbandonedChild30.titleShortFemale>
   
   <!-- EN: Abandoned at birth, young [PAWN_nameDef] started [PAWN_possessive] life in an orphanage.\n\nA rascal and a scoundrel, [PAWN_pronoun] became a clever troublemaker. -->
-  <AbandonedOrphan61.description>Doğumda terk edilen genç [PAWN_nameDef], bir yetimhanede hayatına başladı.\n\n Serseri,hain ve zeki bir baş belası oldu.</AbandonedOrphan61.description>
+  <AbandonedOrphan61.description>Doğumda terk edilen genç [PAWN_nameDef], bir yetimhanede hayatına başladı.\n\nSerseri,hain ve zeki bir baş belası oldu.</AbandonedOrphan61.description>
   <!-- EN: abandoned orphan -->
   <AbandonedOrphan61.title>terk edilmiş yetim</AbandonedOrphan61.title>
   <!-- EN: orphan -->
@@ -26,7 +26,7 @@
   <Abductee43.titleShortFemale>kaçırılmış</Abductee43.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was abducted by xenohumans when [PAWN_pronoun] was still a baby. They experimented on [PAWN_objective] to understand [PAWN_possessive] genetic structure.\n\nAs [PAWN_pronoun] grew up, [PAWN_nameDef] grew a little bit too big and strong for [PAWN_possessive] captors and escaped. -->
-  <Abductee7.description>[PAWN_nameDef], henüz bir bebekken yabancı insanlar tarafından kaçırıldı. Onun genetik yapısını anlamak için üzerinde deney yaptılar.\n\n [PAWN_nameDef]  biraz fazla büyüdü, güçlendi ve kaçtı.</Abductee7.description>
+  <Abductee7.description>[PAWN_nameDef], henüz bir bebekken yabancı insanlar tarafından kaçırıldı. Onun genetik yapısını anlamak için üzerinde deney yaptılar.\n\n[PAWN_nameDef]  biraz fazla büyüdü, güçlendi ve kaçtı.</Abductee7.description>
   <!-- EN: abductee -->
   <Abductee7.title>kaçırılmış</Abductee7.title>
   <Abductee7.titleFemale>kaçırılmış</Abductee7.titleFemale>
@@ -35,7 +35,7 @@
   <Abductee7.titleShortFemale>kaçırılmış</Abductee7.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] went to school like a good space cadet would. [PAWN_pronoun] was very tall and was known for [PAWN_possessive] good looks.\n\nThough [PAWN_pronoun] worried more about [PAWN_possessive] hairstyle than [PAWN_possessive] grades, [PAWN_pronoun] still somehow passed the final exams. -->
-  <AcademyStudent58.description>[PAWN_nameDef] iyi bir uzay öğrencisi gibi okula gitti. O çok uzundu ve güzel görünüşüyle biliniyordu.\n\n O notlarından daha çok saç modeli hakkında endişe duysa da yine de final sınavlarını geçti.</AcademyStudent58.description>
+  <AcademyStudent58.description>[PAWN_nameDef] iyi bir uzay öğrencisi gibi okula gitti. O çok uzundu ve güzel görünüşüyle biliniyordu.\n\nO notlarından daha çok saç modeli hakkında endişe duysa da yine de final sınavlarını geçti.</AcademyStudent58.description>
   <!-- EN: academy student -->
   <AcademyStudent58.title>akademi öğrencisi</AcademyStudent58.title>
   <AcademyStudent58.titleFemale>akademi öğrencisi</AcademyStudent58.titleFemale>
@@ -44,7 +44,7 @@
   <AcademyStudent58.titleShortFemale>öğrenci</AcademyStudent58.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was born at the peak of a lunar eclipse. The elders declared [PAWN_objective] a child of darkness and brought [PAWN_objective] under their care.\n\n[PAWN_possessive] entire childhood was spent studying the lore and rituals of [PAWN_possessive] people - until the day of calling. -->
-  <AccursedChild88.description>[PAWN_nameDef] bir ay tutulmasının zirvesinde doğdu. Yaşlılar onun karanlığın çocuğu olduğunu ilan ettiler ve kendi gözetimleri altına aldılar.\n\n O tüm çocukluğunu halkının irfan ve ritüellerini incelemekle geçirdi - ta ki çağrı gününe kadar.</AccursedChild88.description>
+  <AccursedChild88.description>[PAWN_nameDef] bir ay tutulmasının zirvesinde doğdu. Yaşlılar onun karanlığın çocuğu olduğunu ilan ettiler ve kendi gözetimleri altına aldılar.\n\nO tüm çocukluğunu halkının irfan ve ritüellerini incelemekle geçirdi - ta ki çağrı gününe kadar.</AccursedChild88.description>
   <!-- EN: accursed child -->
   <AccursedChild88.title>lanetli çocuk</AccursedChild88.title>
   <!-- EN: cursed -->
@@ -52,7 +52,7 @@
   <AccursedChild88.titleShortFemale>lanetli</AccursedChild88.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was raised to become an engineer. For years, [PAWN_pronoun] planned to stow away on a cargo ship and start a new, more adventuresome life.\n\nOne night, after [PAWN_possessive] parents fell asleep, [PAWN_pronoun] managed to sneak on board a cargo ship just before it left port. -->
-  <AdventuringChild30.description>[PAWN_nameDef] mühendis olmak için yetiştirildi. Yıllarca bir kargo gemisinde saklanmayı ve yeni, daha maceralı bir hayata başlamayı planladı.\n\n Bir gece, ebeveynleri uykuya daldıktan sonra, limandan ayrılmadan hemen önce bir kargo gemisine gizlice girmeyi başardı.</AdventuringChild30.description>
+  <AdventuringChild30.description>[PAWN_nameDef] mühendis olmak için yetiştirildi. Yıllarca bir kargo gemisinde saklanmayı ve yeni, daha maceralı bir hayata başlamayı planladı.\n\nBir gece, ebeveynleri uykuya daldıktan sonra, limandan ayrılmadan hemen önce bir kargo gemisine gizlice girmeyi başardı.</AdventuringChild30.description>
   <!-- EN: adventuring child -->
   <AdventuringChild30.title>maceracı çocuk</AdventuringChild30.title>
   <!-- EN: adventurer -->
@@ -60,7 +60,7 @@
   <AdventuringChild30.titleShortFemale>maceracı</AdventuringChild30.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] explored all around [PAWN_possessive] family's large estate, uncovering little natural wonders hidden in nearby catacombs, rivers, and caves.\n\nDuring [PAWN_possessive] teenage years, [PAWN_nameDef] made numerous enemies -->
-  <AdventurousYouth70.description>[PAWN_nameDef] yakınlardaki yeraltı mezarlıklarında, nehirlerde ve mağaralarda gizlenmiş küçük doğa harikalarını ortaya çıkararak ailesinin geniş arazisini araştırdı.\n\n [PAWN_nameDef] gençlik yıllarında çok sayıda düşman edindi</AdventurousYouth70.description>
+  <AdventurousYouth70.description>[PAWN_nameDef] yakınlardaki yeraltı mezarlıklarında, nehirlerde ve mağaralarda gizlenmiş küçük doğa harikalarını ortaya çıkararak ailesinin geniş arazisini araştırdı.\n\n[PAWN_nameDef] gençlik yıllarında çok sayıda düşman edindi</AdventurousYouth70.description>
   <!-- EN: adventurous youth -->
   <AdventurousYouth70.title>genç maceracı</AdventurousYouth70.title>
   <!-- EN: adventurer -->
@@ -68,7 +68,7 @@
   <AdventurousYouth70.titleShortFemale>maceracı</AdventurousYouth70.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was fascinated with astronomy. [PAWN_pronoun] would spend hours gazing at planets and nebulae through [PAWN_possessive] telescope.\n\n[PAWN_pronoun] is credited with discovering a small comet that would, years later, strike a nearby moon and disrupt the mining operations there. -->
-  <AmateurAstronomer77.description>[PAWN_nameDef] astronomi ile büyülendi. Teleskobuyla saatlerce gezegenlere ve nebulalara bakardı.\n\n Yıllar sonra yakındaki bir aya çarpacak ve oradaki madencilik faaliyetlerini bozacak küçük bir kuyruklu yıldız keşfetmesiyle tanınır.</AmateurAstronomer77.description>
+  <AmateurAstronomer77.description>[PAWN_nameDef] astronomi ile büyülendi. Teleskobuyla saatlerce gezegenlere ve nebulalara bakardı.\n\nYıllar sonra yakındaki bir aya çarpacak ve oradaki madencilik faaliyetlerini bozacak küçük bir kuyruklu yıldız keşfetmesiyle tanınır.</AmateurAstronomer77.description>
   <!-- EN: amateur astronomer -->
   <AmateurAstronomer77.title>amatör astronot</AmateurAstronomer77.title>
   <AmateurAstronomer77.titleFemale>amatör astronot</AmateurAstronomer77.titleFemale>
@@ -95,7 +95,7 @@
   <AmateurEngineer3.titleShortFemale>mühendis</AmateurEngineer3.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] trained towards [PAWN_possessive] dream of working for [PAWN_possessive] hometown's local council.\n\nFor reasons [PAWN_pronoun] never quite understood, [PAWN_pronoun] was bullied relentlessly by [PAWN_possessive] classmates. [PAWN_pronoun] chose to repress [PAWN_possessive] rage. -->
-  <AngryStudent88.description>[PAWN_nameDef], memleketinin yerel meclisinde çalışma hayali için eğitim aldı. \n\n Hiçbir zaman tam olarak anlayamadığı nedenlerden dolayı sınıf arkadaşları tarafından acımasızca zorbalığa uğradı. Öfkesini bastırmayı seçti.</AngryStudent88.description>
+  <AngryStudent88.description>[PAWN_nameDef], memleketinin yerel meclisinde çalışma hayali için eğitim aldı.\n\nHiçbir zaman tam olarak anlayamadığı nedenlerden dolayı sınıf arkadaşları tarafından acımasızca zorbalığa uğradı. Öfkesini bastırmayı seçti.</AngryStudent88.description>
   <!-- EN: angry student -->
   <AngryStudent88.title>kızgın öğrenci</AngryStudent88.title>
   <AngryStudent88.titleFemale>kızgın öğrenci</AngryStudent88.titleFemale>
@@ -104,7 +104,7 @@
   <AngryStudent88.titleShortFemale>öğrenci</AngryStudent88.titleShortFemale>
   
   <!-- EN: Born on a medieval farm, [PAWN_nameDef] was tasked with caring for domestic animals. [PAWN_pronoun] grew to love them.\n\nWith time, [PAWN_pronoun] learned to tame wild animals. [PAWN_pronoun] dreamed of one day meeting a thrumbo and taming it. -->
-  <AnimalCaretaker20.description>Orta Çağ'dan kalma bir çiftlikte doğan [PAWN_nameDef], evcil hayvanlara bakmakla görevlendirilmişti.Onları sevmeye başladı.\n\n Zamanla vahşi hayvanları evcilleştirmeyi öğrendi. Bir gün bir thrumbo ile karşılaşıp onu evcilleştirmeyi hayal etti.</AnimalCaretaker20.description>
+  <AnimalCaretaker20.description>Orta Çağ'dan kalma bir çiftlikte doğan [PAWN_nameDef], evcil hayvanlara bakmakla görevlendirilmişti.Onları sevmeye başladı.\n\nZamanla vahşi hayvanları evcilleştirmeyi öğrendi. Bir gün bir thrumbo ile karşılaşıp onu evcilleştirmeyi hayal etti.</AnimalCaretaker20.description>
   <!-- EN: animal caretaker -->
   <AnimalCaretaker20.title>hayvan bakıcısı</AnimalCaretaker20.title>
   <AnimalCaretaker20.titleFemale>hayvan bakıcısı</AnimalCaretaker20.titleFemale>
@@ -113,7 +113,7 @@
   <AnimalCaretaker20.titleShortFemale>bakıcı</AnimalCaretaker20.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] worked as a technician in a lab studying animals.\n\n[PAWN_pronoun] spent [PAWN_possessive] days taking care of the animals and cleaning up after them. [PAWN_pronoun] dreamed of having [PAWN_possessive] own lab one day. -->
-  <AnimalLabTech39.description>[PAWN_nameDef] bir hayvan laboratuvarında teknisyen olarak çalıştı.\n\n Günlerini hayvanlarla ilgilenerek ve onların götlerini temizleyerek geçirdi. Bir gün kendi laboratuarına sahip olmayı hayal etti.</AnimalLabTech39.description>
+  <AnimalLabTech39.description>[PAWN_nameDef] bir hayvan laboratuvarında teknisyen olarak çalıştı.\n\nGünlerini hayvanlarla ilgilenerek ve onların götlerini temizleyerek geçirdi. Bir gün kendi laboratuarına sahip olmayı hayal etti.</AnimalLabTech39.description>
   <!-- EN: animal lab tech -->
   <AnimalLabTech39.title>hayvan lab teknikeri</AnimalLabTech39.title>
   <AnimalLabTech39.titleFemale>hayvan lab teknikeri</AnimalLabTech39.titleFemale>
@@ -122,7 +122,7 @@
   <AnimalLabTech39.titleShortFemale>lab teknikeri</AnimalLabTech39.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] lacked typical social skills, and avoided social interaction.\n\n[PAWN_pronoun] gained satisfaction only from steady work. [PAWN_pronoun] especially disliked speaking with overly creative or outgoing individuals. -->
-  <AntisocialChild83.description>[PAWN_nameDef] tipik sosyal becerilerden yoksundu ve sosyal etkileşimden kaçındı.\n\n Yalnızca düzenli çalışmadan tatmin oldu. Özellikle aşırı yaratıcı veya dışa dönük kişilerle konuşmaktan hoşlanmazdı.</AntisocialChild83.description>
+  <AntisocialChild83.description>[PAWN_nameDef] tipik sosyal becerilerden yoksundu ve sosyal etkileşimden kaçındı.\n\nYalnızca düzenli çalışmadan tatmin oldu. Özellikle aşırı yaratıcı veya dışa dönük kişilerle konuşmaktan hoşlanmazdı.</AntisocialChild83.description>
   <!-- EN: antisocial child -->
   <AntisocialChild83.title>antisosyal çocuk</AntisocialChild83.title>
   <!-- EN: antisocial -->
@@ -130,28 +130,28 @@
   <AntisocialChild83.titleShortFemale>antisosyal</AntisocialChild83.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] spent [PAWN_possessive] childhood on a post-apocalyptic world. [PAWN_pronoun] fought for survival from a young age, on a planet where trust did not exist.\n\n[PAWN_pronoun] told everyone that [PAWN_pronoun] had no luck. -->
-  <ApocalypseChild23.description>[PAWN_nameDef] çocukluğunu kıyamet sonrası bir dünyada geçirdi. Küçük yaştan itibaren güvenin olmadığı bir gezegende hayatta kalmak için savaştı.\n\n Herkese 'şansının olmadığını' söyledi.</ApocalypseChild23.description>
+  <ApocalypseChild23.description>[PAWN_nameDef] çocukluğunu kıyamet sonrası bir dünyada geçirdi. Küçük yaştan itibaren güvenin olmadığı bir gezegende hayatta kalmak için savaştı.\n\nHerkese 'şansının olmadığını' söyledi.</ApocalypseChild23.description>
   <!-- EN: apocalypse child -->
   <ApocalypseChild23.title>kıyamet çocuğu</ApocalypseChild23.title>
   <!-- EN: apocalypse -->
   <ApocalypseChild23.titleShort>kıyamette yaşayan</ApocalypseChild23.titleShort>
   
   <!-- EN: [PAWN_nameDef] was chosen at an early age by the village elders to keep the sacred rituals of the Oracle.\n\nAn irrepressibly curious child, [PAWN_nameDef] caused a religious crisis for [PAWN_possessive] tribe when [PAWN_pronoun] accidentally flipped a switch to open the "tombs" of the Gods - cryptosleep caskets inhabited by some very confused ancestors. -->
-  <ApprenticeOracle83.description>[PAWN_nameDef], Kahin'in kutsal ritüellerini sürdürmek için köyün yaşlıları tarafından erken yaşta seçildi.\n\n Karşı konulmaz bir şekilde meraklı bir çocuk olan [PAWN_nameDef], yanlışlıkla "tanrıların mezarları" kapısını açmak için bir düğmeyi çevirdiğinde kabilesi için dini bir krize neden oldu.Kafası çok karışıkdı.- kapının arkası bazı ataların yaşadığı gizli uyku tabutlarıydı.</ApprenticeOracle83.description>
+  <ApprenticeOracle83.description>[PAWN_nameDef], Kahin'in kutsal ritüellerini sürdürmek için köyün yaşlıları tarafından erken yaşta seçildi.\n\nKarşı konulmaz bir şekilde meraklı bir çocuk olan [PAWN_nameDef], yanlışlıkla "tanrıların mezarları" kapısını açmak için bir düğmeyi çevirdiğinde kabilesi için dini bir krize neden oldu.Kafası çok karışıkdı.- kapının arkası bazı ataların yaşadığı gizli uyku tabutlarıydı.</ApprenticeOracle83.description>
   <!-- EN: apprentice oracle -->
   <ApprenticeOracle83.title>çırak kahin</ApprenticeOracle83.title>
   <!-- EN: oracle -->
   <ApprenticeOracle83.titleShort>kahin</ApprenticeOracle83.titleShort>
   
   <!-- EN: [PAWN_nameDef] grew up helping in [PAWN_possessive] father's smithy.\n\nThey were some of the last smiths on the planet that to use traditional smithing methods. They even collect some materials themselves.\n\nSometimes, after work, [PAWN_nameDef] would practice using the swords [PAWN_pronoun] forged. -->
-  <ApprenticeSmith37.description>[PAWN_nameDef], babasının demircisine yardım ederek büyüdü.\n\n Onlar, gezegende geleneksel demircilik yöntemlerini kullanan son demircilerdendi. Hatta bazı malzemeleri kendileri toplarlardı.\n\n Bazen işten sonra [PAWN_nameDef] dövdüğü kılıçları kullanarak pratik yapardı.</ApprenticeSmith37.description>
+  <ApprenticeSmith37.description>[PAWN_nameDef], babasının demircisine yardım ederek büyüdü.\n\nOnlar, gezegende geleneksel demircilik yöntemlerini kullanan son demircilerdendi. Hatta bazı malzemeleri kendileri toplarlardı.\n\nBazen işten sonra [PAWN_nameDef] dövdüğü kılıçları kullanarak pratik yapardı.</ApprenticeSmith37.description>
   <!-- EN: apprentice smith -->
   <ApprenticeSmith37.title>çırak demirci</ApprenticeSmith37.title>
   <!-- EN: apprentice -->
   <ApprenticeSmith37.titleShort>çırak</ApprenticeSmith37.titleShort>
   
   <!-- EN: [PAWN_nameDef] grew up on one of the urbworlds and had to fend for [PAWN_objective]self all [PAWN_possessive] life. [PAWN_pronoun] never trusted anyone, relying on [PAWN_possessive] persuasiveness and cunning to survive.\n\n[PAWN_pronoun] soon became skilled with firearms and knives as well as words. -->
-  <ArtfulDodger78.description>[PAWN_nameDef] urbworld'lerden birinde büyüdü ve tüm hayatı boyunca kendi başının çaresine bakmak zorunda kaldı. Hayatta kalmak için ikna kabiliyetine ve kurnazlığına güvenerek kimseye güvenmedi.\n\n Kısa sürede ateşli silahlar ve bıçaklar kadar kelimelerde de ustalaştı.</ArtfulDodger78.description>
+  <ArtfulDodger78.description>[PAWN_nameDef] urbworld'lerden birinde büyüdü ve tüm hayatı boyunca kendi başının çaresine bakmak zorunda kaldı. Hayatta kalmak için ikna kabiliyetine ve kurnazlığına güvenerek kimseye güvenmedi.\n\nKısa sürede ateşli silahlar ve bıçaklar kadar kelimelerde de ustalaştı.</ArtfulDodger78.description>
   <!-- EN: artful dodger -->
   <ArtfulDodger78.title>usta madrabaz</ArtfulDodger78.title>
   <ArtfulDodger78.titleFemale>usta madrabaz</ArtfulDodger78.titleFemale>
@@ -169,7 +169,7 @@
   <ArtisanFarmer23.titleShortFemale>çiftçi</ArtisanFarmer23.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] grew up in a house near a bustling midworld metropolis.\n\n[PAWN_pronoun] was talented at art and creative work, but often acted strangely, and thus had few friends. -->
-  <ArtisticWeirdo56.description>[PAWN_nameDef], hareketli bir orta dünya metropolünün yakınındaki bir evde büyüdü.\n\n Sanatta ve yaratıcı işlerde yetenekliydi, ancak genellikle tuhaf davranıyordu ve bu nedenle çok az arkadaşı vardı.</ArtisticWeirdo56.description>
+  <ArtisticWeirdo56.description>[PAWN_nameDef], hareketli bir orta dünya metropolünün yakınındaki bir evde büyüdü.\n\nSanatta ve yaratıcı işlerde yetenekliydi, ancak genellikle tuhaf davranıyordu ve bu nedenle çok az arkadaşı vardı.</ArtisticWeirdo56.description>
   <!-- EN: artistic weirdo -->
   <ArtisticWeirdo56.title>sanatsal ucube</ArtisticWeirdo56.title>
   <ArtisticWeirdo56.titleFemale>sanatsal ucube</ArtisticWeirdo56.titleFemale>
@@ -178,16 +178,16 @@
   <ArtisticWeirdo56.titleShortFemale>ucube</ArtisticWeirdo56.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] grew up as a rebel on an formerly-advanced rimworld devastated by war.\n\n[PAWN_possessive] Aspergers syndrome meant [PAWN_pronoun] struggled with social situations and was incapable of caring, but [PAWN_pronoun] learned hard skills like research and shooting very quickly. -->
-  <AspergersRebel13.description>[PAWN_nameDef], savaşın harap ettiği; önceden gelişmiş bir rimworld'de bir asi olarak büyüdü.\n\n Aspergers sendromu; sosyal durumlarla boğuştuğu ve umursamadığı anlamına geliyordu, ancak araştırma ve atış gibi zor becerileri çok çabuk öğrendi.</AspergersRebel13.description>
+  <AspergersRebel13.description>[PAWN_nameDef], savaşın harap ettiği; önceden gelişmiş bir rimworld'de bir asi olarak büyüdü.\n\nAspergers sendromu; sosyal durumlarla boğuştuğu ve umursamadığı anlamına geliyordu, ancak araştırma ve atış gibi zor becerileri çok çabuk öğrendi.</AspergersRebel13.description>
   <!-- EN: aspergers rebel -->
   <AspergersRebel13.title>aspergersli isyancı</AspergersRebel13.title>
   <AspergersRebel13.titleFemale>aspergersli isyancı</AspergersRebel13.titleFemale>
   <!-- EN: rebel -->
-  <AspergersRebel13.titleShort>isyancı</AspergersRebel13.titleShort>
-  <AspergersRebel13.titleShortFemale>isyancı</AspergersRebel13.titleShortFemale>
+  <AspergersRebel13.titleShort>İsyancı</AspergersRebel13.titleShort>
+  <AspergersRebel13.titleShortFemale>İsyancı</AspergersRebel13.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] had a fascination with gadgets and gizmos. [PAWN_pronoun] took apart and put together almost anything [PAWN_pronoun] could find.\n\n[PAWN_pronoun] got used to repairing toys brought to [PAWN_objective] by other children, and even fixed a few devices from [PAWN_possessive] elders. -->
-  <AspiringEngineer58.description>[PAWN_nameDef] küçük aletlere ve ne olduğu belirsiz şeylere hayrandı. Hemen hemen bulabildiği her şeyi parçalarına ayırıp bir araya getirdi.\n\n Diğer çocukların kendisine getirdiği oyuncakları tamir etmeye alıştı ve hatta yetişkinlerin birkaç cihazını tamir etti.</AspiringEngineer58.description>
+  <AspiringEngineer58.description>[PAWN_nameDef] küçük aletlere ve ne olduğu belirsiz şeylere hayrandı. Hemen hemen bulabildiği her şeyi parçalarına ayırıp bir araya getirdi.\n\nDiğer çocukların kendisine getirdiği oyuncakları tamir etmeye alıştı ve hatta yetişkinlerin birkaç cihazını tamir etti.</AspiringEngineer58.description>
   <!-- EN: aspiring engineer -->
   <AspiringEngineer58.title>hevesli mühendis</AspiringEngineer58.title>
   <AspiringEngineer58.titleFemale>hevesli mühendis</AspiringEngineer58.titleFemale>
@@ -196,7 +196,7 @@
   <AspiringEngineer58.titleShortFemale>tamirci</AspiringEngineer58.titleShortFemale>
   
   <!-- EN: The daughter of an engineer and doctor, [PAWN_nameDef]'s early life was intellectually rich. After visiting a physics lab, [PAWN_pronoun] decided [PAWN_pronoun] wanted to be a quantum physicist.\n\nBitten by a camel, kicked off a horse, and chased by dogs, [PAWN_nameDef] developed a fear of animals. -->
-  <AspiringPhysicist47.description>Bir mühendis ve doktorun çocuğu olan [PAWN_nameDef]'in geçnliği entelektüel açıdan zengindi. Bir fizik laboratuvarını ziyaret ettikten sonra kuantum fizikçisi olmak istediğine karar verdi.\n\n Deve tarafından ısırılan, atı tarafından tekmelenen ve köpekler tarafından kovalanan [PAWN_nameDef] hayvanlardan korkmaya başladı.</AspiringPhysicist47.description>
+  <AspiringPhysicist47.description>Bir mühendis ve doktorun çocuğu olan [PAWN_nameDef]'in geçnliği entelektüel açıdan zengindi. Bir fizik laboratuvarını ziyaret ettikten sonra kuantum fizikçisi olmak istediğine karar verdi.\n\nDeve tarafından ısırılan, atı tarafından tekmelenen ve köpekler tarafından kovalanan [PAWN_nameDef] hayvanlardan korkmaya başladı.</AspiringPhysicist47.description>
   <!-- EN: aspiring physicist -->
   <AspiringPhysicist47.title>hevesli fizikçi</AspiringPhysicist47.title>
   <AspiringPhysicist47.titleFemale>hevesli fizikçi</AspiringPhysicist47.titleFemale>
@@ -205,14 +205,14 @@
   <AspiringPhysicist47.titleShortFemale>öğrenci</AspiringPhysicist47.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was being trained in song and dance to become the next big pop idol. [PAWN_pronoun] grew up being taken care of by company handlers.\n\n[PAWN_pronoun] never knew manual labor, but learned a lot about music and social etiquette. -->
-  <AspiringPopIdol28.description>[PAWN_nameDef] bir sonraki büyük pop idolü olmak için şarkı ve dans eğitimi alıyordu. Şirket çalışanları tarafından büyütüldü.\n\n El emeğini hiç bilmiyordu ama müzik ve sosyal görgü kuralları hakkında çok şey öğrendi.</AspiringPopIdol28.description>
+  <AspiringPopIdol28.description>[PAWN_nameDef] bir sonraki büyük pop idolü olmak için şarkı ve dans eğitimi alıyordu. Şirket çalışanları tarafından büyütüldü.\n\nEl emeğini hiç bilmiyordu ama müzik ve sosyal görgü kuralları hakkında çok şey öğrendi.</AspiringPopIdol28.description>
   <!-- EN: aspiring pop idol -->
   <AspiringPopIdol28.title>hevesli pop idolü</AspiringPopIdol28.title>
   <!-- EN: pop idol -->
   <AspiringPopIdol28.titleShort>pop idol</AspiringPopIdol28.titleShort>
   
   <!-- EN: [PAWN_nameDef] was professional athlete at early age. Thanks to [PAWN_possessive] skills, [PAWN_pronoun] was able to leave [PAWN_possessive] homeworld and enroll in a glitterworld university of science and technology.\n\nBecause of [PAWN_possessive] demanding schedule and introverted nature, [PAWN_pronoun] became socially inept. -->
-  <Athlete47.description>[PAWN_nameDef] erken yaşta profesyonel bir atletti. Becerileri sayesinde, anavatanını terk edip bir glitterworld bilim ve teknoloji üniversitesine kaydolabildi.\n\n .Zorlu programı ve içe dönük doğası nedeniyle, sosyal olarak beceriksiz hale geldi.</Athlete47.description>
+  <Athlete47.description>[PAWN_nameDef] erken yaşta profesyonel bir atletti. Becerileri sayesinde, anavatanını terk edip bir glitterworld bilim ve teknoloji üniversitesine kaydolabildi.\n\nZorlu programı ve içe dönük doğası nedeniyle, sosyal olarak beceriksiz hale geldi.</Athlete47.description>
   <!-- EN: athlete -->
   <Athlete47.title>atlet</Athlete47.title>
   <Athlete47.titleFemale>atlet</Athlete47.titleFemale>
@@ -228,7 +228,7 @@
   <AwkwardNerd48.titleShort>nerd</AwkwardNerd48.titleShort>
   
   <!-- EN: The only useful skill [PAWN_nameDef] learned from [PAWN_possessive] tough military school was card-counting. [PAWN_pronoun] amassed many enemies by cheating at casinos, becoming ever more edgy and violent as the threat of retaliation grew.\n\nWhen [PAWN_pronoun] was finally caught, they burned half [PAWN_possessive] skin off. [PAWN_pronoun] could never face fire or violence again. -->
-  <BlackjackPlayer76.description>[PAWN_nameDef]'nin  zorlu askeri okuldan öğrendiği tek beceri kart saymaktı. Kumarhanelerde hile yaparak birçok düşman topladı, misilleme tehdidi büyüdükçe daha da hırslı ve hilekar hale geldi.\n\n Sonunda yakalandığında derisinin yarısını yaktılar, bir daha asla ateşle ya da şiddetle karşılaşamazdı.</BlackjackPlayer76.description>
+  <BlackjackPlayer76.description>[PAWN_nameDef]'nin  zorlu askeri okuldan öğrendiği tek beceri kart saymaktı. Kumarhanelerde hile yaparak birçok düşman topladı, misilleme tehdidi büyüdükçe daha da hırslı ve hilekar hale geldi.\n\nSonunda yakalandığında derisinin yarısını yaktılar, bir daha asla ateşle ya da şiddetle karşılaşamazdı.</BlackjackPlayer76.description>
   <!-- EN: blackjack player -->
   <BlackjackPlayer76.title>blackjack oyuncusu</BlackjackPlayer76.title>
   <BlackjackPlayer76.titleFemale>blackjack oyuncusu</BlackjackPlayer76.titleFemale>
@@ -237,7 +237,7 @@
   <BlackjackPlayer76.titleShortFemale>kumarbaz</BlackjackPlayer76.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef]'s father owned the blacksmith shop in an run-down old city district. [PAWN_nameDef] would help [PAWN_possessive] father whenever [PAWN_pronoun] could.\n\nLater, [PAWN_possessive] father took [PAWN_objective] as a blacksmith's apprentice and raised [PAWN_objective] as a man. [PAWN_nameDef] also took on shooting as a hobby. -->
-  <BlacksmithsSon73.description>[PAWN_nameDef]'in babası, eski bir şehir semtindeki demirci dükkanının sahibiydi. [PAWN_nameDef] elinden geldiğince babasına yardım ederdi.\n\n Daha sonra babası onu demirci çırağı olarak aldı ve bir erkek gibi yetiştirdi.Ayrıca [PAWN_nameDef]  hobi olarak atış yaptı.</BlacksmithsSon73.description>
+  <BlacksmithsSon73.description>[PAWN_nameDef]'in babası, eski bir şehir semtindeki demirci dükkanının sahibiydi. [PAWN_nameDef] elinden geldiğince babasına yardım ederdi.\n\nDaha sonra babası onu demirci çırağı olarak aldı ve bir erkek gibi yetiştirdi.Ayrıca [PAWN_nameDef]  hobi olarak atış yaptı.</BlacksmithsSon73.description>
   <!-- EN: blacksmith's son -->
   <BlacksmithsSon73.title>demircinin çocuğu</BlacksmithsSon73.title>
   <BlacksmithsSon73.titleFemale>demircinin çocuğu</BlacksmithsSon73.titleFemale>
@@ -246,7 +246,7 @@
   <BlacksmithsSon73.titleShortFemale>demirci</BlacksmithsSon73.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was born under auspicious circumstances to a midworld spiritual group and held in reverence throughout [PAWN_possessive] childhood.\n\n[PAWN_pronoun] learned to take care of the poor and give succor to the faithful from an early age. -->
-  <BlessedChild46.description>[PAWN_nameDef], orta dünyada ruhani bir grubun kutsal koşulları altında doğdu ve çocukluğu boyunca saygıyla anıldı.\n\n Fakirlere bakmayı ve sadıklara yardım etmeyi erken yaşlardan itibaren öğrendi.</BlessedChild46.description>
+  <BlessedChild46.description>[PAWN_nameDef], orta dünyada ruhani bir grubun kutsal koşulları altında doğdu ve çocukluğu boyunca saygıyla anıldı.\n\nFakirlere bakmayı ve sadıklara yardım etmeyi erken yaşlardan itibaren öğrendi.</BlessedChild46.description>
   <!-- EN: blessed child -->
   <BlessedChild46.title>kutsal çocuk</BlessedChild46.title>
   <!-- EN: blessed -->
@@ -254,7 +254,7 @@
   <BlessedChild46.titleShortFemale>kutsanmış</BlessedChild46.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was born into a famously skilled family of bodyguards. [PAWN_possessive] mothers Elena and Victoria forced [PAWN_objective] into many dangerous situations, training [PAWN_objective] to put [PAWN_possessive] client's well-being over [PAWN_possessive] own.\n\n[PAWN_nameDef] was taught about many herbs and natural poisons to help [PAWN_objective] prevent clients from being poisoned. -->
-  <BodyguardTrainee54.description>[PAWN_nameDef], ünlü, yetenekli bir koruma ailesinde doğdu.Anneleri Elena ve Victoria, onu birçok tehlikeli duruma zorladı ve müvekkilinin iyiliğini kendisininkinden üstün tutması için eğitti.\n\n .[PAWN_nameDef]'ye birçok şifalı bitki ve doğal bitki hakkında bilgi verildi. Müşterilerin zehirlenmesini önlemesine yardımcı olmak için zehirler de öğretildi.</BodyguardTrainee54.description>
+  <BodyguardTrainee54.description>[PAWN_nameDef], ünlü, yetenekli bir koruma ailesinde doğdu.Anneleri Elena ve Victoria, onu birçok tehlikeli duruma zorladı ve müvekkilinin iyiliğini kendisininkinden üstün tutması için eğitti.\n\n[PAWN_nameDef]'ye birçok şifalı bitki ve doğal bitki hakkında bilgi verildi. Müşterilerin zehirlenmesini önlemesine yardımcı olmak için zehirler de öğretildi.</BodyguardTrainee54.description>
   <!-- EN: bodyguard trainee -->
   <BodyguardTrainee54.title>stajyer koruma</BodyguardTrainee54.title>
   <BodyguardTrainee54.titleFemale>stajyer koruma</BodyguardTrainee54.titleFemale>
@@ -263,7 +263,7 @@
   <BodyguardTrainee54.titleShortFemale>koruma</BodyguardTrainee54.titleShortFemale>
   
   <!-- EN: Born to a family of fortune hunters, [PAWN_nameDef] always had a passion for ancient history.\n\nThough never a tough or social boy, [PAWN_pronoun] loved to dig through history books as well as dirt piles. -->
-  <BoneCollector14.description>Bir servet avcısı ailesinde doğan [PAWN_nameDef] her zaman antik tarihe tutkuyla bağlıydı.\n\n Hiçbir zaman sert veya sosyal bir çocuk olmasa da tarih kitaplarını ve toprak yığınlarını kazmayı severdi.</BoneCollector14.description>
+  <BoneCollector14.description>Bir servet avcısı ailesinde doğan [PAWN_nameDef] her zaman antik tarihe tutkuyla bağlıydı.\n\nHiçbir zaman sert veya sosyal bir çocuk olmasa da tarih kitaplarını ve toprak yığınlarını kazmayı severdi.</BoneCollector14.description>
   <!-- EN: bone collector -->
   <BoneCollector14.title>Kemik koleksiyoncusu</BoneCollector14.title>
   <BoneCollector14.titleFemale>Kemik koleksiyoncusu</BoneCollector14.titleFemale>
@@ -279,16 +279,16 @@
   <Bookworm3.titleShort>kitap kurdu</Bookworm3.titleShort>
   
   <!-- EN: [PAWN_nameDef] was in a boy scout troop on a midworld.\n\n[PAWN_pronoun] learned many survival skills including how to thrive in the outdoors and how to tend to basic wounds. -->
-  <BoyScout42.description>[PAWN_nameDef] bir orta dünyada izci birliğindeydi.\n\n Dışarıda nasıl başarılı olunacağı ve temel yaralara nasıl bakılacağı dahil olmak üzere birçok hayatta kalma becerisi öğrendi.</BoyScout42.description>
+  <BoyScout42.description>[PAWN_nameDef] bir orta dünyada izci birliğindeydi.\n\nDışarıda nasıl başarılı olunacağı ve temel yaralara nasıl bakılacağı dahil olmak üzere birçok hayatta kalma becerisi öğrendi.</BoyScout42.description>
   <!-- EN: boy scout -->
   <BoyScout42.title>cocuk izci</BoyScout42.title>
   <BoyScout42.titleFemale>cocuk izci</BoyScout42.titleFemale>
   <!-- EN: scout -->
-  <BoyScout42.titleShort>izci</BoyScout42.titleShort>
-  <BoyScout42.titleShortFemale>izci</BoyScout42.titleShortFemale>
+  <BoyScout42.titleShort>İzci</BoyScout42.titleShort>
+  <BoyScout42.titleShortFemale>İzci</BoyScout42.titleShortFemale>
   
   <!-- EN: War may never change - but the cast of characters does.\n\nBorn on a violent urbworld, [PAWN_nameDef] was trained from a young age to fight the wars of others, and became rather good at it. -->
-  <BoySoldier14.description>Savaş asla değişmeyebilir - ancak karakterler değişir.\n\n Şiddet içeren bir urbworld'de doğan [PAWN_nameDef], küçük yaştan itibaren diğerlerinin savaşlarına katılmak için eğitildi ve bunda oldukça başarılı oldu.</BoySoldier14.description>
+  <BoySoldier14.description>Savaş asla değişmeyebilir - ancak karakterler değişir.\n\nŞiddet içeren bir urbworld'de doğan [PAWN_nameDef], küçük yaştan itibaren diğerlerinin savaşlarına katılmak için eğitildi ve bunda oldukça başarılı oldu.</BoySoldier14.description>
   <!-- EN: boy soldier -->
   <BoySoldier14.title>çocuk asker</BoySoldier14.title>
   <!-- EN: soldier -->
@@ -305,7 +305,7 @@
   <BrothelGofer84.titleShortFemale>ayakçı</BrothelGofer84.titleShortFemale>
   
   <!-- EN: Growing up in a gang, [PAWN_nameDef] learned the brutality of the streets.\n\nKnowing that showing weakness could be fatal, [PAWN_pronoun] closed [PAWN_objective]self off from others. -->
-  <BrutalThief59.description>Bir çete içinde büyüyen [PAWN_nameDef], sokakların vahşetini öğrendi.\n\n Zayıflık göstermenin ölümcül olabileceğini bilerek, kendini diğerlerinden soyutladı.</BrutalThief59.description>
+  <BrutalThief59.description>Bir çete içinde büyüyen [PAWN_nameDef], sokakların vahşetini öğrendi.\n\nZayıflık göstermenin ölümcül olabileceğini bilerek, kendini diğerlerinden soyutladı.</BrutalThief59.description>
   <!-- EN: brutal thief -->
   <BrutalThief59.title>gaddar hırsız</BrutalThief59.title>
   <BrutalThief59.titleFemale>gaddar hırsız</BrutalThief59.titleFemale>
@@ -314,14 +314,14 @@
   <BrutalThief59.titleShortFemale>hırsız</BrutalThief59.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] grew up in an underground shelter, waiting for radioactive fallout to subside. [PAWN_possessive] rich family had gained access to a luxury bunker city, while billions died on the surface.\n\nDetermined to one day seek revenge against the hated enemy, [PAWN_nameDef] spent most of [PAWN_possessive] time practicing shooting in [PAWN_possessive] private training facility. -->
-  <BunkerKid41.description>[PAWN_nameDef] bir yeraltı sığınağında, radyoaktif serpintilerin dinmesini bekleyerek büyüdü. Zengin ailesi lüks bir sığınak şehrine erişim sağlarken, milyarlarca insan yüzeyde can verdi.\n\n Bir gün nefret edilen düşmandan intikam almaya kararlı olan [PAWN_nameDef], zamanının çoğunu özel eğitim tesisinde atış pratiği yaparak geçirdi. .</BunkerKid41.description>
+  <BunkerKid41.description>[PAWN_nameDef] bir yeraltı sığınağında, radyoaktif serpintilerin dinmesini bekleyerek büyüdü. Zengin ailesi lüks bir sığınak şehrine erişim sağlarken, milyarlarca insan yüzeyde can verdi.\n\nBir gün nefret edilen düşmandan intikam almaya kararlı olan [PAWN_nameDef], zamanının çoğunu özel eğitim tesisinde atış pratiği yaparak geçirdi. .</BunkerKid41.description>
   <!-- EN: bunker kid -->
   <BunkerKid41.title>sığınak çocuğu</BunkerKid41.title>
   <!-- EN: bunker kid -->
   <BunkerKid41.titleShort>sığınak çocuğu</BunkerKid41.titleShort>
   
   <!-- EN: Born on the planet New China, [PAWN_nameDef]'s father was a police chief and kept extremely strict watch over [PAWN_possessive] son.\n\n[PAWN_nameDef] had to do military-style drill exercises every day and keep [PAWN_possessive] room spotlessly clean, always ready for inspection. [PAWN_pronoun] came to abhor violence. -->
-  <Cadet96.description>Yeni Çin gezegeninde doğan [PAWN_nameDef]'in babası polis şefiydi ve oğluna son derece sıkı bir şekilde göz kulak oldu.\n\n [PAWN_nameDef] her gün askeri tarzda tatbikatlar yapmak ve odasını tertemiz tutmak zorundaydı , her zaman denetime hazır. Şiddetten nefret etmeye meyilliydi</Cadet96.description>
+  <Cadet96.description>Yeni Çin gezegeninde doğan [PAWN_nameDef]'in babası polis şefiydi ve oğluna son derece sıkı bir şekilde göz kulak oldu.\n\n[PAWN_nameDef] her gün askeri tarzda tatbikatlar yapmak ve odasını tertemiz tutmak zorundaydı , her zaman denetime hazır. Şiddetten nefret etmeye meyilliydi</Cadet96.description>
   <!-- EN: cadet -->
   <Cadet96.title>harbiyeli</Cadet96.title>
   <Cadet96.titleFemale>harbiyeli</Cadet96.titleFemale>
@@ -330,7 +330,7 @@
   <Cadet96.titleShortFemale>harbiyeli</Cadet96.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was born on a urbworld merchant ship to an entrepreneurial mother and an absent father. Born male, [PAWN_pronoun] disliked boy stuff, and got into [PAWN_possessive] mother's things all the time.\n\nEventually, [PAWN_pronoun] traveled with [PAWN_possessive] mother to a glitterworld and spent [PAWN_possessive] savings on a body [PAWN_pronoun] was happy with. -->
-  <CaravanChild53.description>[PAWN_nameDef] bir urbworld ticaret gemisinde girişimci bir anne ve yanında olmayan bir babanın çocuğu olarak dünyaya geldi. Erkek olarak doğdu, erkek  eşyalarını sevmedi ve her zaman annesinin eşyalarına girdi.\n\n Sonunda annesiyle bir glitterworld'e gitti ve biriktirdiği parayı mutlu olduğu bir vücuda harcadı.</CaravanChild53.description>
+  <CaravanChild53.description>[PAWN_nameDef] bir urbworld ticaret gemisinde girişimci bir anne ve yanında olmayan bir babanın çocuğu olarak dünyaya geldi. Erkek olarak doğdu, erkek  eşyalarını sevmedi ve her zaman annesinin eşyalarına girdi.\n\nSonunda annesiyle bir glitterworld'e gitti ve biriktirdiği parayı mutlu olduğu bir vücuda harcadı.</CaravanChild53.description>
   <!-- EN: caravan child -->
   <CaravanChild53.title>kervan cocuğu</CaravanChild53.title>
   <!-- EN: child -->
@@ -346,7 +346,7 @@
   <CaravanTraveler6.titleShortFemale>gezgin</CaravanTraveler6.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] helped out in [PAWN_possessive] father's cat breeding business, socializing, herding, and feeding hundreds of cats.\n\nWhen [PAWN_pronoun] refused to clean up after the cats, [PAWN_pronoun] was transferred to the breeding science division. -->
-  <CatHerder4.description>[PAWN_nameDef] babasının kedi yetiştirme işinde; sosyalleşmesinde, gütmesinde ve yüzlerce kediyi beslemesinde yardımcı oldu.\n\n Kedilere baktıktan sonra temizlik yapmayı reddedince üreme bilimi bölümüne transfer edildi.</CatHerder4.description>
+  <CatHerder4.description>[PAWN_nameDef] babasının kedi yetiştirme işinde; sosyalleşmesinde, gütmesinde ve yüzlerce kediyi beslemesinde yardımcı oldu.\n\nKedilere baktıktan sonra temizlik yapmayı reddedince üreme bilimi bölümüne transfer edildi.</CatHerder4.description>
   <!-- EN: cat herder -->
   <CatHerder4.title>kedi çobanı</CatHerder4.title>
   <CatHerder4.titleFemale>kedi çobanı</CatHerder4.titleFemale>
@@ -355,14 +355,14 @@
   <CatHerder4.titleShortFemale>çoban</CatHerder4.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] grew up in a cave on an tundra planet, and was adopted by a traveling group of entertainers known only as the Wizards. Once a starfaring crew, the Wizards told [PAWN_objective] wondrous stories about the universe.\n\nOne day, the Wizards did not return from scavenging. After years of waiting, [PAWN_nameDef] set off into space to find them. -->
-  <CaveChild17.description>[PAWN_nameDef] bir tundra gezegenindeki bir mağarada büyüdü ve yalnızca Sihirbazlar olarak bilinen gezici bir eğlence grubu tarafından evlat edinildi. Bir zamanlar yıldızlardan kaçan bir ekip olan Büyücüler, ona evren hakkında harika hikayeler anlattı.\n\n Bir gün, Büyücüler yağmadan geri dönmedi. [PAWN_nameDef] yıllarca bekledikten sonra onları bulmak için uzaya doğru yola çıktı.</CaveChild17.description>
+  <CaveChild17.description>[PAWN_nameDef] bir tundra gezegenindeki bir mağarada büyüdü ve yalnızca Sihirbazlar olarak bilinen gezici bir eğlence grubu tarafından evlat edinildi. Bir zamanlar yıldızlardan kaçan bir ekip olan Büyücüler, ona evren hakkında harika hikayeler anlattı.\n\nBir gün, Büyücüler yağmadan geri dönmedi. [PAWN_nameDef] yıllarca bekledikten sonra onları bulmak için uzaya doğru yola çıktı.</CaveChild17.description>
   <!-- EN: cave child -->
   <CaveChild17.title>mağara çocuğu</CaveChild17.title>
   <!-- EN: cave kid -->
   <CaveChild17.titleShort>mağara cocuğu</CaveChild17.titleShort>
   
   <!-- EN: [PAWN_nameDef] loved to play chess. [PAWN_pronoun] even earned the nickname [PAWN_nameDef] for some of [PAWN_possessive] craftier moves.\n\n[PAWN_pronoun] never got into trouble - mostly because [PAWN_pronoun] was good at not getting caught. -->
-  <ChessMaster67.description>[PAWN_nameDef] satranç oynamayı severdi. Hatta bazı kurnaz hareketleri için GrandMaster takma adını bile kazandı.\n\n Başı hiç belaya girmedi - çoğunlukla yakalanmamakta iyi olduğu için.</ChessMaster67.description>
+  <ChessMaster67.description>[PAWN_nameDef] satranç oynamayı severdi. Hatta bazı kurnaz hareketleri için GrandMaster takma adını bile kazandı.\n\nBaşı hiç belaya girmedi - çoğunlukla yakalanmamakta iyi olduğu için.</ChessMaster67.description>
   <!-- EN: chess master -->
   <ChessMaster67.title>satranç ustası</ChessMaster67.title>
   <ChessMaster67.titleFemale>satranç ustası</ChessMaster67.titleFemale>
@@ -371,7 +371,7 @@
   <ChessMaster67.titleShortFemale>satrançı</ChessMaster67.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was a child-knave of King Loteric. [PAWN_pronoun] enjoyed the training with wooden sticks and engaging others in close combat. [PAWN_pronoun] adapted quickly to the heat of battle and was good at spreading fire.\n\n[PAWN_pronoun] served [PAWN_possessive] lord well, until the king died in an unfortunate accident. -->
-  <ChildKnave69.description>[PAWN_nameDef], Kral Loteric'in valesiydi. Tahta sopalarla yapılan eğitimden ve diğerlerini yakın dövüşe sokmaktan keyif aldı. Savaşın sıcaklığına çabuk uyum sağladı ve ateşi yaymakta iyiydi.\n\n Kral talihsiz bir kazada ölene kadar efendisine iyi hizmet etti.</ChildKnave69.description>
+  <ChildKnave69.description>[PAWN_nameDef], Kral Loteric'in valesiydi. Tahta sopalarla yapılan eğitimden ve diğerlerini yakın dövüşe sokmaktan keyif aldı. Savaşın sıcaklığına çabuk uyum sağladı ve ateşi yaymakta iyiydi.\n\nKral talihsiz bir kazada ölene kadar efendisine iyi hizmet etti.</ChildKnave69.description>
   <!-- EN: child-knave -->
   <ChildKnave69.title>çocuk vale</ChildKnave69.title>
   <!-- EN: knave -->
@@ -386,7 +386,7 @@
   <ChildOfDrifters18.titleShortFemale>serseri</ChildOfDrifters18.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was raised underground on a "marble" planet - a wasteland of radioactive asphalt and toxic fallout.\n\nTo survive on a planet devoid of life, [PAWN_pronoun] had to learn how to farm underground and how to fight without wasting bullets. -->
-  <ChildOfGlass61.description>[PAWN_nameDef] yeraltında "mermer" bir gezegende büyütüldü - radyoaktif asfalt ve toksik serpintiden oluşan bir çorak arazi.\n\n Hayattan yoksun bir gezegende hayatta kalabilmek için yeraltında nasıl tarım yapılacağını ve mermileri boşa harcamadan nasıl savaşılacağını öğrenmek zorundaydı. .</ChildOfGlass61.description>
+  <ChildOfGlass61.description>[PAWN_nameDef] yeraltında "mermer" bir gezegende büyütüldü - radyoaktif asfalt ve toksik serpintiden oluşan bir çorak arazi.\n\nHayattan yoksun bir gezegende hayatta kalabilmek için yeraltında nasıl tarım yapılacağını ve mermileri boşa harcamadan nasıl savaşılacağını öğrenmek zorundaydı. .</ChildOfGlass61.description>
   <!-- EN: child of glass -->
   <ChildOfGlass61.title>cam çocuk</ChildOfGlass61.title>
   <!-- EN: survivor -->
@@ -400,7 +400,7 @@
   <ChildProdigy76.titleShort>dahi</ChildProdigy76.titleShort>
   
   <!-- EN: A frightfully intelligent child, [PAWN_nameDef] was kidnapped by a glitterworld corporation and forced to research technologies for weaponizing anti-matter.\n\n[PAWN_pronoun] vowed never to invent anything again. -->
-  <ChildResearcher32.description>Korkunç derecede zeki bir çocuk olan [PAWN_nameDef] bir glitterworld şirketi tarafından kaçırıldı ve anti-maddeyi silah yapmak için teknolojiler araştırmaya zorlandı.\n\n Bir daha hiçbir şey icat etmeyeceğine yemin etti.</ChildResearcher32.description>
+  <ChildResearcher32.description>Korkunç derecede zeki bir çocuk olan [PAWN_nameDef] bir glitterworld şirketi tarafından kaçırıldı ve anti-maddeyi silah yapmak için teknolojiler araştırmaya zorlandı.\n\nBir daha hiçbir şey icat etmeyeceğine yemin etti.</ChildResearcher32.description>
   <!-- EN: child researcher -->
   <ChildResearcher32.title>araştırmacı çocuk</ChildResearcher32.title>
   <!-- EN: researcher -->
@@ -408,7 +408,7 @@
   <ChildResearcher32.titleShortFemale>araştırmacı</ChildResearcher32.titleShortFemale>
   
   <!-- EN: After graduating college very young, [PAWN_nameDef] devoted [PAWN_possessive] life to becoming immortal. [PAWN_pronoun] was arrested for trying to genetically modify [PAWN_objective]self.\n\nThe authorities released [PAWN_objective] on the condition that [PAWN_pronoun] would work in a government lab on spacecraft technology. [PAWN_pronoun] was permitted to continue [PAWN_possessive] personal research in [PAWN_possessive] free time. -->
-  <ChildScientist30.description>Üniversiteyi çok genç yaşta bitirdikten sonra [PAWN_nameDef] hayatını ölümsüz olmaya adadı. Kendisini genetik olarak değiştirmeye çalışmaktan tutuklandı.\n\n Yetkililer, uzay aracı teknolojisi üzerine bir devlet laboratuvarında çalışması şartıyla onu serbest bıraktı. Boş zamanlarında kişisel araştırmalarına devam etmesine izin verildi.</ChildScientist30.description>
+  <ChildScientist30.description>Üniversiteyi çok genç yaşta bitirdikten sonra [PAWN_nameDef] hayatını ölümsüz olmaya adadı. Kendisini genetik olarak değiştirmeye çalışmaktan tutuklandı.\n\nYetkililer, uzay aracı teknolojisi üzerine bir devlet laboratuvarında çalışması şartıyla onu serbest bıraktı. Boş zamanlarında kişisel araştırmalarına devam etmesine izin verildi.</ChildScientist30.description>
   <!-- EN: child scientist -->
   <ChildScientist30.title>çocuk bilimadamı</ChildScientist30.title>
   <!-- EN: scientist -->
@@ -424,7 +424,7 @@
   <ChildSlave58.titleShortFemale>köle</ChildSlave58.titleShortFemale>
   
   <!-- EN: Children are often presumed innocent, and so make ideal spies. [PAWN_nameDef] was trained in the arts of infiltration and information-gathering when [PAWN_pronoun] was very young.\n\n[PAWN_possessive] spent years behind enemy lines, gathering intel in a brutal war. During this time, [PAWN_pronoun] had limited opportunity for education. -->
-  <ChildSpy84.description>Çocuklar genellikle masum kabul edilir ve bu nedenle ideal casuslar olurlar. [PAWN_nameDef], çok küçükken sızma ve bilgi toplama sanatlarında eğitildi.\n\n Yıllarını düşman hatlarının gerisinde acımasız bir savaşta istihbarat toplayarak geçirdi. Bu süre zarfında, eğitim için sınırlı bir fırsatı vardı.</ChildSpy84.description>
+  <ChildSpy84.description>Çocuklar genellikle masum kabul edilir ve bu nedenle ideal casuslar olurlar. [PAWN_nameDef], çok küçükken sızma ve bilgi toplama sanatlarında eğitildi.\n\nYıllarını düşman hatlarının gerisinde acımasız bir savaşta istihbarat toplayarak geçirdi. Bu süre zarfında, eğitim için sınırlı bir fırsatı vardı.</ChildSpy84.description>
   <!-- EN: child spy -->
   <ChildSpy84.title>casus çocuk</ChildSpy84.title>
   <ChildSpy84.titleFemale>casus çocuk</ChildSpy84.titleFemale>
@@ -433,7 +433,7 @@
   <ChildSpy84.titleShortFemale>casus</ChildSpy84.titleShortFemale>
   
   <!-- EN: Growing up in the circus, [PAWN_nameDef] learned a lot of interesting things. More interesting than the balls [PAWN_pronoun] juggled were the pockets [PAWN_pronoun] picked between shows.\n\nA mistake with some firesticks made [PAWN_objective] develop a deathly fear of fire. -->
-  <CircusPerformer37.description>Sirkte büyüyen [PAWN_nameDef] birçok ilginç şey öğrendi. Hokkabazlık yaptığı toplardan daha ilginci, göstericilerin arasında topladığı ceplerdiki paraydı.\n\n Ateş çubuklarıyla yaptığı gösterideki bir hata, ölümcül bir ateş korkusu geliştirmesine neden oldu.</CircusPerformer37.description>
+  <CircusPerformer37.description>Sirkte büyüyen [PAWN_nameDef] birçok ilginç şey öğrendi. Hokkabazlık yaptığı toplardan daha ilginci, göstericilerin arasında topladığı ceplerdiki paraydı.\n\nAteş çubuklarıyla yaptığı gösterideki bir hata, ölümcül bir ateş korkusu geliştirmesine neden oldu.</CircusPerformer37.description>
   <!-- EN: circus performer -->
   <CircusPerformer37.title>sirk çalışanı</CircusPerformer37.title>
   <CircusPerformer37.titleFemale>sirk çalışanı</CircusPerformer37.titleFemale>
@@ -442,7 +442,7 @@
   <CircusPerformer37.titleShortFemale>Hokkabaz</CircusPerformer37.titleShortFemale>
   
   <!-- EN: In the ultra-competitive environs of [PAWN_possessive] glitterworld school, [PAWN_nameDef] always offered to play the class clown to diffuse tension.\n\n[PAWN_pronoun] developed a sense of social desperation from this, as well as an appreciation for the artistic side of comedy. -->
-  <ClassClown96.description>Glitterworld okulunun aşırı rekabetçi ortamında [PAWN_nameDef], gerilimi dağıtmak için her zaman sınıfın palyaçosunu oynamayı teklif etti.\n\n Bundan toplumsal bir çaresizlik duygusunu ve komedinin sanatsal yönü için takdir geliştirdi.</ClassClown96.description>
+  <ClassClown96.description>Glitterworld okulunun aşırı rekabetçi ortamında [PAWN_nameDef], gerilimi dağıtmak için her zaman sınıfın palyaçosunu oynamayı teklif etti.\n\nBundan toplumsal bir çaresizlik duygusunu ve komedinin sanatsal yönü için takdir geliştirdi.</ClassClown96.description>
   <!-- EN: class clown -->
   <ClassClown96.title>Sınıfın palyaçosu</ClassClown96.title>
   <!-- EN: clowny kid -->
@@ -475,14 +475,14 @@
   <Colonist22.titleShortFemale>kolonist</Colonist22.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was born the child of two doctors in a small colony. Because of [PAWN_possessive] parents, [PAWN_pronoun] was always interested in science and medicine.\n\n[PAWN_nameDef] never really got along with other children, and as a result became withdrawn and unsociable. -->
-  <ColonyKid47.description>[PAWN_nameDef] küçük bir kolonide iki doktorun çocuğu olarak doğdu. Ailesi nedeniyle her zaman bilim ve tıpla ilgilendi.\n\n [PAWN_nameDef] diğer çocuklarla hiçbir zaman pek iyi geçinemezdi ve sonuç olarak içine kapanık ve asosyal biri oldu.</ColonyKid47.description>
+  <ColonyKid47.description>[PAWN_nameDef] küçük bir kolonide iki doktorun çocuğu olarak doğdu. Ailesi nedeniyle her zaman bilim ve tıpla ilgilendi.\n\n[PAWN_nameDef] diğer çocuklarla hiçbir zaman pek iyi geçinemezdi ve sonuç olarak içine kapanık ve asosyal biri oldu.</ColonyKid47.description>
   <!-- EN: colony kid -->
   <ColonyKid47.title>koloni çocuğu</ColonyKid47.title>
   <!-- EN: colony kid -->
   <ColonyKid47.titleShort>koloni çocuğu</ColonyKid47.titleShort>
   
-  <!-- EN: [PAWN_nameDef] was a street urchin on a feudal steamworld.\n\n        After [PAWN_pronoun] tried to steal food from the palace, the emperor, desperate to secure an heir, took [PAWN_objective] in and groomed [PAWN_objective] to be next in line for the throne. -->
-  <CommonerHeir5.description>[PAWN_nameDef], feodal bir buhar çağı dünyasında bir sokak çocuğuydu. \n\n Saraydan yiyecek çalmaya çalıştıktan sonra, bir varis bulma konusunda umutsuz olan imparator, onu içeri aldı ve taht için sıradaki olması için onu yetiştirdi.</CommonerHeir5.description>
+  <!-- EN: [PAWN_nameDef] was a street urchin on a feudal steamworld.\n\nAfter [PAWN_pronoun] tried to steal food from the palace, the emperor, desperate to secure an heir, took [PAWN_objective] in and groomed [PAWN_objective] to be next in line for the throne. -->
+  <CommonerHeir5.description>[PAWN_nameDef], feodal bir buhar çağı dünyasında bir sokak çocuğuydu.\n\nSaraydan yiyecek çalmaya çalıştıktan sonra, bir varis bulma konusunda umutsuz olan imparator, onu içeri aldı ve taht için sıradaki olması için onu yetiştirdi.</CommonerHeir5.description>
   <!-- EN: commoner heir -->
   <CommonerHeir5.title>alt tabakalı varis</CommonerHeir5.title>
   <CommonerHeir5.titleFemale>alt tabakalı varis</CommonerHeir5.titleFemale>
@@ -490,31 +490,31 @@
   <CommonerHeir5.titleShort>varis</CommonerHeir5.titleShort>
   <CommonerHeir5.titleShortFemale>varis</CommonerHeir5.titleShortFemale>
   
-  <!-- EN: As a child, [PAWN_nameDef] crafted complex algorithms. [PAWN_pronoun] was used as a "human computer" for most of [PAWN_possessive] childhood. This left [PAWN_objective] socially awkward and rather scrawny.\n\n        Despite the solitary confinement, [PAWN_nameDef] developed a great imagination to occupy [PAWN_possessive] idle time. -->
-  <Computer80.description>Çocukken [PAWN_nameDef] karmaşık algoritmalar geliştirdi. Çocukluğunun çoğunda bir "insan bilgisayarı" olarak kullanıldı. Bu onun sosyal açıdan garip ve oldukça cılız kalmasına neden oldu. \n\n Hücre hapsine rağmen [PAWN_nameDef] boş zamanını doldurmak için harika bir hayal gücü geliştirdi.</Computer80.description>
+  <!-- EN: As a child, [PAWN_nameDef] crafted complex algorithms. [PAWN_pronoun] was used as a "human computer" for most of [PAWN_possessive] childhood. This left [PAWN_objective] socially awkward and rather scrawny.\n\nDespite the solitary confinement, [PAWN_nameDef] developed a great imagination to occupy [PAWN_possessive] idle time. -->
+  <Computer80.description>Çocukken [PAWN_nameDef] karmaşık algoritmalar geliştirdi. Çocukluğunun çoğunda bir "insan bilgisayarı" olarak kullanıldı. Bu onun sosyal açıdan garip ve oldukça cılız kalmasına neden oldu.\n\nHücre hapsine rağmen [PAWN_nameDef] boş zamanını doldurmak için harika bir hayal gücü geliştirdi.</Computer80.description>
   <!-- EN: computer -->
   <Computer80.title>Bilgisayar</Computer80.title>
   <!-- EN: computer -->
   <Computer80.titleShort>bilgisayar</Computer80.titleShort>
   
   <!-- EN: [PAWN_nameDef] spent most of [PAWN_possessive] childhood on [PAWN_possessive] computer, typing away, never knowing when to get up and eat.\n\n[PAWN_pronoun] had a very narrow interest: hacking cryptosleep safety protocols. -->
-  <ComputerGeek62.description>[PAWN_nameDef] çocukluğunun çoğunu bilgisayarında oynayarak,ne zaman kalkıp yemek yiyeceğini bilemeden geçirdi. \n\n Çok dar bir ilgisi vardı: kripto uyku güvenlik protokollerini hacklemek.</ComputerGeek62.description>
+  <ComputerGeek62.description>[PAWN_nameDef] çocukluğunun çoğunu bilgisayarında oynayarak,ne zaman kalkıp yemek yiyeceğini bilemeden geçirdi.\n\nÇok dar bir ilgisi vardı: kripto uyku güvenlik protokollerini hacklemek.</ComputerGeek62.description>
   <!-- EN: computer geek -->
   <ComputerGeek62.title>bilgisayar geek</ComputerGeek62.title>
   <!-- EN: geek -->
   <ComputerGeek62.titleShort>geek</ComputerGeek62.titleShort>
   
   <!-- EN: Growing up in [PAWN_possessive] father's lab, [PAWN_nameDef] was given the life of an intellectual elite. [PAWN_pronoun] got everything [PAWN_pronoun] desired, and price was never an object.\n\nHowever [PAWN_nameDef] did not partake in the luxury given to him. Instead, [PAWN_pronoun] pursued more physical, and - in [PAWN_possessive] father's eyes - lower-class jobs. -->
-  <ConstructionGrunt84.description>Babasının laboratuvarında büyüyen [PAWN_nameDef] entelektüel bir seçkinin hayatıbı yaşıyordu. İstediği her şeye sahip,fiyat onun için önemli olmadı. \n\n Ancak [PAWN_nameDef] kendisine verilen lüksen sıkıldı. Bunun yerine, daha fiziksel ve - babasının gözünde - alt sınıf işleri yapmaya başladı.</ConstructionGrunt84.description>
+  <ConstructionGrunt84.description>Babasının laboratuvarında büyüyen [PAWN_nameDef] entelektüel bir seçkinin hayatıbı yaşıyordu. İstediği her şeye sahip,fiyat onun için önemli olmadı.\n\nAncak [PAWN_nameDef] kendisine verilen lüksen sıkıldı. Bunun yerine, daha fiziksel ve - babasının gözünde - alt sınıf işleri yapmaya başladı.</ConstructionGrunt84.description>
   <!-- EN: construction grunt -->
   <ConstructionGrunt84.title>sızlanan inşaatçı</ConstructionGrunt84.title>
   <ConstructionGrunt84.titleFemale>sızlanan inşaatçı</ConstructionGrunt84.titleFemale>
   <!-- EN: builder -->
-  <ConstructionGrunt84.titleShort>inşaat işçisi</ConstructionGrunt84.titleShort>
-  <ConstructionGrunt84.titleShortFemale>inşaat işçisi</ConstructionGrunt84.titleShortFemale>
+  <ConstructionGrunt84.titleShort>İnşaat işçisi</ConstructionGrunt84.titleShort>
+  <ConstructionGrunt84.titleShortFemale>İnşaat işçisi</ConstructionGrunt84.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] spent [PAWN_possessive] formative years on a glitterworld in the core region, where [PAWN_pronoun] and [PAWN_possessive] friends pursued lives of idle pleasure.\n\nAs [PAWN_pronoun] grew up, [PAWN_pronoun] began to find the life of ease unfulfilling. [PAWN_pronoun] decided to look for a more challenging path. -->
-  <CoreDilettante33.description>[PAWN_nameDef] büyüme yıllarını çekirdek bölgedeki bir glitterworld'de geçirdi, burada kendisi ve arkadaşları boş boş gezerek zevkli bir hayat sürdüler. \n\n. Büyüdükçe, kolay hayatın doyumsuz olduğunu anlamaya başladı. Daha zorlu bir yol aramaya karar verdi.</CoreDilettante33.description>
+  <CoreDilettante33.description>[PAWN_nameDef] büyüme yıllarını çekirdek bölgedeki bir glitterworld'de geçirdi, burada kendisi ve arkadaşları boş boş gezerek zevkli bir hayat sürdüler.\n\nBüyüdükçe, kolay hayatın doyumsuz olduğunu anlamaya başladı. Daha zorlu bir yol aramaya karar verdi.</CoreDilettante33.description>
   <!-- EN: core dilettante -->
   <CoreDilettante33.title>çekirdek aylakçı</CoreDilettante33.title>
   <CoreDilettante33.titleFemale>çekirdek aylakçı</CoreDilettante33.titleFemale>
@@ -532,7 +532,7 @@
   <CoreworldStudent50.titleShortFemale>öğrenci</CoreworldStudent50.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was bred to become an executive for the space exploration corporation that owned [PAWN_possessive] home planet. [PAWN_possessive] family had been working for that corporation for four generations.\n\nAt age five, [PAWN_pronoun] enrolled at the corporate academy where [PAWN_pronoun] learned loyalty and ruthlessness. [PAWN_nameDef] excelled in finding diplomatic solutions where others would need violence. -->
-  <CorpBredStudent54.description>[PAWN_nameDef], kendi gezegenine sahip olan uzay araştırma şirketi için yönetici olmak üzere yetiştirildi. ailesi dört kuşaktır o şirkette çalışıyordu. \n\n Beş yaşında, sadakat ve acımasızlığı öğrendiği kurumsal akademiye kaydoldu. [PAWN_nameDef], başkalarının şiddete ihtiyaç duyacağı durumlarda diplomatik çözümler bulma konusunda başarılı oldu.</CorpBredStudent54.description>
+  <CorpBredStudent54.description>[PAWN_nameDef], kendi gezegenine sahip olan uzay araştırma şirketi için yönetici olmak üzere yetiştirildi. ailesi dört kuşaktır o şirkette çalışıyordu.\n\nBeş yaşında, sadakat ve acımasızlığı öğrendiği kurumsal akademiye kaydoldu. [PAWN_nameDef], başkalarının şiddete ihtiyaç duyacağı durumlarda diplomatik çözümler bulma konusunda başarılı oldu.</CorpBredStudent54.description>
   <!-- EN: corp-bred student -->
   <CorpBredStudent54.title>şirket yerlisi</CorpBredStudent54.title>
   <CorpBredStudent54.titleFemale>şirket yerlisi</CorpBredStudent54.titleFemale>
@@ -541,7 +541,7 @@
   <CorpBredStudent54.titleShortFemale>öğrenci</CorpBredStudent54.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] grew up in a colony owned by a large glitterworld corporation. All children had virtual reality devices attached by force, and were raised in a brutal digital world.\n\nConstantly forced to fight others for the entertainment of the wealthy, gunplay and tactics became the center of [PAWN_nameDef]'s universe. -->
-  <CorporateSlave22.description>[PAWN_nameDef] büyük bir glitterworld şirketine ait bir kolonide büyüdü. Tüm çocukların zorla  sanal gerçekliğe bağlanan cihazları vardı ve vahşi bir dijital dünyada büyüdüler.\n\n Zenginlerin eğlencesi için sürekli olarak başkalarıyla savaşmaya zorlanan, silah oyunları ve taktikler [PAWN_nameDef]'in hayatının merkezi haline geldi.</CorporateSlave22.description>
+  <CorporateSlave22.description>[PAWN_nameDef] büyük bir glitterworld şirketine ait bir kolonide büyüdü. Tüm çocukların zorla  sanal gerçekliğe bağlanan cihazları vardı ve vahşi bir dijital dünyada büyüdüler.\n\nZenginlerin eğlencesi için sürekli olarak başkalarıyla savaşmaya zorlanan, silah oyunları ve taktikler [PAWN_nameDef]'in hayatının merkezi haline geldi.</CorporateSlave22.description>
   <!-- EN: corporate slave -->
   <CorporateSlave22.title>kurumsal köle</CorporateSlave22.title>
   <CorporateSlave22.titleFemale>kurumsal köle</CorporateSlave22.titleFemale>
@@ -550,7 +550,7 @@
   <CorporateSlave22.titleShortFemale>asker</CorporateSlave22.titleShortFemale>
   
   <!-- EN: De Dion was bred to become an executive officer for the large space trading corporation that owned [PAWN_possessive] home planet. [PAWN_possessive] family had been working for that corporation for seven generations.\n\nAt age six, [PAWN_pronoun] started to study at the corporate academy, where [PAWN_pronoun] became a loyal follower and a ruthless executive. -->
-  <CorpStudent95.description>[PAWN_nameDef], kendi gezegenine sahip olan büyük uzay ticaret şirketi için yönetici olarak yetiştirildi. Ailesi yedi kuşaktır o şirkette çalışıyordu.\n\n Altı yaşında, sadık bir takipçi ve acımasız bir yönetici olduğu kurumsal akademide okumaya başladı.</CorpStudent95.description>
+  <CorpStudent95.description>[PAWN_nameDef], kendi gezegenine sahip olan büyük uzay ticaret şirketi için yönetici olarak yetiştirildi. Ailesi yedi kuşaktır o şirkette çalışıyordu.\n\nAltı yaşında, sadık bir takipçi ve acımasız bir yönetici olduğu kurumsal akademide okumaya başladı.</CorpStudent95.description>
   <!-- EN: corp student -->
   <CorpStudent95.title>şirket öğrencisi</CorpStudent95.title>
   <CorpStudent95.titleFemale>şirket öğrencisi</CorpStudent95.titleFemale>
@@ -566,7 +566,7 @@
   <CountryChild95.titleShort>taşralı çocuk</CountryChild95.titleShort>
   
   <!-- EN: [PAWN_nameDef] grew up on a rimworld, under the tyranny of [PAWN_possessive] father, who forced [PAWN_objective] to work every day on the farm. [PAWN_pronoun] dreamed of escaping [PAWN_possessive] father and exploring the universe.\n\nOne day, when the trade ship was overhead, [PAWN_pronoun] stowed away among the goods in the launch pods, and escaped into space. -->
-  <CowFarmer39.description>[PAWN_nameDef] onu her gün çiftlikte çalışmaya zorlayan babasının zulmü altında bir rimworld'de büyüdü. Babasından kaçmayı ve evreni keşfetmeyi hayal etti.\n\n Bir gün, ticaret gemisi tepedeyken, fırlatma bölmelerindeki malların arasına saklandı ve uzaya kaçtı.</CowFarmer39.description>
+  <CowFarmer39.description>[PAWN_nameDef] onu her gün çiftlikte çalışmaya zorlayan babasının zulmü altında bir rimworld'de büyüdü. Babasından kaçmayı ve evreni keşfetmeyi hayal etti.\n\nBir gün, ticaret gemisi tepedeyken, fırlatma bölmelerindeki malların arasına saklandı ve uzaya kaçtı.</CowFarmer39.description>
   <!-- EN: cow farmer -->
   <CowFarmer39.title>Büyükbaş çiftçisi</CowFarmer39.title>
   <CowFarmer39.titleFemale>Büyükbaş çiftçisi</CowFarmer39.titleFemale>
@@ -575,14 +575,14 @@
   <CowFarmer39.titleShortFemale>çiftçi</CowFarmer39.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was adopted child of a notorious crime boss. [PAWN_pronoun] was taught all facets of the family business, from smuggling to inventive ways of killing.\n\nWhen the family was attacked, [PAWN_possessive] father ordered [PAWN_objective] to hide in a secret cryptosleep vault. -->
-  <CrimeBossChild39.description>[PAWN_nameDef], kötü şöhretli bir suç patronunun evlatlık çocuğuydu. Kaçakçılıktan,yaratıcı öldürme yöntemlerine kadar aile işinin tüm yönleri kendisine öğretildi.\n\n Aile saldırıya uğradığında, babası ona gizli bir kripto uyku kasasında saklanmasını emretti.</CrimeBossChild39.description>
+  <CrimeBossChild39.description>[PAWN_nameDef], kötü şöhretli bir suç patronunun evlatlık çocuğuydu. Kaçakçılıktan,yaratıcı öldürme yöntemlerine kadar aile işinin tüm yönleri kendisine öğretildi.\n\nAile saldırıya uğradığında, babası ona gizli bir kripto uyku kasasında saklanmasını emretti.</CrimeBossChild39.description>
   <!-- EN: crime boss' child -->
   <CrimeBossChild39.title>Suç patronunun çocuğu</CrimeBossChild39.title>
   <!-- EN: crime kid -->
   <CrimeBossChild39.titleShort>Şuçlu çocuk</CrimeBossChild39.titleShort>
   
   <!-- EN: [PAWN_nameDef] was more interested in the systems and patterns of the world rather than its inhabitants. [PAWN_possessive] social skills suffered.\n\n[PAWN_nameDef] came to understand that all things are part of the whole, and to destroy part would be to destroy all. -->
-  <CuriousChild33.description>[PAWN_nameDef], sakinlerinden çok dünyanın sistemleri ve kalıplarıyla ilgileniyordu. Sosyal becerileri zayıftı.\n\n. [PAWN_nameDef] her şeyin bütünün parçası olduğunu ve parçayı yok etmenin her şeyi yok etmek olduğunu anlamaya başladı.</CuriousChild33.description>
+  <CuriousChild33.description>[PAWN_nameDef], sakinlerinden çok dünyanın sistemleri ve kalıplarıyla ilgileniyordu. Sosyal becerileri zayıftı.\n\n[PAWN_nameDef] her şeyin bütünün parçası olduğunu ve parçayı yok etmenin her şeyi yok etmek olduğunu anlamaya başladı.</CuriousChild33.description>
   <!-- EN: curious child -->
   <CuriousChild33.title>meraklı çocuk</CuriousChild33.title>
   <!-- EN: curious -->
@@ -590,7 +590,7 @@
   <CuriousChild33.titleShortFemale>meraklı</CuriousChild33.titleShortFemale>
   
   <!-- EN: Born on a glitterworld, [PAWN_nameDef] was very interested in the process of documenting information, and quickly became senior glitterpedia recorder.\n\n[PAWN_pronoun] was effective at self-study, but [PAWN_pronoun] lacked social experience. -->
-  <DataDecoder39.description>Bir glitterworld'de doğan [PAWN_nameDef], bilgilerin belgelenmesi süreciyle çok ilgilendi ve kısa sürede kıdemli bir kriptograf oldu.\n\n Kendi kendine çalışma konusunda etkiliydi, ancak sosyal deneyimlerden yoksundu.</DataDecoder39.description>
+  <DataDecoder39.description>Bir glitterworld'de doğan [PAWN_nameDef], bilgilerin belgelenmesi süreciyle çok ilgilendi ve kısa sürede kıdemli bir kriptograf oldu.\n\nKendi kendine çalışma konusunda etkiliydi, ancak sosyal deneyimlerden yoksundu.</DataDecoder39.description>
   <!-- EN: data decoder -->
   <DataDecoder39.title>bilgi kriptografı</DataDecoder39.title>
   <DataDecoder39.titleFemale>bilgi kriptografı</DataDecoder39.titleFemale>
@@ -599,7 +599,7 @@
   <DataDecoder39.titleShortFemale>kriptograf</DataDecoder39.titleShortFemale>
   
   <!-- EN: The child of a wealthy manufacturer, [PAWN_nameDef] was pampered from an early age. [PAWN_pronoun] developed an affinity for reading and art, and a distaste for menial chores.\n\nA revolution brought [PAWN_possessive] father's businesses under state control. Penniless, [PAWN_nameDef] worked hard to complete [PAWN_possessive] education. -->
-  <DedicatedStudent12.description>Zengin bir üreticinin çocuğu olan [PAWN_nameDef] erken yaşlardan itibaren şımartıldı. Okumaya ve sanata karşı bir yakınlık geliştirdi ve sıradan işlerden hoşlanmadı.\n\n. Devrimde babasının işlerini devlet kontrolü altına aldı. Beş parasız [PAWN_nameDef] eğitimini tamamlamak için çok çalıştı.</DedicatedStudent12.description>
+  <DedicatedStudent12.description>Zengin bir üreticinin çocuğu olan [PAWN_nameDef] erken yaşlardan itibaren şımartıldı. Okumaya ve sanata karşı bir yakınlık geliştirdi ve sıradan işlerden hoşlanmadı.\n\nDevrimde babasının işlerini devlet kontrolü altına aldı. Beş parasız [PAWN_nameDef] eğitimini tamamlamak için çok çalıştı.</DedicatedStudent12.description>
   <!-- EN: dedicated student -->
   <DedicatedStudent12.title>adanmış öğrenci</DedicatedStudent12.title>
   <DedicatedStudent12.titleFemale>adanmış öğrenci</DedicatedStudent12.titleFemale>
@@ -608,14 +608,14 @@
   <DedicatedStudent12.titleShortFemale>öğrenci</DedicatedStudent12.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was born to a tribe of desert ascetics who wandered the endless wastes.\n\nThey sought a mythical substance they believed could liberate them from ignorance through psychedelic revelation - and usher in a new period of interstellar peace. -->
-  <DesertRat47.description>[PAWN_nameDef] sonsuz çöllerde dolaşan bir çöl çilekeş kabilesinde doğdu.\n\n Psikedelik vahiy yoluyla kendilerini cehaletten kurtaracağına ve yıldızlararası barışın yeni bir dönemini başlatacağına inandıkları efsanevi bir madde aradılar.</DesertRat47.description>
+  <DesertRat47.description>[PAWN_nameDef] sonsuz çöllerde dolaşan bir çöl çilekeş kabilesinde doğdu.\n\nPsikedelik vahiy yoluyla kendilerini cehaletten kurtaracağına ve yıldızlararası barışın yeni bir dönemini başlatacağına inandıkları efsanevi bir madde aradılar.</DesertRat47.description>
   <!-- EN: desert rat -->
   <DesertRat47.title>çöl faresi</DesertRat47.title>
   <!-- EN: desert rat -->
   <DesertRat47.titleShort>çöl faresi</DesertRat47.titleShort>
   
   <!-- EN: [PAWN_nameDef] was born in diplomatic family.\n\nTravelling often, [PAWN_pronoun] was home-schooled and saw the world mostly through a computer. -->
-  <DiplomatsChild97.description>[PAWN_nameDef] diplomat bir ailede doğdu.\n\n Sık sık seyahat ediyordu, evde eğitim görüyordu ve dünyayı çoğunlukla bir bilgisayar aracılığıyla görüyordu.</DiplomatsChild97.description>
+  <DiplomatsChild97.description>[PAWN_nameDef] diplomat bir ailede doğdu.\n\nSık sık seyahat ediyordu, evde eğitim görüyordu ve dünyayı çoğunlukla bir bilgisayar aracılığıyla görüyordu.</DiplomatsChild97.description>
   <!-- EN: diplomat's child -->
   <DiplomatsChild97.title>diplomatın çocuğu</DiplomatsChild97.title>
   <!-- EN: diplomat -->
@@ -632,7 +632,7 @@
   <DisasterSurvivor29.titleShortFemale>felaketten kurtulan</DisasterSurvivor29.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was uprooted when marauders attacked [PAWN_possessive] family farm, destroying machinery and killing farmhands and beasts alike.\n\nAfter the death of all [PAWN_pronoun] knew, [PAWN_pronoun] was left in the ruins to fend for [PAWN_objective]self. -->
-  <DisasterSurvivor65.description>[PAWN_nameDef], yağmacılar aile çiftliğine saldırdığında;makineleri,çiftçileri,hayvanları öldürüp kökünü kuruttular.\n\n Bildiği her şeyin ölümünden sonra, kendi başının çaresine bakması için harabelerde kaldı.</DisasterSurvivor65.description>
+  <DisasterSurvivor65.description>[PAWN_nameDef], yağmacılar aile çiftliğine saldırdığında;makineleri,çiftçileri,hayvanları öldürüp kökünü kuruttular.\n\nBildiği her şeyin ölümünden sonra, kendi başının çaresine bakması için harabelerde kaldı.</DisasterSurvivor65.description>
   <!-- EN: disaster survivor -->
   <DisasterSurvivor65.title>felaketten kurtulan</DisasterSurvivor65.title>
   <DisasterSurvivor65.titleFemale>felaketten kurtulan</DisasterSurvivor65.titleFemale>
@@ -641,7 +641,7 @@
   <DisasterSurvivor65.titleShortFemale>felaketten kurtulan</DisasterSurvivor65.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] grew up isolated on a trash planet. A dumping ground for surrounding glitterworlds, it was a harsh home. As a baby, [PAWN_pronoun] sucked on the tap of a discarded nutrient paste dispenser for comfort.\n\nIn these desperate circumstances, against all odds, [PAWN_pronoun] survived - and thrived. -->
-  <DiscardedYouth93.description>[PAWN_nameDef] bir gezegenin çöplüğünde izole bir şekilde büyüdü. Çevredeki glitterworld'ler için bir çöplük, zorlu bir evdi. Bebekken yaşamak için atılmış bir besin macunu dağıtıcısının musluğunu emerdi.\n\n Bu umutsuz koşullarda, her şeye rağmen hayatta kaldı - ve başarılı oldu.</DiscardedYouth93.description>
+  <DiscardedYouth93.description>[PAWN_nameDef] bir gezegenin çöplüğünde izole bir şekilde büyüdü. Çevredeki glitterworld'ler için bir çöplük, zorlu bir evdi. Bebekken yaşamak için atılmış bir besin dağıtıcısının musluğunu emerdi.\n\nBu umutsuz koşullarda, her şeye rağmen hayatta kaldı - ve başarılı oldu.</DiscardedYouth93.description>
   <!-- EN: discarded youth -->
   <DiscardedYouth93.title>ıskarta genç</DiscardedYouth93.title>
   <!-- EN: discarded -->
@@ -675,7 +675,7 @@
   <DreadedBaby56.titleShortFemale>bebek dude</DreadedBaby56.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was an expressive child. [PAWN_pronoun] sang often, and made friends very easily, be they young or old, male or female.\n\n[PAWN_pronoun] hated fighting, but when made angry, [PAWN_pronoun] could be dangerous. [PAWN_possessive] temper was quick. -->
-  <Dreamer79.description>[PAWN_nameDef] etkileyici bir çocuktu. Sık sık şarkı söyler ve genç ya da yaşlı, erkek ya da kadın fark etmeksizin çok kolay arkadaş edinirdi.\n\n Dövüşmekten nefret ederdi ama sinirlendiğinde tehlikeli olabilirdi. Çabuk öfkeniirdi.</Dreamer79.description>
+  <Dreamer79.description>[PAWN_nameDef] etkileyici bir çocuktu. Sık sık şarkı söyler ve genç ya da yaşlı, erkek ya da kadın fark etmeksizin çok kolay arkadaş edinirdi.\n\nDövüşmekten nefret ederdi ama sinirlendiğinde tehlikeli olabilirdi. Çabuk öfkeniirdi.</Dreamer79.description>
   <!-- EN: dreamer -->
   <Dreamer79.title>hayalperest</Dreamer79.title>
   <Dreamer79.titleFemale>hayalperest</Dreamer79.titleFemale>
@@ -684,7 +684,7 @@
   <Dreamer79.titleShortFemale>hayalperest</Dreamer79.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was never sure what [PAWN_pronoun] wanted to do with [PAWN_possessive] life. [PAWN_pronoun] spent most of [PAWN_possessive] time doing low-wage jobs and wondering what [PAWN_possessive] future would be like.\n\n[PAWN_pronoun] entertained [PAWN_objective]self with space sims and survival games, dreaming of one day being somewhere more interesting. -->
-  <Drudge9.description>[PAWN_nameDef] hayatıyla ne yapmak istediğinden asla emin değildi. Zamanının çoğunu düşük ücretli işler yaparak ve geleceğinin nasıl olacağını merak ederek geçirdi.\n\n Bir gün daha ilginç bir yerde olmanın hayalini kurarak, kendini uzay simülasyonları ve hayatta kalma oyunlarıyla eğlendirdi.</Drudge9.description>
+  <Drudge9.description>[PAWN_nameDef] hayatıyla ne yapmak istediğinden asla emin değildi. Zamanının çoğunu düşük ücretli işler yaparak ve geleceğinin nasıl olacağını merak ederek geçirdi.\n\nBir gün daha ilginç bir yerde olmanın hayalini kurarak, kendini uzay simülasyonları ve hayatta kalma oyunlarıyla eğlendirdi.</Drudge9.description>
   <!-- EN: drudge -->
   <Drudge9.title>ağır işçi</Drudge9.title>
   <Drudge9.titleFemale>ağır işçi</Drudge9.titleFemale>
@@ -693,7 +693,7 @@
   <Drudge9.titleShortFemale>ağır işçi</Drudge9.titleShortFemale>
   
   <!-- EN: Raised in an orphanage, [PAWN_nameDef] turned towards the gang life at age ten.\n\n[PAWN_pronoun] was exploited by the local gang as a drug mule to traffic "substance F" across rival gang territory. [PAWN_pronoun] took a bullet or two. -->
-  <DrugMule80.description>Yetimhanede büyüyen [PAWN_nameDef], on yaşında çete hayatına yöneldi.\n\n Yerel çete tarafından veya rakip çete topraklarında "F maddesi" ticareti yapmak için bir uyuşturucu kuryesi olarak sömürüldü. Bir iki kurşun yedi.</DrugMule80.description>
+  <DrugMule80.description>Yetimhanede büyüyen [PAWN_nameDef], on yaşında çete hayatına yöneldi.\n\nYerel çete tarafından veya rakip çete topraklarında "F maddesi" ticareti yapmak için bir uyuşturucu kuryesi olarak sömürüldü. Bir iki kurşun yedi.</DrugMule80.description>
   <!-- EN: drug mule -->
   <DrugMule80.title>kartel kuryesi</DrugMule80.title>
   <DrugMule80.titleFemale>kartel kuryesi</DrugMule80.titleFemale>
@@ -702,7 +702,7 @@
   <DrugMule80.titleShortFemale>kurye</DrugMule80.titleShortFemale>
   
   <!-- EN: From the time [PAWN_nameDef] could walk, [PAWN_pronoun] helped take care of the animals and crops that [PAWN_possessive] people tended in their arid homeland.\n\nThe work toughened [PAWN_objective], but left little time for intellectual activities. -->
-  <DustyFarmHand75.description>[PAWN_nameDef] yürüyebildiği andan itibaren, halkının kurak anavatanlarında yetiştirdiği hayvanlara ve ekinlere bakmaya yardım etti.\n\n İşi onu sertleştirdi ve entelektüel faaliyetlere çok az zaman bıraktı.</DustyFarmHand75.description>
+  <DustyFarmHand75.description>[PAWN_nameDef] yürüyebildiği andan itibaren, halkının kurak anavatanlarında yetiştirdiği hayvanlara ve ekinlere bakmaya yardım etti.\n\nİşi onu sertleştirdi ve entelektüel faaliyetlere çok az zaman bıraktı.</DustyFarmHand75.description>
   <!-- EN: dusty farm hand -->
   <DustyFarmHand75.title>aksi rençper</DustyFarmHand75.title>
   <DustyFarmHand75.titleFemale>aksi rençper</DustyFarmHand75.titleFemale>
@@ -711,7 +711,7 @@
   <DustyFarmHand75.titleShortFemale>rençper</DustyFarmHand75.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was an incredibly empathetic child, so much that [PAWN_pronoun] was totally overwhelmed by simple social interactions. Once, [PAWN_pronoun] stepped on a bug and felt so guilty [PAWN_pronoun] cried for an hour.\n\n[PAWN_nameDef] did try to use a gun one time, but it went very poorly, as the loud noise made [PAWN_objective] flinch uncontrollably. -->
-  <Empath47.description>[PAWN_nameDef] inanılmaz derecede empatik bir çocuktu, o kadar ki basit sosyal etkileşimlerden tamamen bunalmıştı. Bir keresinde bir böceğe bastı ve kendini o kadar suçlu hissetti ki bir saat ağladı.\n\n [PAWN_nameDef] bir kez silah kullanmayı denedi ancak çok kötü gitti.Çünkü yüksek ses kontrolsüz bir şekilde irkilmesine neden oldu.</Empath47.description>
+  <Empath47.description>[PAWN_nameDef] inanılmaz derecede empatik bir çocuktu, o kadar ki basit sosyal etkileşimlerden tamamen bunalmıştı. Bir keresinde bir böceğe bastı ve kendini o kadar suçlu hissetti ki bir saat ağladı.\n\n[PAWN_nameDef] bir kez silah kullanmayı denedi ancak çok kötü gitti.Çünkü yüksek ses kontrolsüz bir şekilde irkilmesine neden oldu.</Empath47.description>
   <!-- EN: empath -->
   <Empath47.title>empat</Empath47.title>
   <Empath47.titleFemale>empat</Empath47.titleFemale>
@@ -720,14 +720,14 @@
   <Empath47.titleShortFemale>empat</Empath47.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] grew up on a glitterworld, training in rapier arts and singing. [PAWN_pronoun] spent several years as an energetic teen pop idol.\n\nHowever, [PAWN_pronoun] decided that the music and modeling industries were not paying [PAWN_objective] enough attention, so [PAWN_pronoun] left. -->
-  <EnergeticPopIdol61.description>[PAWN_nameDef], meç sanatlarında eğitim alarak ve şarkı söyleyerek bir glitterworld'de büyüdü. Enerjik bir genç pop idolü olarak birkaç yıl geçirdi.\n\n Ancak müzik ve mankenlik endüstrilerinin ona yeterince ilgi göstermediğine karar verdi ve ayrıldı.</EnergeticPopIdol61.description>
+  <EnergeticPopIdol61.description>[PAWN_nameDef], meç sanatlarında eğitim alarak ve şarkı söyleyerek bir glitterworld'de büyüdü. Enerjik bir genç pop idolü olarak birkaç yıl geçirdi.\n\nAncak müzik ve mankenlik endüstrilerinin ona yeterince ilgi göstermediğine karar verdi ve ayrıldı.</EnergeticPopIdol61.description>
   <!-- EN: energetic pop idol -->
   <EnergeticPopIdol61.title>enerjik pop idolü</EnergeticPopIdol61.title>
   <!-- EN: pop idol -->
   <EnergeticPopIdol61.titleShort>pop idol</EnergeticPopIdol61.titleShort>
   
   <!-- EN: A member of a royal family, [PAWN_nameDef] was exiled for shaming [PAWN_possessive] family.\n\nLiving in a foreign land, mostly alone, [PAWN_pronoun] spent most of [PAWN_possessive] time making huts and houses to live in. [PAWN_pronoun] found little time in an average day for enjoyment, and lost all [PAWN_possessive] friends and family. -->
-  <ExiledPrince58.description>Kraliyet ailesinin bir üyesi olan [PAWN_nameDef] ailesini utandırdığı için sürgüne gönderildi.\n\n Yabancı bir ülkede, çoğunlukla yalnız yaşayarak, zamanının çoğunu içinde yaşamak için kulübeler ve evler yaparak geçirdi. Ortalama bir günde eğlenmek için çok az zaman buldu ve tüm arkadaşlarını ve ailesini kaybetti.</ExiledPrince58.description>
+  <ExiledPrince58.description>Kraliyet ailesinin bir üyesi olan [PAWN_nameDef] ailesini utandırdığı için sürgüne gönderildi.\n\nYabancı bir ülkede, çoğunlukla yalnız yaşayarak, zamanının çoğunu içinde yaşamak için kulübeler ve evler yaparak geçirdi. Ortalama bir günde eğlenmek için çok az zaman buldu ve tüm arkadaşlarını ve ailesini kaybetti.</ExiledPrince58.description>
   <!-- EN: exiled prince -->
   <ExiledPrince58.title>sürgün prens</ExiledPrince58.title>
   <ExiledPrince58.titleFemale>sürgün prenses</ExiledPrince58.titleFemale>
@@ -736,29 +736,29 @@
   <ExiledPrince58.titleShortFemale>prenses</ExiledPrince58.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] grew up in a large factory city on an industrial world.\n\nSince poverty was rampant and food scarce, [PAWN_pronoun] worked for whatever wages [PAWN_pronoun] could get. This wasn't an easy life, but [PAWN_nameDef] never shied away from a hard day's work. -->
-  <FactoryDrone58.description>[PAWN_nameDef], endüstriyel bir dünyada büyük bir fabrika şehrinde büyüdü.\n\n Yoksulluk had safhada ve yiyecek kıt olduğu için, alabildiği her ücret için çalıştı. Bu kolay bir hayat değildi, ama [PAWN_nameDef] zor bir günün işinden asla kaçmadı.</FactoryDrone58.description>
+  <FactoryDrone58.description>[PAWN_nameDef], endüstriyel bir dünyada büyük bir fabrika şehrinde büyüdü.\n\nYoksulluk had safhada ve yiyecek kıt olduğu için, alabildiği her ücret için çalıştı. Bu kolay bir hayat değildi, ama [PAWN_nameDef] zor bir günün işinden asla kaçmadı.</FactoryDrone58.description>
   <!-- EN: factory drone -->
   <FactoryDrone58.title>endüstriyel drone</FactoryDrone58.title>
   <!-- EN: worker -->
-  <FactoryDrone58.titleShort>işçi</FactoryDrone58.titleShort>
-  <FactoryDrone58.titleShortFemale>işçi</FactoryDrone58.titleShortFemale>
+  <FactoryDrone58.titleShort>İşçi</FactoryDrone58.titleShort>
+  <FactoryDrone58.titleShortFemale>İşçi</FactoryDrone58.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was born on a glitterworld falling into chaos. [PAWN_possessive] father was killed in action.\n\n[PAWN_pronoun] struggled for a scholarship at Utmaior Academy and had to prove [PAWN_possessive] right to be there. A child genius, [PAWN_pronoun] was bullied as a charity case and couldn't make friends with the other kids. -->
-  <FallenProdigy40.description>[PAWN_nameDef] kaosa düşen bir glitterworld'de doğdu. Babası operasyonda öldürüldü.\n\n Utmaior Akademisi'nde burs için mücadele etti ve orada bulunma hakkını kanıtlaması gerekiyordu. Bir çocuk deha ve bir hayırsever olarak zorbalığa uğradı ve diğer çocuklarla arkadaş olamadı.</FallenProdigy40.description>
+  <FallenProdigy40.description>[PAWN_nameDef] kaosa düşen bir glitterworld'de doğdu. Babası operasyonda öldürüldü.\n\nUtmaior Akademisi'nde burs için mücadele etti ve orada bulunma hakkını kanıtlaması gerekiyordu. Bir çocuk deha ve bir hayırsever olarak zorbalığa uğradı ve diğer çocuklarla arkadaş olamadı.</FallenProdigy40.description>
   <!-- EN: fallen prodigy -->
   <FallenProdigy40.title>düşmüş deha</FallenProdigy40.title>
   <!-- EN: prodigy -->
   <FallenProdigy40.titleShort>deha</FallenProdigy40.titleShort>
   
   <!-- EN: [PAWN_nameDef] worked on [PAWN_possessive] family's farm, looking after the animals and treating them when they were injured. Preferring hands-on tasks and the outdoors, [PAWN_pronoun] avoided softer jobs that might have kept [PAWN_objective] cooped up inside.\n\n[PAWN_pronoun] enjoyed this lonely work, and tended to stay out of people's way and do [PAWN_possessive] own thing. -->
-  <FarmBoy64.description>[PAWN_nameDef] ailesinin çiftliğinde çalıştı, hayvanlara baktı ve yaralandıklarında onları tedavi etti. Uygulamalı görevleri ve açık havayı tercih ederek, kendisini içeride tutabilecek daha yumuşak işlerden kaçındı.\n\n Bu yalnız işten zevk aldı ve insanların yolundan uzak durmaya ve kendi işini yapmaya meyilliydi.</FarmBoy64.description>
+  <FarmBoy64.description>[PAWN_nameDef] ailesinin çiftliğinde çalıştı, hayvanlara baktı ve yaralandıklarında onları tedavi etti. Uygulamalı görevleri ve açık havayı tercih ederek, kendisini içeride tutabilecek daha yumuşak işlerden kaçındı.\n\nBu yalnız işten zevk aldı ve insanların yolundan uzak durmaya ve kendi işini yapmaya meyilliydi.</FarmBoy64.description>
   <!-- EN: farm boy -->
   <FarmBoy64.title>çocuk çiftçi</FarmBoy64.title>
   <!-- EN: farm boy -->
   <FarmBoy64.titleShort>çocuk çiftçi</FarmBoy64.titleShort>
   
   <!-- EN: [PAWN_nameDef]'s parents died in a fire when [PAWN_pronoun] was seven. [PAWN_pronoun] grew up on [PAWN_possessive] uncle's farm, plowing fields and doing manual labor.\n\n[PAWN_pronoun] could not bear answering questions about [PAWN_possessive] parents, so [PAWN_pronoun] replaced social contact with hard work. -->
-  <FarmerBoy88.description>[PAWN_nameDef]'in ailesi o yedi yaşındayken bir yangında öldü. Amcasının çiftliğinde, tarlaları sürerek ve el emeğiyle büyüdü.\n\n Ebeveynleri hakkındaki soruları yanıtlamaya dayanamadı, bu yüzden sosyal teması sıkı çalışma ile değiştirdi.</FarmerBoy88.description>
+  <FarmerBoy88.description>[PAWN_nameDef]'in ailesi o yedi yaşındayken bir yangında öldü. Amcasının çiftliğinde, tarlaları sürerek ve el emeğiyle büyüdü.\n\nEbeveynleri hakkındaki soruları yanıtlamaya dayanamadı, bu yüzden sosyal teması sıkı çalışma ile değiştirdi.</FarmerBoy88.description>
   <!-- EN: farmer boy -->
   <FarmerBoy88.title>çiftçi çocuk</FarmerBoy88.title>
   <!-- EN: farmer -->
@@ -766,21 +766,21 @@
   <FarmerBoy88.titleShortFemale>çiftçi</FarmerBoy88.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] grew up on [PAWN_possessive] parents' vineyard. [PAWN_pronoun] spent [PAWN_possessive] youth exploring the land and making friends with various bugs and insects.\n\nHaving heard stories about all the fascinating things out there in the universe, [PAWN_pronoun] always dreamed of venturing out to see it for [PAWN_objective]self. -->
-  <FarmersDaughter81.description>[PAWN_nameDef] ailesinin bağında büyüdü. Gençliğini araziyi keşfederek ve çeşitli böcek ve haşaratlarla arkadaş olmak için harcadı.\n\n Evrendeki büyüleyici şeyler hakkında hikayeler duyduktan sonra, her zaman onu kendi gözleriyle görmek için dışarı çıkmayı hayal etti.</FarmersDaughter81.description>
+  <FarmersDaughter81.description>[PAWN_nameDef] ailesinin bağında büyüdü. Gençliğini araziyi keşfederek ve çeşitli böcek ve haşaratlarla arkadaş olmak için harcadı.\n\nEvrendeki büyüleyici şeyler hakkında hikayeler duyduktan sonra, her zaman onu kendi gözleriyle görmek için dışarı çıkmayı hayal etti.</FarmersDaughter81.description>
   <!-- EN: farmer's daughter -->
   <FarmersDaughter81.title>çiftçinin kızı</FarmersDaughter81.title>
   <!-- EN: farm girl -->
   <FarmersDaughter81.titleShort>çiftçi kız</FarmersDaughter81.titleShort>
   
   <!-- EN: [PAWN_nameDef] spent much of [PAWN_possessive] childhood learning biome farming. In [PAWN_possessive] biome they kept animals to investigate which would cope best in the alien environment.\n\nDue to this, the travel restrictions and oxygen rationing system, [PAWN_pronoun] rarely got to meet anyone from outside [PAWN_possessive] family. -->
-  <FarmersSon20.description>[PAWN_nameDef] çocukluğunun çoğunu biyom çiftçiliğini öğrenerek geçirdi. Biyomunda, uzaylı ortamında hangisinin en iyi şekilde başa çıkacağını araştırmak için hayvanları tuttular.\n\n Bu nedenle, seyahat kısıtlamaları ve oksijen karne sistemi nedeniyle, ailesinin dışından kimseyle nadiren tanışıyordu.</FarmersSon20.description>
+  <FarmersSon20.description>[PAWN_nameDef] çocukluğunun çoğunu biyom çiftçiliğini öğrenerek geçirdi. Biyomunda, uzaylı ortamında hangisinin en iyi şekilde başa çıkacağını araştırmak için hayvanları tuttular.\n\nBu nedenle, seyahat kısıtlamaları ve oksijen karne sistemi nedeniyle, ailesinin dışından kimseyle nadiren tanışıyordu.</FarmersSon20.description>
   <!-- EN: farmer's son -->
   <FarmersSon20.title>çiftçinin oğlu</FarmersSon20.title>
   <!-- EN: farmer -->
   <FarmersSon20.titleShort>çiftçi</FarmersSon20.titleShort>
   
   <!-- EN: [PAWN_nameDef] was born on a farm on a rimworld.\n\nEverything was taken care of by the few members of the farm, including [PAWN_nameDef]. This helped [PAWN_objective] build independence, spirit, and a well-rounded character. -->
-  <FarmHand2.description>[PAWN_nameDef] bir rimworld'deki bir çiftlikte doğdu.\n\n Her şey, [PAWN_nameDef] dahil çiftliğin birkaç üyesi tarafından halledildi. Bu onun bağımsız ruh ve çok yönlü bir karakter oluşturmasına yardımcı oldu.</FarmHand2.description>
+  <FarmHand2.description>[PAWN_nameDef] bir rimworld'deki bir çiftlikte doğdu.\n\nHer şey, [PAWN_nameDef] dahil çiftliğin birkaç üyesi tarafından halledildi. Bu onun bağımsız ruh ve çok yönlü bir karakter oluşturmasına yardımcı oldu.</FarmHand2.description>
   <!-- EN: farm hand -->
   <FarmHand2.title>rençper</FarmHand2.title>
   <FarmHand2.titleFemale>rençper</FarmHand2.titleFemale>
@@ -805,7 +805,7 @@
   <FarmMechanic1.titleShortFemale>makinist</FarmMechanic1.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] and [PAWN_possessive] family lived a hard but prosperous life along with their fellow colonists on an outlying rimworld.\n\nOne day, a group of mechanoids attacked, killing everyone aside from [PAWN_nameDef]. [PAWN_pronoun] then lived alone in the desert until a group of raiders found him. -->
-  <FeralChild85.description>[PAWN_nameDef] ve ailesi, uzaktaki bir rimworld'de diğer sömürgecilerle birlikte zor ama müreffeh bir hayat yaşadılar.\n\n Bir gün, bir grup mekanoid saldırdı ve [PAWN_nameDef] dışındaki herkesi öldürdü. Daha sonra bir grup akıncı onu bulana kadar çölde yalnız yaşadı.</FeralChild85.description>
+  <FeralChild85.description>[PAWN_nameDef] ve ailesi, uzaktaki bir rimworld'de diğer sömürgecilerle birlikte zor ama müreffeh bir hayat yaşadılar.\n\nBir gün, bir grup mekanoid saldırdı ve [PAWN_nameDef] dışındaki herkesi öldürdü. Daha sonra bir grup akıncı onu bulana kadar çölde yalnız yaşadı.</FeralChild85.description>
   <!-- EN: feral child -->
   <FeralChild85.title>vahşi çocuk</FeralChild85.title>
   <!-- EN: survivor -->
@@ -813,7 +813,7 @@
   <FeralChild85.titleShortFemale>kurtulan</FeralChild85.titleShortFemale>
   
   <!-- EN: Abandoned on an animal planet as a small child with nought but a blanket with a name embroidered on it, [PAWN_nameDef] made [PAWN_objective]self one with the wilderness.\n\nWhen [PAWN_pronoun] was 13, [PAWN_pronoun] encountered a team of mineral surveyors, who "offered" [PAWN_objective] passage off of the planet. -->
-  <FeralChild96.description>Küçük bir çocukken bir vahşi gezegende terkedilmiş, üzerinde isim işlenmiş bir battaniyeden başka hiçbir şeyi olmayan [PAWN_nameDef], vahşi doğayla bütünleşmiştir.\n\n 13 yaşındayken, ona gezegenden ayrılmasını "teklif eden" bir maden araştırmacıları ekibiyle karşılaştı.</FeralChild96.description>
+  <FeralChild96.description>Küçük bir çocukken bir vahşi gezegende terkedilmiş, üzerinde isim işlenmiş bir battaniyeden başka hiçbir şeyi olmayan [PAWN_nameDef], vahşi doğayla bütünleşmiştir.\n\n13 yaşındayken, ona gezegenden ayrılmasını "teklif eden" bir maden araştırmacıları ekibiyle karşılaştı.</FeralChild96.description>
   <!-- EN: feral child -->
   <FeralChild96.title>vahşi çocuk</FeralChild96.title>
   <!-- EN: feral -->
@@ -821,7 +821,7 @@
   <FeralChild96.titleShortFemale>vahşi</FeralChild96.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was the son of a medieval farmer, and was expected to follow in [PAWN_possessive] footsteps. [PAWN_pronoun] was brought up as a kind, well trained farm boy.\n\n[PAWN_pronoun] lived in an unusual feudal kingdom which co-existed with a midworld society which was itself well-known for genetic manipulation. -->
-  <FeudalFarmBoy0.description>[PAWN_nameDef] bir ortaçağ çiftçisinin oğluydu ve onun ayak izlerini takip etmesi bekleniyordu. Nazik, iyi eğitimli bir çiftlik çocuğu olarak yetiştirildi.\n\n Kendisi  genetik manipülasyonla tanınan bir orta dünya toplumuyla birlikte var olan alışılmadık bir feodal krallıkta yaşıyordu.</FeudalFarmBoy0.description>
+  <FeudalFarmBoy0.description>[PAWN_nameDef] bir ortaçağ çiftçisinin oğluydu ve onun ayak izlerini takip etmesi bekleniyordu. Nazik, iyi eğitimli bir çiftlik çocuğu olarak yetiştirildi.\n\nKendisi  genetik manipülasyonla tanınan bir orta dünya toplumuyla birlikte var olan alışılmadık bir feodal krallıkta yaşıyordu.</FeudalFarmBoy0.description>
   <!-- EN: feudal farm boy -->
   <FeudalFarmBoy0.title>feodal çiftçi çocuğu</FeudalFarmBoy0.title>
   <!-- EN: slave -->
@@ -829,7 +829,7 @@
   <FeudalFarmBoy0.titleShortFemale>köle</FeudalFarmBoy0.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] grew up on a feudal world that was part of a multi-planet empire. As the son of a high lord, [PAWN_pronoun] enjoyed many privileges.\n\n[PAWN_pronoun] learned to maneuver in both the political landscape and in close quarters combat. -->
-  <FeudalLordling56.description>[PAWN_nameDef], çok gezegenli bir imparatorluğun parçası olan feodal bir dünyada büyüdü. Yüksek bir lordun oğlu olarak birçok ayrıcalığa sahipti. \n\n Hem siyasi ortamda hem de yakın muharebede manevra yapmayı öğrendi.</FeudalLordling56.description>
+  <FeudalLordling56.description>[PAWN_nameDef], çok gezegenli bir imparatorluğun parçası olan feodal bir dünyada büyüdü. Yüksek bir lordun oğlu olarak birçok ayrıcalığa sahipti.\n\nHem siyasi ortamda hem de yakın muharebede manevra yapmayı öğrendi.</FeudalLordling56.description>
   <!-- EN: feudal lordling -->
   <FeudalLordling56.title>feodal lord</FeudalLordling56.title>
   <FeudalLordling56.titleFemale>feodal leydi</FeudalLordling56.titleFemale>
@@ -846,7 +846,7 @@
   <FireScarredChild1.titleShortFemale>korkmuş</FireScarredChild1.titleShortFemale>
   
   <!-- EN: When [PAWN_pronoun] was a baby, [PAWN_nameDef]'s mother went insane and left [PAWN_objective] in the woods.\n\nRaised by wild people, [PAWN_nameDef] was known for both loving and killing animals. -->
-  <ForestChild83.description>O daha bebekken [PAWN_nameDef]'in annesi delirdi ve onu ormanda bıraktı.\n\n Vahşi insanlar tarafından yetiştirilen [PAWN_nameDef] hem hayvanları sevmesiyle hem de öldürmesiyle biliniyordu.</ForestChild83.description>
+  <ForestChild83.description>O daha bebekken [PAWN_nameDef]'in annesi delirdi ve onu ormanda bıraktı.\n\nVahşi insanlar tarafından yetiştirilen [PAWN_nameDef] hem hayvanları sevmesiyle hem de öldürmesiyle biliniyordu.</ForestChild83.description>
   <!-- EN: forest child -->
   <ForestChild83.title>orman çocuğu</ForestChild83.title>
   <!-- EN: forest kid -->
@@ -861,7 +861,7 @@
   <FoundryApprentice76.titleShortFemale>dökümcü</FoundryApprentice76.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] grew up on a toxic world with tyrannical leaders. While the rest of the population was high on the planet's narcotic exports, [PAWN_pronoun] joined a rebel militia.\n\nAfter a risky operation against the regime failed, [PAWN_pronoun] fled the planet, staying alive by threatening mutual annihilation with a planetcracker antimatter bomb. -->
-  <Freethinker38.description>[PAWN_nameDef] zalim liderlerin olduğu zehirli bir dünyada büyüdü. Nüfusun çoğunluğu gezegenin narkotik ihracatında çalışırken, o isyancı milislere katıldı.\n\n Rejime karşı riskli bir operasyonun başarısız olmasının ardından gezegenden kaçtı ve bir gezegen yokedici antimadde bombasıyla karşılıklı imha tehdidinde bulunarak hayatta kaldı.</Freethinker38.description>
+  <Freethinker38.description>[PAWN_nameDef] zalim liderlerin olduğu zehirli bir dünyada büyüdü. Nüfusun çoğunluğu gezegenin narkotik ihracatında çalışırken, o isyancı milislere katıldı.\n\nRejime karşı riskli bir operasyonun başarısız olmasının ardından gezegenden kaçtı ve bir gezegen yokedici antimadde bombasıyla karşılıklı imha tehdidinde bulunarak hayatta kaldı.</Freethinker38.description>
   <!-- EN: freethinker -->
   <Freethinker38.title>Özgür düşünür</Freethinker38.title>
   <Freethinker38.titleFemale>Özgür düşünür</Freethinker38.titleFemale>
@@ -870,7 +870,7 @@
   <Freethinker38.titleShortFemale>düşünür</Freethinker38.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] inherited a sense of duty from [PAWN_possessive] father, and began a law enforcement career on [PAWN_possessive] frontier homeworld.\n\n[PAWN_pronoun] tried to uphold the law with honor, but the corruption and greed of local government officials often discouraged him. -->
-  <FrontierMarshal54.description>[PAWN_nameDef] babasından bir görev duygusu miras aldı ve sınırdaki anavatanında bir kolluk kuvveti kariyerine başladı.\n\n Yasayı onurla uygulamaya çalıştı, ancak yerel hükümet yetkililerinin yolsuzluğu ve açgözlülüğü genellikle onun cesaretini kırıyordu.</FrontierMarshal54.description>
+  <FrontierMarshal54.description>[PAWN_nameDef] babasından bir görev duygusu miras aldı ve sınırdaki anavatanında bir kolluk kuvveti kariyerine başladı.\n\nYasayı onurla uygulamaya çalıştı, ancak yerel hükümet yetkililerinin yolsuzluğu ve açgözlülüğü genellikle onun cesaretini kırıyordu.</FrontierMarshal54.description>
   <!-- EN: frontier marshal -->
   <FrontierMarshal54.title>sınır mareşali</FrontierMarshal54.title>
   <FrontierMarshal54.titleFemale>sınır mareşali</FrontierMarshal54.titleFemale>
@@ -879,16 +879,16 @@
   <FrontierMarshal54.titleShortFemale>mareşal</FrontierMarshal54.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] served the high admiral of a space fleet. [PAWN_pronoun] learned the ways of court, including etiquette and speechcraft.\n\nIn [PAWN_possessive] feudal society, it was considered a great honor to serve a man of such prestige. -->
-  <GalacticPage37.description>[PAWN_nameDef] bir uzay filosunun yüksek amiraline hizmet etti. Görgü kuralları ve konuşma sanatı dahil olmak üzere mahkeme yöntemlerini öğrendi.\n\n Feodal toplumda böyle prestijli bir adama hizmet etmek büyük bir onur olarak kabul edildi.</GalacticPage37.description>
+  <GalacticPage37.description>[PAWN_nameDef] bir uzay filosunun yüksek amiraline hizmet etti. Görgü kuralları ve konuşma sanatı dahil olmak üzere mahkeme yöntemlerini öğrendi.\n\nFeodal toplumda böyle prestijli bir adama hizmet etmek büyük bir onur olarak kabul edildi.</GalacticPage37.description>
   <!-- EN: galactic page -->
   <GalacticPage37.title>galaktik içoğlan</GalacticPage37.title>
   <GalacticPage37.titleFemale>galaktik içoğlan</GalacticPage37.titleFemale>
   <!-- EN: page -->
-  <GalacticPage37.titleShort>içoğlan</GalacticPage37.titleShort>
-  <GalacticPage37.titleShortFemale>içoğlan</GalacticPage37.titleShortFemale>
+  <GalacticPage37.titleShort>İçoğlan</GalacticPage37.titleShort>
+  <GalacticPage37.titleShortFemale>İçoğlan</GalacticPage37.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was a fanatical gamer who learned to survive in virtual reality games.\n\nOnce, while attempting to prove [PAWN_possessive] skills in the real world, [PAWN_pronoun] was abducted by a criminal scientist and experimented on. [PAWN_pronoun] escaped, but the experience stayed with him. -->
-  <GameFanatic86.description>[PAWN_nameDef], sanal gerçeklik oyunlarında hayatta kalmayı öğrenen fanatik bir oyuncuydu.\n\n Bir keresinde, gerçek dünyada yeteneklerini kanıtlamaya çalışırken, bir suçlu bilim adamı tarafından kaçırıldı ve üzerinde deneyler yapıldı. O kaçtı, ama deneyimleri onunla kaldı.</GameFanatic86.description>
+  <GameFanatic86.description>[PAWN_nameDef], sanal gerçeklik oyunlarında hayatta kalmayı öğrenen fanatik bir oyuncuydu.\n\nBir keresinde, gerçek dünyada yeteneklerini kanıtlamaya çalışırken, bir suçlu bilim adamı tarafından kaçırıldı ve üzerinde deneyler yapıldı. O kaçtı, ama deneyimleri onunla kaldı.</GameFanatic86.description>
   <!-- EN: game fanatic -->
   <GameFanatic86.title>oyun bağımlısı</GameFanatic86.title>
   <GameFanatic86.titleFemale>oyun bağımlısı</GameFanatic86.titleFemale>
@@ -896,36 +896,36 @@
   <GameFanatic86.titleShort>oyuncu</GameFanatic86.titleShort>
   
   <!-- EN: [PAWN_nameDef] grew up without parents. [PAWN_possessive] whole life was spent alone, fighting for survival on the streets.\n\nNo matter how hard it became to survive, [PAWN_pronoun] never gave up. -->
-  <GangMember16.description>[PAWN_nameDef] ebeveynsiz büyüdü. Bütün hayatı yalnız başına sokaklarda hayatta kalma mücadelesiyle geçmiştir.\n\n Hayatta kalmak ne kadar zor olursa olsun, asla pes etmedi.</GangMember16.description>
+  <GangMember16.description>[PAWN_nameDef] ebeveynsiz büyüdü. Bütün hayatı yalnız başına sokaklarda hayatta kalma mücadelesiyle geçmiştir.\n\nHayatta kalmak ne kadar zor olursa olsun, asla pes etmedi.</GangMember16.description>
   <!-- EN: gang member -->
   <GangMember16.title>geng üyesi</GangMember16.title>
   <!-- EN: gang kid -->
   <GangMember16.titleShort>geng çocuğu</GangMember16.titleShort>
   
   <!-- EN: [PAWN_nameDef] grew up homeless on an urbworld. [PAWN_pronoun] was forced to fight and struggle for everything, making [PAWN_objective] hard and ruthless long before adulthood.\n\n[PAWN_nameDef] would have stayed in those streets, had [PAWN_pronoun] not been injured in a shootout and had [PAWN_possessive] body confiscated for use by one of the worldwide city's ruling corporations. -->
-  <GangMember83.description>[PAWN_nameDef] bir urbworld'de evsiz büyüdü. Her şey için savaşmak ve mücadele etmek zorunda kaldı, bu da onu yetişkinlikten çok önce sert ve acımasız yaptı.\n\n [PAWN_nameDef] bir çatışmada yaralanmasaydı ve vücudu dünyadaki şehirleri yöneten şirketlerinden biri tarafından kullanılmak üzere el konmasaydı, o sokaklarda kalacaktı.</GangMember83.description>
+  <GangMember83.description>[PAWN_nameDef] bir urbworld'de evsiz büyüdü. Her şey için savaşmak ve mücadele etmek zorunda kaldı, bu da onu yetişkinlikten çok önce sert ve acımasız yaptı.\n\n[PAWN_nameDef] bir çatışmada yaralanmasaydı ve vücudu dünyadaki şehirleri yöneten şirketlerinden biri tarafından kullanılmak üzere el konmasaydı, o sokaklarda kalacaktı.</GangMember83.description>
   <!-- EN: gang member -->
   <GangMember83.title>geng üyesi</GangMember83.title>
   <!-- EN: ganger -->
   <GangMember83.titleShort>ganger</GangMember83.titleShort>
   <GangMember83.titleShortFemale>ganger</GangMember83.titleShortFemale>
   
-  <!-- EN: The son of a genetically-engineered "perfect mate" on a glitterworld, [PAWN_nameDef] was much more shy, withdrawn and nervous than [PAWN_possessive] parents. [PAWN_pronoun] kept mostly to [PAWN_objective]self, studying science and medicine and taking on gardening as a hobby. \n\nIn [PAWN_possessive] teens, [PAWN_pronoun] ran away from home, seeking a quieter life. -->
-  <GlitterworldKid85.description>Bir glitterworld'de genetik olarak tasarlanmış "mükemmel bir eşin" oğlu olan [PAWN_nameDef], ebeveynlerinden çok daha utangaç, içine kapanık ve gergindi. Çoğunlukla kendi kendine takıldı, bilim ve tıp okudu ve bahçecilikle uğraştı.\n\n Gençliğinde daha sakin bir hayat arayarak evden kaçtı.</GlitterworldKid85.description>
+  <!-- EN: The son of a genetically-engineered "perfect mate" on a glitterworld, [PAWN_nameDef] was much more shy, withdrawn and nervous than [PAWN_possessive] parents. [PAWN_pronoun] kept mostly to [PAWN_objective]self, studying science and medicine and taking on gardening as a hobby.\n\nIn [PAWN_possessive] teens, [PAWN_pronoun] ran away from home, seeking a quieter life. -->
+  <GlitterworldKid85.description>Bir glitterworld'de genetik olarak tasarlanmış "mükemmel bir eşin" oğlu olan [PAWN_nameDef], ebeveynlerinden çok daha utangaç, içine kapanık ve gergindi. Çoğunlukla kendi kendine takıldı, bilim ve tıp okudu ve bahçecilikle uğraştı.\n\nGençliğinde daha sakin bir hayat arayarak evden kaçtı.</GlitterworldKid85.description>
   <!-- EN: glitterworld kid -->
   <GlitterworldKid85.title>glitterworld çocuğu</GlitterworldKid85.title>
   <!-- EN: glit kid -->
   <GlitterworldKid85.titleShort>glitterworld'lü çocuk</GlitterworldKid85.titleShort>
   
   <!-- EN: [PAWN_nameDef] loved technology from the day [PAWN_pronoun] was born. [PAWN_pronoun] had a mechanoid companion which [PAWN_pronoun] tried to modify.\n\n[PAWN_possessive] obsession with technology meant that [PAWN_pronoun] never appreciated arts or culture. -->
-  <GlitterworldNerd20.description>[PAWN_nameDef] doğduğu günden beri teknolojiyi seviyordu. Değiştirmeye çalıştığı mekanik bir arkadaşı vardı.\n\n Teknolojiye olan takıntısı, sanatı veya kültürü asla takdir etmediği anlamına geliyordu.</GlitterworldNerd20.description>
+  <GlitterworldNerd20.description>[PAWN_nameDef] doğduğu günden beri teknolojiyi seviyordu. Değiştirmeye çalıştığı mekanik bir arkadaşı vardı.\n\nTeknolojiye olan takıntısı, sanatı veya kültürü asla takdir etmediği anlamına geliyordu.</GlitterworldNerd20.description>
   <!-- EN: glitterworld nerd -->
   <GlitterworldNerd20.title>glitterworld ineği</GlitterworldNerd20.title>
   <!-- EN: nerd -->
-  <GlitterworldNerd20.titleShort>inek</GlitterworldNerd20.titleShort>
+  <GlitterworldNerd20.titleShort>İnek</GlitterworldNerd20.titleShort>
   
   <!-- EN: [PAWN_nameDef] grew up in a glitterworld royal household. [PAWN_pronoun] was groomed from a young age to marry into another planet's royal family.\n\nUnfortunately, [PAWN_possessive] crooked teeth made [PAWN_objective] undesirable to suitors, so [PAWN_pronoun] became bitter and resentful. -->
-  <GlitterworldRoyal24.description>[PAWN_nameDef] bir glitterworld kraliyet ailesinde büyüdü. Başka bir gezegenin kraliyet ailesiyle evlenmek için genç yaşta yetiştirildi.\n\n Ne yazık ki, çarpık dişleri onu talipler için istenmeyen biri hale getirdi, bu yüzden hüzünlü ve küskün oldu.</GlitterworldRoyal24.description>
+  <GlitterworldRoyal24.description>[PAWN_nameDef] bir glitterworld kraliyet ailesinde büyüdü. Başka bir gezegenin kraliyet ailesiyle evlenmek için genç yaşta yetiştirildi.\n\nNe yazık ki, çarpık dişleri onu talipler için istenmeyen biri hale getirdi, bu yüzden hüzünlü ve küskün oldu.</GlitterworldRoyal24.description>
   <!-- EN: glitterworld royal -->
   <GlitterworldRoyal24.title>glitterworld asili</GlitterworldRoyal24.title>
   <GlitterworldRoyal24.titleFemale>glitterworld asili</GlitterworldRoyal24.titleFemale>
@@ -943,7 +943,7 @@
   <GNomeSculptor34.titleShortFemale>heykeltıraş</GNomeSculptor34.titleShortFemale>
   
   <!-- EN: Growing up in a urbworld, [PAWN_nameDef] never had it easy. Every day was a struggle and pollution, hunger, and gangs of older kids.\n\nIn the little space [PAWN_pronoun] had to [PAWN_objective]self, [PAWN_pronoun] studied [PAWN_possessive] passion - guns, combat tactics, and war history. -->
-  <GunKid30.description>Bir urbworld'de büyüyen [PAWN_nameDef] için hayat hiç kolay olmamıştı. Her gün bir mücadele ve kirlilik, açlık ve daha büyük çocuklardan oluşan çeteler vardı.\n\n Kendine ayırdığı küçük alanda tutkusunu - silahlar, savaş taktikleri ve savaş tarihini - çalıştı.</GunKid30.description>
+  <GunKid30.description>Bir urbworld'de büyüyen [PAWN_nameDef] için hayat hiç kolay olmamıştı. Her gün bir mücadele ve kirlilik, açlık ve daha büyük çocuklardan oluşan çeteler vardı.\n\nKendine ayırdığı küçük alanda tutkusunu - silahlar, savaş taktikleri ve savaş tarihini - çalıştı.</GunKid30.description>
   <!-- EN: gun kid -->
   <GunKid30.title>Tek tabanca çocuk</GunKid30.title>
   <GunKid30.titleFemale>Tek tabanca çocuk</GunKid30.titleFemale>
@@ -952,7 +952,7 @@
   <GunKid30.titleShortFemale>Tek tabanca çocuk</GunKid30.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was a professional gymnast at an early age. Thanks to [PAWN_possessive] skills, [PAWN_pronoun] was able to enroll in a glitterworld university.\n\nBecause of the lack of career opportunities in gymnastics, [PAWN_pronoun] left the university unemployed and carrying an enormous debt. -->
-  <Gymnast48.description>[PAWN_nameDef] erken yaşta profesyonel bir jimnastikçiydi. Becerileri sayesinde bir glitterworld üniversitesine kaydolmayı başardı.\n\n Jimnastikte kariyer imkanları olmadığı için işsiz kaldı ve çok büyük bir borçla üniversiteden ayrıldı.</Gymnast48.description>
+  <Gymnast48.description>[PAWN_nameDef] erken yaşta profesyonel bir jimnastikçiydi. Becerileri sayesinde bir glitterworld üniversitesine kaydolmayı başardı.\n\nJimnastikte kariyer imkanları olmadığı için işsiz kaldı ve çok büyük bir borçla üniversiteden ayrıldı.</Gymnast48.description>
   <!-- EN: gymnast -->
   <Gymnast48.title>jimnastikçi</Gymnast48.title>
   <Gymnast48.titleFemale>jimnastikçi</Gymnast48.titleFemale>
@@ -960,8 +960,8 @@
   <Gymnast48.titleShort>jimnastikçi</Gymnast48.titleShort>
   <Gymnast48.titleShortFemale>jimnastikçi</Gymnast48.titleShortFemale>
   
-  <!-- EN: Born on a high-tech world, [PAWN_nameDef] learned to hack computers at a young age. \n\nSpending many hours tinkering alone made [PAWN_objective] very good with machines, but very bad with humans. -->
-  <HackerKid98.description>Yüksek teknolojili bir dünyada doğan [PAWN_nameDef] genç yaşta bilgisayarları hacklemeyi öğrendi.\n\n Tek başına onca saat harcamak onu makinelerle çok iyi, insanlarla çok kötü yaptı.</HackerKid98.description>
+  <!-- EN: Born on a high-tech world, [PAWN_nameDef] learned to hack computers at a young age.\n\nSpending many hours tinkering alone made [PAWN_objective] very good with machines, but very bad with humans. -->
+  <HackerKid98.description>Yüksek teknolojili bir dünyada doğan [PAWN_nameDef] genç yaşta bilgisayarları hacklemeyi öğrendi.\n\nTek başına onca saat harcamak onu makinelerle çok iyi, insanlarla çok kötü yaptı.</HackerKid98.description>
   <!-- EN: hacker kid -->
   <HackerKid98.title>çocuk hacker</HackerKid98.title>
   <!-- EN: hacker -->
@@ -984,7 +984,7 @@
   <HeadjackAddict4.titleShortFemale>jak kafa</HeadjackAddict4.titleShortFemale>
   
   <!-- EN: Due to [PAWN_possessive] affinity for technology and desire to help others, [PAWN_nameDef] jumped at the chance to take a job at a help desk.\n\nUnfortunately, the job's soul-crushing after-effects lasted longer than [PAWN_possessive] enthusiasm. -->
-  <HelpDeskWorker31.description>[PAWN_nameDef], teknolojiye olan yakınlığı ve başkalarına yardım etme arzusu nedeniyle, bir yardım masasında iş bulma şansını yakaladı.\n\n Ne yazık ki, işin insanın içini burkucu etkileri, onun coşkusundan daha uzun sürdü.</HelpDeskWorker31.description>
+  <HelpDeskWorker31.description>[PAWN_nameDef], teknolojiye olan yakınlığı ve başkalarına yardım etme arzusu nedeniyle, bir yardım masasında iş bulma şansını yakaladı.\n\nNe yazık ki, işin insanın içini burkucu etkileri, onun coşkusundan daha uzun sürdü.</HelpDeskWorker31.description>
   <!-- EN: help desk worker -->
   <HelpDeskWorker31.title>yardım masası çalışanı</HelpDeskWorker31.title>
   <HelpDeskWorker31.titleFemale>yardım masası çalışan</HelpDeskWorker31.titleFemale>
@@ -993,7 +993,7 @@
   <HelpDeskWorker31.titleShortFemale>yardım elemanı</HelpDeskWorker31.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] crafted sculptures from spent hex-cells and traded them to a local museum for food.\n\nAfter [PAWN_possessive] popularity grew, [PAWN_pronoun] was approached by a pirate and abducted. The pirate kept [PAWN_objective] prisoner and forced [PAWN_objective] to create sculptures for sale. -->
-  <HexCellArtist91.description>[PAWN_nameDef], harcanan hex-cells heykeller yaptı ve bunları para için yerel bir müzeye sattı.\n\n Popülaritesi arttıktan sonra bir korsan ona yaklaştı ve onu kaçırdı. Korsan onu tutsak etti ve satılık heykeller yapmaya zorladı.</HexCellArtist91.description>
+  <HexCellArtist91.description>[PAWN_nameDef], harcanan hex-cells heykeller yaptı ve bunları para için yerel bir müzeye sattı.\n\nPopülaritesi arttıktan sonra bir korsan ona yaklaştı ve onu kaçırdı. Korsan onu tutsak etti ve satılık heykeller yapmaya zorladı.</HexCellArtist91.description>
   <!-- EN: hex-cell artist -->
   <HexCellArtist91.title>hex-cell sanatçısı</HexCellArtist91.title>
   <HexCellArtist91.titleFemale>hex-cell sanatçısı</HexCellArtist91.titleFemale>
@@ -1002,7 +1002,7 @@
   <HexCellArtist91.titleShortFemale>sanatçı</HexCellArtist91.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was born as low-ranking royalty in a large imperial family.\n\n[PAWN_pronoun] was placed In charge of running [PAWN_possessive] home planet from an early age, and learned important political and cultural skills in that role. -->
-  <HighBaroness37.description>[PAWN_nameDef], büyük bir imparatorluk ailesinde düşük rütbeli bir kraliyet ailesi üyesi olarak doğdu.\n\n Erken yaşlardan itibaren ana gezegenini yönetmekle görevlendirildi ve bu rolde önemli siyasi ve kültürel beceriler öğrendi.</HighBaroness37.description>
+  <HighBaroness37.description>[PAWN_nameDef], büyük bir imparatorluk ailesinde düşük rütbeli bir kraliyet ailesi üyesi olarak doğdu.\n\nErken yaşlardan itibaren ana gezegenini yönetmekle görevlendirildi ve bu rolde önemli siyasi ve kültürel beceriler öğrendi.</HighBaroness37.description>
   <!-- EN: high baroness -->
   <HighBaroness37.title>Yüksek baron</HighBaroness37.title>
   <HighBaroness37.titleFemale>Yüksek baroniçe</HighBaroness37.titleFemale>
@@ -1037,14 +1037,14 @@
   <HunterScavenger64.titleShortFemale>yağmacı</HunterScavenger64.titleShortFemale>
   
   <!-- EN: Growing up on the frozen wastes of an ocean moon, [PAWN_nameDef] only had animals and a few hard-bitten sailors as companions.\n\nThe lack of social interaction made [PAWN_objective] develop a interest in engineering - but [PAWN_pronoun] never developed any great fondness for humans. -->
-  <IcePlanetChild95.description>Bir ayın donmuş okyanus atıklarında büyüyen [PAWN_nameDef], yalnızca hayvanlara ve birkaç hırçın denizciye yol arkadaşı olarak sahipti.\n\n Sosyal etkileşim eksikliği onun mühendisliğe ilgi duymasını sağladı, ancak hiçbir zaman insanlık için büyük başarılar kazanamadı.</IcePlanetChild95.description>
+  <IcePlanetChild95.description>Bir ayın donmuş okyanus atıklarında büyüyen [PAWN_nameDef], yalnızca hayvanlara ve birkaç hırçın denizciye yol arkadaşı olarak sahipti.\n\nSosyal etkileşim eksikliği onun mühendisliğe ilgi duymasını sağladı, ancak hiçbir zaman insanlık için büyük başarılar kazanamadı.</IcePlanetChild95.description>
   <!-- EN: ice planet child -->
   <IcePlanetChild95.title>buz gezegeni çocuğu</IcePlanetChild95.title>
   <!-- EN: ice child -->
   <IcePlanetChild95.titleShort>buz çocuk</IcePlanetChild95.titleShort>
   
   <!-- EN: [PAWN_nameDef] was born on an iceworld. Survival depended on staying together and building with nothing.\n\n[PAWN_pronoun] got used to the cold. [PAWN_pronoun] never got used to dealing with those strange green things called plants. -->
-  <IceworldSurvivor75.description>[PAWN_nameDef] bir buz dünyasında doğdu. Hayatta kalmak, bir arada kalmaya ve hiçbir şey olmadan inşa etmeye bağlıydı.\n\n Soğuğa alıştı. Bitki denen o garip yeşil şeylerle uğraşmaya hiç alışamadı.</IceworldSurvivor75.description>
+  <IceworldSurvivor75.description>[PAWN_nameDef] bir buz dünyasında doğdu. Hayatta kalmak, bir arada kalmaya ve hiçbir şey olmadan inşa etmeye bağlıydı.\n\nSoğuğa alıştı. Bitki denen o garip yeşil şeylerle uğraşmaya hiç alışamadı.</IceworldSurvivor75.description>
   <!-- EN: iceworld survivor -->
   <IceworldSurvivor75.title>buz dünyasından kurtulan</IceworldSurvivor75.title>
   <IceworldSurvivor75.titleFemale>buz dünyasından kurtulan</IceworldSurvivor75.titleFemale>
@@ -1053,10 +1053,10 @@
   <IceworldSurvivor75.titleShortFemale>buzdoğan</IceworldSurvivor75.titleShortFemale>
   
   <!-- EN: Raised in the military traditions of [PAWN_possessive] forefathers, [PAWN_nameDef] was taught from a young age that [PAWN_pronoun] would be a great leader and the hero of [PAWN_possessive] family.\n\n[PAWN_pronoun] excelled at [PAWN_possessive] studies and graduated from the academy with honors. -->
-  <IdealisticCadet64.description>Atalarının askeri gelenekleriyle yetiştirilen [PAWN_nameDef]'e küçük yaşlardan itibaren büyük bir lider ve ailesinin kahramanı olacağı öğretildi.\n\n Çalışmalarında başarılı oldu ve akademiden onur derecesiyle mezun oldu.</IdealisticCadet64.description>
+  <IdealisticCadet64.description>Atalarının askeri gelenekleriyle yetiştirilen [PAWN_nameDef]'e küçük yaşlardan itibaren büyük bir lider ve ailesinin kahramanı olacağı öğretildi.\n\nÇalışmalarında başarılı oldu ve akademiden onur derecesiyle mezun oldu.</IdealisticCadet64.description>
   <!-- EN: idealistic cadet -->
-  <IdealisticCadet64.title>idealist harbiyeli</IdealisticCadet64.title>
-  <IdealisticCadet64.titleFemale>idealist harbiyeli</IdealisticCadet64.titleFemale>
+  <IdealisticCadet64.title>İdealist harbiyeli</IdealisticCadet64.title>
+  <IdealisticCadet64.titleFemale>İdealist harbiyeli</IdealisticCadet64.titleFemale>
   <!-- EN: cadet -->
   <IdealisticCadet64.titleShort>harbiyeli</IdealisticCadet64.titleShort>
   <IdealisticCadet64.titleShortFemale>harbiyeli</IdealisticCadet64.titleShortFemale>
@@ -1064,8 +1064,8 @@
   <!-- EN: [PAWN_nameDef] studied on an imperial midworld where guns were banned and self-defense study was encouraged. The relative safety allowed [PAWN_objective] to focus on [PAWN_possessive] botanical research. -->
   <ImperialStudent49.description>[PAWN_nameDef], silahların yasaklandığı ve kendini savunma çalışmalarının teşvik edildiği bir imparatorluk orta dünyasında çalıştı. Göreceli güvenlik, botanik araştırmalarına odaklanmasına izin verdi.</ImperialStudent49.description>
   <!-- EN: imperial student -->
-  <ImperialStudent49.title>imparatorluk öğrencisi</ImperialStudent49.title>
-  <ImperialStudent49.titleFemale>imparatorluk öğrencisi</ImperialStudent49.titleFemale>
+  <ImperialStudent49.title>İmparatorluk öğrencisi</ImperialStudent49.title>
+  <ImperialStudent49.titleFemale>İmparatorluk öğrencisi</ImperialStudent49.titleFemale>
   <!-- EN: student -->
   <ImperialStudent49.titleShort>öğrenci</ImperialStudent49.titleShort>
   <ImperialStudent49.titleShortFemale>öğrenci</ImperialStudent49.titleShortFemale>
@@ -1078,7 +1078,7 @@
   <IndworldUrchin73.titleShort>afacan</IndworldUrchin73.titleShort>
   
   <!-- EN: [PAWN_nameDef] was raised on a world wracked by war.\n\nAt an early age, [PAWN_pronoun] was shown how to use guns and cruelty to project [PAWN_possessive] will. [PAWN_pronoun] later distinguished [PAWN_objective]self by committing atrocities with more enthusiasm than anyone else. -->
-  <Infantry99.description>[PAWN_nameDef], savaşın harap ettiği bir dünyada büyüdü.\n\n Küçük yaşta, iradesini yansıtmak için silahları ve zulmü nasıl kullanacağı kendisine gösterildi. Daha sonra herkesten daha büyük bir şevkle vahşet işleyerek kendini gösterdi.</Infantry99.description>
+  <Infantry99.description>[PAWN_nameDef], savaşın harap ettiği bir dünyada büyüdü.\n\nKüçük yaşta, iradesini yansıtmak için silahları ve zulmü nasıl kullanacağı kendisine gösterildi. Daha sonra herkesten daha büyük bir şevkle vahşet işleyerek kendini gösterdi.</Infantry99.description>
   <!-- EN: infantry -->
   <Infantry99.title>piyade</Infantry99.title>
   <Infantry99.titleFemale>piyade</Infantry99.titleFemale>
@@ -1087,7 +1087,7 @@
   <Infantry99.titleShortFemale>piyade</Infantry99.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef]'s wealthy parents provided everything [PAWN_pronoun] ever wanted. After discovering joywires, [PAWN_pronoun] became obsessed. Once [PAWN_possessive] parents realized what happened, they cut [PAWN_objective] off.\n\nUncaring and often violent, [PAWN_pronoun] sought [PAWN_possessive] next joywire fix by any means possible. -->
-  <JoywireAddict76.description>[PAWN_nameDef]'in varlıklı ebeveynleri onun istediği her şeyi sağladı. Joywires keşfettikten sonra bağımlı hale geldi. Ailesi ne olduğunu anlayınca para vermeyi kestiler.\n\n İlgisiz ve çoğu zaman şiddet içeren bir şekilde mümkün olan her şekilde joywire bulmaya çözüm aradı.</JoywireAddict76.description>
+  <JoywireAddict76.description>[PAWN_nameDef]'in varlıklı ebeveynleri onun istediği her şeyi sağladı. Joywires keşfettikten sonra bağımlı hale geldi. Ailesi ne olduğunu anlayınca para vermeyi kestiler.\n\nİlgisiz ve çoğu zaman şiddet içeren bir şekilde mümkün olan her şekilde joywire bulmaya çözüm aradı.</JoywireAddict76.description>
   <!-- EN: joywire addict -->
   <JoywireAddict76.title>joywire bağımlısı</JoywireAddict76.title>
   <JoywireAddict76.titleFemale>joywire bağımlısı</JoywireAddict76.titleFemale>
@@ -1095,14 +1095,14 @@
   <JoywireAddict76.titleShort>bağımlı</JoywireAddict76.titleShort>
   
   <!-- EN: [PAWN_nameDef] was abandoned as a newborn, and grew up among the animals of [PAWN_possessive] homeworld's dense jungles.\n\nWhen [PAWN_pronoun] was a teenager, a traveling doctor found [PAWN_objective] injured near a road, hissing and meowing. [PAWN_pronoun] rescued [PAWN_objective] and took [PAWN_objective] on as an apprentice. -->
-  <JungleKid35.description>[PAWN_nameDef] yeni doğmuş bir bebekken terk edildi ve anavatanının yoğun ormanlarının hayvanları arasında büyüdü.\n\n Gençken, seyahat eden bir doktor onu yolun yakınında yaralı, tıslayarak ve miyavlayarak buldu. Onu kurtardı ve çırak olarak aldı.</JungleKid35.description>
+  <JungleKid35.description>[PAWN_nameDef] yeni doğmuş bir bebekken terk edildi ve anavatanının yoğun ormanlarının hayvanları arasında büyüdü.\n\nGençken, seyahat eden bir doktor onu yolun yakınında yaralı, tıslayarak ve miyavlayarak buldu. Onu kurtardı ve çırak olarak aldı.</JungleKid35.description>
   <!-- EN: jungle kid -->
   <JungleKid35.title>orman çocuğu</JungleKid35.title>
   <!-- EN: jungle kid -->
   <JungleKid35.titleShort>orman çocuğu</JungleKid35.titleShort>
   
   <!-- EN: Left for dead at a young age, [PAWN_nameDef] was rescued by an old man who ran an urbworld junkyard. The old man forced [PAWN_nameDef] to do dangerous, demanding work.\n\n[PAWN_nameDef] became very familiar with machines, but [PAWN_pronoun] grew up with almost no other experiences. -->
-  <JunkyardMechanic51.description>Genç yaşta ölüme terk edilen [PAWN_nameDef], bir urbworld hurdalığı işleten yaşlı bir adam tarafından kurtarıldı. Yaşlı adam [PAWN_nameDef]'i tehlikeli, zorlu işler yapmaya zorladı.\n\n [PAWN_nameDef] makinelere çok aşina oldu, ancak neredeyse başka hiçbir deneyim yaşamadan büyüdü.</JunkyardMechanic51.description>
+  <JunkyardMechanic51.description>Genç yaşta ölüme terk edilen [PAWN_nameDef], bir urbworld hurdalığı işleten yaşlı bir adam tarafından kurtarıldı. Yaşlı adam [PAWN_nameDef]'i tehlikeli, zorlu işler yapmaya zorladı.\n\n[PAWN_nameDef] makinelere çok aşina oldu, ancak neredeyse başka hiçbir deneyim yaşamadan büyüdü.</JunkyardMechanic51.description>
   <!-- EN: junkyard mechanic -->
   <JunkyardMechanic51.title>hurdalık mekaniği</JunkyardMechanic51.title>
   <JunkyardMechanic51.titleFemale>hurdalık mekaniği</JunkyardMechanic51.titleFemale>
@@ -1119,7 +1119,7 @@
   <KidScientist53.titleShortFemale>bilim adamı</KidScientist53.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was a bloodlusting child. Villagers thought [PAWN_objective] the product of a snake demon and human coupling.\n\nAfter watching how [PAWN_possessive] human father betrayed and murdered [PAWN_possessive] mother, [PAWN_pronoun] longed to see how many more humans [PAWN_pronoun] could get to fall into [PAWN_possessive] hands. -->
-  <Killer41.description>[PAWN_nameDef] kana susamış bir çocuktu. Köylüler onun bir yılan iblisi ile insan çiftinin ürünü olduğunu düşündüler.\n\n İnsan babasının annesine nasıl ihanet ettiğini ve onu öldürdüğünü gördükten sonra, daha ne kadar insanın eline geçebileceğini görmek istedi.</Killer41.description>
+  <Killer41.description>[PAWN_nameDef] kana susamış bir çocuktu. Köylüler onun bir yılan iblisi ile insan çiftinin ürünü olduğunu düşündüler.\n\nİnsan babasının annesine nasıl ihanet ettiğini ve onu öldürdüğünü gördükten sonra, daha ne kadar insanın eline geçebileceğini görmek istedi.</Killer41.description>
   <!-- EN: killer -->
   <Killer41.title>katil</Killer41.title>
   <Killer41.titleFemale>katil</Killer41.titleFemale>
@@ -1128,7 +1128,7 @@
   <Killer41.titleShortFemale>katil</Killer41.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was born in a laboratory as part of a altruistic but failed attempt to create a new class of human.\n\n[PAWN_possessive] childhood was filled with books and one-on-one tutoring. [PAWN_pronoun] was awkward, shy, and naive to the true nature of humanity. -->
-  <LabGrownChild22.description>[PAWN_nameDef], yeni bir insan sınıfı yaratma girişiminin bir parçası olarak bir laboratuvarda doğdu.\n\n Çocukluğu kitaplarla ve bire bir derslerle doluydu. Garip, utangaç ve insanlığın gerçek doğasına karşı saftı.</LabGrownChild22.description>
+  <LabGrownChild22.description>[PAWN_nameDef], yeni bir insan sınıfı yaratma girişiminin bir parçası olarak bir laboratuvarda doğdu.\n\nÇocukluğu kitaplarla ve bire bir derslerle doluydu. Garip, utangaç ve insanlığın gerçek doğasına karşı saftı.</LabGrownChild22.description>
   <!-- EN: lab-grown child -->
   <LabGrownChild22.title>metainsan</LabGrownChild22.title>
   <!-- EN: lab-grown -->
@@ -1143,14 +1143,14 @@
   <LaborCampOrphan91.titleShort>yetim</LaborCampOrphan91.titleShort>
   
   <!-- EN: [PAWN_pronoun] preferred logical activities like computers and was completely useless at art.\n\nBeing awkward in social situations, [PAWN_possessive] friends were few but close. -->
-  <LogicalChild2.description>Bilgisayar gibi mantıksal etkinlikleri tercih ediyordu ve sanatta tamamen işe yaramazdı.\n\n Sosyal ortamlarda becerikli olan arkadaşları azdı ama yakınlardı.</LogicalChild2.description>
+  <LogicalChild2.description>Bilgisayar gibi mantıksal etkinlikleri tercih ediyordu ve sanatta tamamen işe yaramazdı.\n\nSosyal ortamlarda becerikli olan arkadaşları azdı ama yakınlardı.</LogicalChild2.description>
   <!-- EN: logical child -->
   <LogicalChild2.title>mantıklı çocuk</LogicalChild2.title>
   <!-- EN: logic kid -->
   <LogicalChild2.titleShort>mantık çocuğu</LogicalChild2.titleShort>
   
   <!-- EN: [PAWN_nameDef] grew up miserable on the plains of a rimworld. [PAWN_pronoun] found the strength to fight under the teachings of an old, broken scientist.\n\n[PAWN_pronoun] quickly learned to play with people's fears, and was nicknamed 'mad scientist'. -->
-  <MadScientist47.description>[PAWN_nameDef] rimworld ovalarında perişan bir halde büyüdü. Yaşlı,çılgın bir bilim adamının öğretileri altında savaşacak gücü buldu.\n\n İnsanların korkularıyla oynamayı çabucak öğrendi ve 'Dr.doom' lakabıyla anıldı.</MadScientist47.description>
+  <MadScientist47.description>[PAWN_nameDef] rimworld ovalarında perişan bir halde büyüdü. Yaşlı,çılgın bir bilim adamının öğretileri altında savaşacak gücü buldu.\n\nİnsanların korkularıyla oynamayı çabucak öğrendi ve 'Dr.doom' lakabıyla anıldı.</MadScientist47.description>
   <!-- EN: mad scientist -->
   <MadScientist47.title>çılgın bilimci</MadScientist47.title>
   <MadScientist47.titleFemale>çılgın bilimci</MadScientist47.titleFemale>
@@ -1159,7 +1159,7 @@
   <MadScientist47.titleShortFemale>bilimadamı</MadScientist47.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was in a planetary marine cadet program.\n\n[PAWN_pronoun] was kicked out for shooting an officer. It was never established whether this was an accident. -->
-  <MarineCadet73.description>[PAWN_nameDef] gezegende deniz kuvvetleri öğrenci programındaydı.\n\n Bir subayı vurduğu için atıldı. Bunun bir kaza olup olmadığı hiçbir zaman tespit edilemedi.</MarineCadet73.description>
+  <MarineCadet73.description>[PAWN_nameDef] gezegende deniz kuvvetleri öğrenci programındaydı.\n\nBir subayı vurduğu için atıldı. Bunun bir kaza olup olmadığı hiçbir zaman tespit edilemedi.</MarineCadet73.description>
   <!-- EN: marine cadet -->
   <MarineCadet73.title>deniz kuvvetleri öğrencisi</MarineCadet73.title>
   <MarineCadet73.titleFemale>deniz kuvvetleri öğrencisi</MarineCadet73.titleFemale>
@@ -1168,21 +1168,21 @@
   <MarineCadet73.titleShortFemale>askeri öğrenci</MarineCadet73.titleShortFemale>
   
   <!-- EN: The only son of a well respected mechanoid inventor, [PAWN_nameDef] had access to the materials to subvert and modify [PAWN_possessive] father's creations.\n\n[PAWN_pronoun] used drugs to increase [PAWN_possessive] productivity. Unfortunately, the side-effects included persistent delusions of being mechanized, which limited [PAWN_possessive] social life. -->
-  <MechanoidHacker93.description>Saygın bir mekanoid mucidin tek oğlu olan [PAWN_nameDef], babasının eserlerini altüst etmek ve değiştirmek için materyallere erişebildi.\n\n Üretkenliğini artırmak için uyuşturucu kullandı. Ne yazık ki yan etkiler arasında; sosyal yaşamını sınırlayan, mekanize olmanın kalıcı sanrıları vardı.</MechanoidHacker93.description>
+  <MechanoidHacker93.description>Saygın bir mekanoid mucidin tek oğlu olan [PAWN_nameDef], babasının eserlerini altüst etmek ve değiştirmek için materyallere erişebildi.\n\nÜretkenliğini artırmak için uyuşturucu kullandı. Ne yazık ki yan etkiler arasında; sosyal yaşamını sınırlayan, mekanize olmanın kalıcı sanrıları vardı.</MechanoidHacker93.description>
   <!-- EN: mechanoid hacker -->
   <MechanoidHacker93.title>mekanoid hacker</MechanoidHacker93.title>
   <!-- EN: mechacker -->
   <MechanoidHacker93.titleShort>Mekhacker</MechanoidHacker93.titleShort>
   
   <!-- EN: [PAWN_nameDef] grew up in an urbworld as the only child of a pair of mechanoid designers.\nThey encouraged [PAWN_possessive] interest in the machines. Eventually, [PAWN_pronoun] became obsessed with building [PAWN_possessive] own.\n\nUnfortunately this also lead to [PAWN_objective] being a loner as [PAWN_pronoun] preferred technical books to friends. -->
-  <MechanoidNerd10.description>[PAWN_nameDef] mekanoid tasarımcısı bir çiftin tek çocuğu olarak bir urbworld'de büyüdü. Makinelere olan ilgisini teşvik ettiler. Sonunda, kendininkini inşa etme konusunda takıntılı hale geldi.\n\n Ne yazık ki bu teknik kitapları arkadaşlarına tercih ettiği için yalnız kalmasına da neden oldu.</MechanoidNerd10.description>
+  <MechanoidNerd10.description>[PAWN_nameDef] mekanoid tasarımcısı bir çiftin tek çocuğu olarak bir urbworld'de büyüdü. Makinelere olan ilgisini teşvik ettiler. Sonunda, kendininkini inşa etme konusunda takıntılı hale geldi.\n\nNe yazık ki bu teknik kitapları arkadaşlarına tercih ettiği için yalnız kalmasına da neden oldu.</MechanoidNerd10.description>
   <!-- EN: mechanoid nerd -->
   <MechanoidNerd10.title>Mekanoid nerd</MechanoidNerd10.title>
   <!-- EN: mechanerd -->
   <MechanoidNerd10.titleShort>Mekanerd</MechanoidNerd10.titleShort>
   
   <!-- EN: [PAWN_nameDef] traveled between rimworlds with [PAWN_possessive] family. [PAWN_nameDef]'s mother, a renowned doctor, often delivered lectures from the hull of their retrofitted cargo/medical ship.\n\nSometimes, the family took on difficult long-term medical work with especially needy patients, and [PAWN_nameDef] helped where [PAWN_pronoun] could. -->
-  <MedicalHelper27.description>[PAWN_nameDef] ailesiyle birlikte rimworld'ler arasında seyahat etti. [PAWN_nameDef]'in tanınmış bir doktor olan annesi, genellikle tıbbi kargo gemilerinin gövdesinden dersler verirdi.\n\n Bazen aile özellikle muhtaç hastalarla uzun süreli zorlu tedaviler üstlenirdi ve [PAWN_nameDef] elinden geldiğince yardım yapardı.</MedicalHelper27.description>
+  <MedicalHelper27.description>[PAWN_nameDef] ailesiyle birlikte rimworld'ler arasında seyahat etti. [PAWN_nameDef]'in tanınmış bir doktor olan annesi, genellikle tıbbi kargo gemilerinin gövdesinden dersler verirdi.\n\nBazen aile özellikle muhtaç hastalarla uzun süreli zorlu tedaviler üstlenirdi ve [PAWN_nameDef] elinden geldiğince yardım yapardı.</MedicalHelper27.description>
   <!-- EN: medical helper -->
   <MedicalHelper27.title>tıbbi yardımcı</MedicalHelper27.title>
   <MedicalHelper27.titleFemale>tıbbi yardımcı</MedicalHelper27.titleFemale>
@@ -1200,7 +1200,7 @@
   <MedicalStudent38.titleShortFemale>öğrenci</MedicalStudent38.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] grew up on a glitterworld in a family of doctors and chose to maintain the tradition.\n\n[PAWN_pronoun] had few friends, but got along with [PAWN_possessive] siblings very well. -->
-  <MedicalStudent96.description>[PAWN_nameDef] doktorlardan oluşan bir ailede glitterworld'de büyüdü ve aile geleneği sürdürmeyi seçti.\n\n Birkaç arkadaşı vardı ama kardeşleriyle de çok iyi anlaşıyorlardı.</MedicalStudent96.description>
+  <MedicalStudent96.description>[PAWN_nameDef] doktorlardan oluşan bir ailede glitterworld'de büyüdü ve aile geleneği sürdürmeyi seçti.\n\nBirkaç arkadaşı vardı ama kardeşleriyle de çok iyi anlaşıyorlardı.</MedicalStudent96.description>
   <!-- EN: medical student -->
   <MedicalStudent96.title>tıp öğrencisi</MedicalStudent96.title>
   <MedicalStudent96.titleFemale>tıp öğrencisi</MedicalStudent96.titleFemale>
@@ -1208,8 +1208,8 @@
   <MedicalStudent96.titleShort>öğrenci</MedicalStudent96.titleShort>
   <MedicalStudent96.titleShortFemale>öğrenci</MedicalStudent96.titleShortFemale>
   
-  <!-- EN: Born to a nomadic family in a feudal society, [PAWN_nameDef] was instructed in the arts of speechcraft, sleight of hand, horse riding.\n\n        [PAWN_pronoun] was always running around the camp doing odd jobs to help [PAWN_possessive] extended family. -->
-  <MedievalNomad12.description>Feodal bir toplumda göçebe bir ailede dünyaya gelen [PAWN_nameDef] ; konuşma sanatı, el çabukluğu, ata binme sanatları konusunda eğitim aldı.\n\n Geniş ailesine yardım etmek için her zaman kampta dolaşıp ufak tefek işler yapıyordu.</MedievalNomad12.description>
+  <!-- EN: Born to a nomadic family in a feudal society, [PAWN_nameDef] was instructed in the arts of speechcraft, sleight of hand, horse riding.\n\n[PAWN_pronoun] was always running around the camp doing odd jobs to help [PAWN_possessive] extended family. -->
+  <MedievalNomad12.description>Feodal bir toplumda göçebe bir ailede dünyaya gelen [PAWN_nameDef] ; konuşma sanatı, el çabukluğu, ata binme sanatları konusunda eğitim aldı.\n\nGeniş ailesine yardım etmek için her zaman kampta dolaşıp ufak tefek işler yapıyordu.</MedievalNomad12.description>
   <!-- EN: medieval nomad -->
   <MedievalNomad12.title>Ortaçağ göçebesi</MedievalNomad12.title>
   <MedievalNomad12.titleFemale>Ortaçağ göçebesi</MedievalNomad12.titleFemale>
@@ -1243,7 +1243,7 @@
   <MedievalSquire5.titleShort>yaver</MedievalSquire5.titleShort>
   
   <!-- EN: [PAWN_nameDef] grew up poor and hungry on a medieval planet, learning to fend for [PAWN_objective]self.\n\nAt first, [PAWN_pronoun] only took what [PAWN_pronoun] needed. Then [PAWN_pronoun] learned to take what [PAWN_pronoun] wanted. -->
-  <MedievalThief74.description>[PAWN_nameDef] bir orta çağ gezegeninde kendi başının çaresine bakmayı öğrenerek fakir ve aç büyüdü.\n\n İlk başta sadece ihtiyacı olanı aldı. Sonra istediğini almayı öğrendi.</MedievalThief74.description>
+  <MedievalThief74.description>[PAWN_nameDef] bir orta çağ gezegeninde kendi başının çaresine bakmayı öğrenerek fakir ve aç büyüdü.\n\nİlk başta sadece ihtiyacı olanı aldı. Sonra istediğini almayı öğrendi.</MedievalThief74.description>
   <!-- EN: medieval thief -->
   <MedievalThief74.title>ortaçağ hırsızı</MedievalThief74.title>
   <MedievalThief74.titleFemale>ortaçağ hırsızı</MedievalThief74.titleFemale>
@@ -1261,7 +1261,7 @@
   <MercenaryRecruit18.titleShortFemale>acemi</MercenaryRecruit18.titleShortFemale>
   
   <!-- EN: Descended from a long line of mercenaries, [PAWN_nameDef] grew up in a busy trading hub.\n\n[PAWN_possessive] interest in the foreign goods at the market often distracted [PAWN_objective] from [PAWN_possessive] chores and training. -->
-  <MercenaryRecruit36.description>Uzun bir paralı asker soyundan gelen [PAWN_nameDef] yoğun bir ticaret merkezinde büyüdü.\n\n Piyasadaki yabancı mallara olan ilgisi onu genellikle işlerinden ve eğitiminden uzaklaştırdı.</MercenaryRecruit36.description>
+  <MercenaryRecruit36.description>Uzun bir paralı asker soyundan gelen [PAWN_nameDef] yoğun bir ticaret merkezinde büyüdü.\n\nPiyasadaki yabancı mallara olan ilgisi onu genellikle işlerinden ve eğitiminden uzaklaştırdı.</MercenaryRecruit36.description>
   <!-- EN: mercenary recruit -->
   <MercenaryRecruit36.title>acemi paralı asker</MercenaryRecruit36.title>
   <MercenaryRecruit36.titleFemale>acemi paralı asker</MercenaryRecruit36.titleFemale>
@@ -1270,7 +1270,7 @@
   <MercenaryRecruit36.titleShortFemale>acemi</MercenaryRecruit36.titleShortFemale>
   
   <!-- EN: Growing up on a high-tech midworld with a flourishing space transit industry, [PAWN_nameDef] wished to leave for the stars and live among the growing spacer class.\n\n[PAWN_pronoun] excelled in [PAWN_possessive] studies, and gained entry to [PAWN_possessive] homeworld's most prestigious naval academy. -->
-  <MidworldCadet83.description>Gelişen bir uzay geçiş endüstrisi ile yüksek teknolojili bir orta dünyada büyüyen [PAWN_nameDef], yıldızlara gitmek ve büyüyen uzay filosunun içinde yaşamak istedi. \n\nÇalışmalarında başarılı oldu ve anavatanının en prestijli deniz akademisine giriş hakkı kazandı.</MidworldCadet83.description>
+  <MidworldCadet83.description>Gelişen bir uzay geçiş endüstrisi ile yüksek teknolojili bir orta dünyada büyüyen [PAWN_nameDef], yıldızlara gitmek ve büyüyen uzay filosunun içinde yaşamak istedi.\n\nÇalışmalarında başarılı oldu ve anavatanının en prestijli deniz akademisine giriş hakkı kazandı.</MidworldCadet83.description>
   <!-- EN: midworld cadet -->
   <MidworldCadet83.title>ortadünya askeri öğrenci</MidworldCadet83.title>
   <MidworldCadet83.titleFemale>ortadünya askeri öğrenci</MidworldCadet83.titleFemale>
@@ -1286,7 +1286,7 @@
   <MidworldGeek18.titleShort>geek</MidworldGeek18.titleShort>
   
   <!-- EN: [PAWN_nameDef] was born on a peaceful, unimportant midworld.\n\nWhile [PAWN_pronoun] had a few friends, [PAWN_pronoun] preferred to spend [PAWN_possessive] time in solitude, tinkering on [PAWN_possessive] autocycle while listening to netcasts, or plinking at plastic soldiers with a new rifle [PAWN_pronoun] had just put together. -->
-  <MidworldLoner80.description>[PAWN_nameDef] barışçıl, önemsiz bir orta dünyada doğdu. \n\n Birkaç arkadaşı varken, zamanını yalnız başına geçirmeyi, netcast'leri dinlerken otomatik bisikletini kurcalamayı ya da topladığı tüfekle plastik askerlere ateş etmeyi tercih etti.</MidworldLoner80.description>
+  <MidworldLoner80.description>[PAWN_nameDef] barışçıl, önemsiz bir orta dünyada doğdu.\n\nBirkaç arkadaşı varken, zamanını yalnız başına geçirmeyi, netcast'leri dinlerken otomatik bisikletini kurcalamayı ya da topladığı tüfekle plastik askerlere ateş etmeyi tercih etti.</MidworldLoner80.description>
   <!-- EN: midworld loner -->
   <MidworldLoner80.title>ortadünya yalnızı</MidworldLoner80.title>
   <MidworldLoner80.titleFemale>ortadünya yalnızı</MidworldLoner80.titleFemale>
@@ -1295,7 +1295,7 @@
   <MidworldLoner80.titleShortFemale>yalnız</MidworldLoner80.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was born into a loving but poor family.\n\n[PAWN_pronoun] discovered [PAWN_pronoun] had an artistic talent which [PAWN_pronoun] inherited from [PAWN_possessive] father. [PAWN_possessive] mother taught [PAWN_objective] the benefits of hard work and determination. As [PAWN_pronoun] grew older, [PAWN_nameDef] developed a fascination with technology and military history. -->
-  <MidworldSketcher71.description>[PAWN_nameDef] sevgi dolu ama fakir bir ailede doğdu. \n\nBabasından miras kalan sanatsal bir yeteneği olduğunu keşfetti. Annesi ona çok çalışmanın ve kararlılığın faydalarını öğretti. [PAWN_nameDef] yaşlandıkça teknoloji ve askeri tarihe karşı bir hayranlık duymaya başladı.</MidworldSketcher71.description>
+  <MidworldSketcher71.description>[PAWN_nameDef] sevgi dolu ama fakir bir ailede doğdu.\n\nBabasından miras kalan sanatsal bir yeteneği olduğunu keşfetti. Annesi ona çok çalışmanın ve kararlılığın faydalarını öğretti. [PAWN_nameDef] yaşlandıkça teknoloji ve askeri tarihe karşı bir hayranlık duymaya başladı.</MidworldSketcher71.description>
   <!-- EN: midworld sketcher -->
   <MidworldSketcher71.title>ortadünya desinatör</MidworldSketcher71.title>
   <MidworldSketcher71.titleFemale>ortadünya desinatör</MidworldSketcher71.titleFemale>
@@ -1304,7 +1304,7 @@
   <MidworldSketcher71.titleShortFemale>desinatör</MidworldSketcher71.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef]'s military family forced [PAWN_objective] to train in hand-to-hand combat and fighting tactics.\n\nIn [PAWN_possessive] own time, [PAWN_pronoun] built small inventions. This sharpened [PAWN_possessive] mind. -->
-  <MilitantChild49.description>[PAWN_nameDef]'in askeri ailesi onu göğüs göğüse çarpışma ve dövüş taktikleri konusunda eğitim almaya zorladı. \n\n Kendi döneminde küçük icatlar yaptı. Bu aklını keskinleştirdi.</MilitantChild49.description>
+  <MilitantChild49.description>[PAWN_nameDef]'in askeri ailesi onu göğüs göğüse çarpışma ve dövüş taktikleri konusunda eğitim almaya zorladı.\n\nKendi döneminde küçük icatlar yaptı. Bu aklını keskinleştirdi.</MilitantChild49.description>
   <!-- EN: militant child -->
   <MilitantChild49.title>çocuk militan</MilitantChild49.title>
   <!-- EN: soldier -->
@@ -1312,7 +1312,7 @@
   <MilitantChild49.titleShortFemale>asker</MilitantChild49.titleShortFemale>
   
   <!-- EN: Orphaned as a child, [PAWN_nameDef] was sent to a secret military school on a harsh deadworld.\n\nTaking quickly to firearms and survival training, [PAWN_pronoun] graduated with honor, transitioning into a leadership position in covert operations. -->
-  <MilitaryCadet16.description>Çocukken öksüz kalan [PAWN_nameDef], zorlu bir ölüm dünyasında gizli bir askeri okula gönderildi. \n\nAteşli silahlara ve hayatta kalma eğitimine hızla katılarak onur derecesiyle mezun oldu ve gizli operasyonlarda liderlik pozisyonuna geçti.</MilitaryCadet16.description>
+  <MilitaryCadet16.description>Çocukken öksüz kalan [PAWN_nameDef], zorlu bir ölüm dünyasında gizli bir askeri okula gönderildi.\n\nAteşli silahlara ve hayatta kalma eğitimine hızla katılarak onur derecesiyle mezun oldu ve gizli operasyonlarda liderlik pozisyonuna geçti.</MilitaryCadet16.description>
   <!-- EN: military cadet -->
   <MilitaryCadet16.title>askeri öğrenci</MilitaryCadet16.title>
   <MilitaryCadet16.titleFemale>askeri öğrenci</MilitaryCadet16.titleFemale>
@@ -1321,14 +1321,14 @@
   <MilitaryCadet16.titleShortFemale>askeri öğrenci</MilitaryCadet16.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] grew up in a family with a rich military background. [PAWN_possessive] teenage years were spent traveling system to system wherever [PAWN_possessive] parents were deployed.\n\nFollowing the tradition of [PAWN_possessive] family, [PAWN_pronoun] enlisted at the earliest possible age. -->
-  <MilitaryChild82.description>[PAWN_nameDef] zengin bir askeri geçmişe sahip bir ailede büyüdü. Gençlik yılları, anne ve babasının atandığı her yerdeki sistemden sisteme seyahat etmekle geçti. \n\nAilesinin geleneğini takip ederek, mümkün olan en erken yaşta askere gitti.</MilitaryChild82.description>
+  <MilitaryChild82.description>[PAWN_nameDef] zengin bir askeri geçmişe sahip bir ailede büyüdü. Gençlik yılları, anne ve babasının atandığı her yerdeki sistemden sisteme seyahat etmekle geçti.\n\nAilesinin geleneğini takip ederek, mümkün olan en erken yaşta askere gitti.</MilitaryChild82.description>
   <!-- EN: military child -->
   <MilitaryChild82.title>militer çocuk</MilitaryChild82.title>
   <!-- EN: military -->
   <MilitaryChild82.titleShort>militer</MilitaryChild82.titleShort>
   
   <!-- EN: [PAWN_nameDef] was born on a midworld run by an intensely militaristic dictatorship.\n\nFrom a young age, [PAWN_pronoun] was trained to be a good soldier. They taught [PAWN_objective] how to use a gun and how to fight with melee weapons. -->
-  <MilitaryRecruit49.description>[PAWN_nameDef], yoğun militarist bir diktatörlük tarafından yönetilen bir orta dünyada doğdu. \n\nKüçük yaştan itibaren iyi bir asker olmak için eğitildi. Ona silah kullanmayı ve yakın dövüş silahlarıyla savaşmayı öğrettiler.</MilitaryRecruit49.description>
+  <MilitaryRecruit49.description>[PAWN_nameDef], yoğun militarist bir diktatörlük tarafından yönetilen bir orta dünyada doğdu.\n\nKüçük yaştan itibaren iyi bir asker olmak için eğitildi. Ona silah kullanmayı ve yakın dövüş silahlarıyla savaşmayı öğrettiler.</MilitaryRecruit49.description>
   <!-- EN: military recruit -->
   <MilitaryRecruit49.title>askeri acemi er</MilitaryRecruit49.title>
   <MilitaryRecruit49.titleFemale>askeri acemi er</MilitaryRecruit49.titleFemale>
@@ -1367,7 +1367,7 @@
   <MusicIdol50.titleShort>müzik idolü</MusicIdol50.titleShort>
   
   <!-- EN: [PAWN_nameDef] grew up on a backwater planet with minimal education. [PAWN_pronoun] had to hunt and grow food to survive.\n\n[PAWN_possessive] family's home was frequently raided for food by scavengers. This made [PAWN_nameDef] very suspicious and slow to trust anyone [PAWN_pronoun] doesn't know. -->
-  <Naturalist14.description>[PAWN_nameDef], minimum eğitimle durgun bir gezegende büyüdü. Hayatta kalabilmek için avlanmak ve yiyecek yetiştirmek zorundaydı.\n\n Ailesinin evi, haydutlar tarafından sık sık yemek için yağmalandı. Bu, [PAWN_nameDef]'i çok şüpheci ve tanımadığı birine zor güvenmesini neden oldu.</Naturalist14.description>
+  <Naturalist14.description>[PAWN_nameDef], minimum eğitimle durgun bir gezegende büyüdü. Hayatta kalabilmek için avlanmak ve yiyecek yetiştirmek zorundaydı.\n\nAilesinin evi, haydutlar tarafından sık sık yemek için yağmalandı. Bu, [PAWN_nameDef]'i çok şüpheci ve tanımadığı birine zor güvenmesini neden oldu.</Naturalist14.description>
   <!-- EN: naturalist -->
   <Naturalist14.title>doğacı</Naturalist14.title>
   <Naturalist14.titleFemale>doğacı</Naturalist14.titleFemale>
@@ -1385,14 +1385,14 @@
   <NavyPathfinder53.titleShortFemale>rehber</NavyPathfinder53.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was curious about everything. While other kids played tag in the suburbs of their industrial city, [PAWN_nameDef] read every book [PAWN_pronoun] could find about technology, robots, and weapons - whatever looked coolest.\n\n[PAWN_possessive] strong French accent kept [PAWN_objective] from making real friends. -->
-  <Nerd92.description>[PAWN_nameDef] her şeyi merak ediyordu. Diğer çocuklar sanayi şehirlerinin kenar mahallelerinde tavla oynarken, [PAWN_nameDef] teknoloji, robotlar ve silahlar hakkında bulabildiği her kitabı okudu havalı görünen her şeyi.\n\n Güçlü Fransız aksanı, onu gerçek arkadaşlar edinmekten alıkoydu.</Nerd92.description>
+  <Nerd92.description>[PAWN_nameDef] her şeyi merak ediyordu. Diğer çocuklar sanayi şehirlerinin kenar mahallelerinde tavla oynarken, [PAWN_nameDef] teknoloji, robotlar ve silahlar hakkında bulabildiği her kitabı okudu havalı görünen her şeyi.\n\nGüçlü Fransız aksanı, onu gerçek arkadaşlar edinmekten alıkoydu.</Nerd92.description>
   <!-- EN: nerd -->
   <Nerd92.title>nerd</Nerd92.title>
   <!-- EN: nerd -->
   <Nerd92.titleShort>nerd</Nerd92.titleShort>
   
   <!-- EN: [PAWN_nameDef] was fascinated with combat. [PAWN_possessive] parents traveled often, so [PAWN_pronoun] was able to sample many different fighting styles, from 76th-wave jujutsu to the infamous 'urbworld-style' karate.\n\nA polite child, most fighters accepted [PAWN_possessive] requests for training - but moving around often without finishing a tutelage made [PAWN_objective] lazy. -->
-  <NewAgeDuelist27.description>[PAWN_nameDef] dövüşten büyülendi. Ailesi sık sık seyahat ediyordu, bu yüzden 76. dalga jujutsu'dan meşhur "urbworld tarzı" karateye kadar birçok farklı dövüş stilini denemeyi başardı.\n\n Kibar bir çocuktu ve dövüşçülerin eğitim taleplerini kabul etti - ancak vesayetini bitirmeden sık sık dolaşmak onu tembelleştirdi.</NewAgeDuelist27.description>
+  <NewAgeDuelist27.description>[PAWN_nameDef] dövüşten büyülendi. Ailesi sık sık seyahat ediyordu, bu yüzden 76. dalga jujutsu'dan meşhur "urbworld tarzı" karateye kadar birçok farklı dövüş stilini denemeyi başardı.\n\nKibar bir çocuktu ve dövüşçülerin eğitim taleplerini kabul etti - ancak vesayetini bitirmeden sık sık dolaşmak onu tembelleştirdi.</NewAgeDuelist27.description>
   <!-- EN: new age duelist -->
   <NewAgeDuelist27.title>yeni nesil düellocu</NewAgeDuelist27.title>
   <NewAgeDuelist27.titleFemale>yeni nesil düellocu</NewAgeDuelist27.titleFemale>
@@ -1401,7 +1401,7 @@
   <NewAgeDuelist27.titleShortFemale>düellocu</NewAgeDuelist27.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was adopted by a prominent noble family after being left on their doorstep by [PAWN_possessive] mother.\n\n[PAWN_pronoun] quickly learned secrets that passed between the nobles like cheap wine - of worlds beyond [PAWN_possessive] own, languages, cultures and technologies both new and old. -->
-  <NobleWard61.description>[PAWN_nameDef], annesi tarafından kapılarına bırakıldıktan sonra önde gelen bir soylu aile tarafından evlat edinildi.\n\n Soylular arasında ucuz şarap gibi geçen sırları, kendi dünyasının ötesindeki dünyaların, dillerin, kültürlerin ve hem yeni hem de eski teknolojilerin sırlarını çabucak öğrendi.</NobleWard61.description>
+  <NobleWard61.description>[PAWN_nameDef], annesi tarafından kapılarına bırakıldıktan sonra önde gelen bir soylu aile tarafından evlat edinildi.\n\nSoylular arasında ucuz şarap gibi geçen sırları, kendi dünyasının ötesindeki dünyaların, dillerin, kültürlerin ve hem yeni hem de eski teknolojilerin sırlarını çabucak öğrendi.</NobleWard61.description>
   <!-- EN: noble ward -->
   <NobleWard61.title>soylu veraset</NobleWard61.title>
   <!-- EN: ward -->
@@ -1417,7 +1417,7 @@
   <OfficerCadet25.titleShortFemale>askeri öğrenci</OfficerCadet25.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was born an raised in an offworld soldier growth facility. From a very young age, [PAWN_pronoun] was taught close-quarters combat tactics, aggression, and how to survive on distant planets.\n\nOne of the best, [PAWN_nameDef] was eventually chose to enter the orbital-deployment shock troop corps. -->
-  <OffworldRecruit91.description>[PAWN_nameDef] dünya dışı bir asker yetiştirme tesisinde büyümüş olarak doğdu. Çok küçük yaşlardan itibaren ona yakın dövüş taktikleri, saldırganlık ve uzak gezegenlerde nasıl hayatta kalınacağı öğretildi.\n\n En iyilerinden biri olan [PAWN_nameDef] sonunda yörünge konuşlandırılmış "şok birlik" birliğine girmek için seçildi.</OffworldRecruit91.description>
+  <OffworldRecruit91.description>[PAWN_nameDef] dünya dışı bir asker yetiştirme tesisinde büyümüş olarak doğdu. Çok küçük yaşlardan itibaren ona yakın dövüş taktikleri, saldırganlık ve uzak gezegenlerde nasıl hayatta kalınacağı öğretildi.\n\nEn iyilerinden biri olan [PAWN_nameDef] sonunda yörünge konuşlandırılmış "şok birlik" birliğine girmek için seçildi.</OffworldRecruit91.description>
   <!-- EN: offworld recruit -->
   <OffworldRecruit91.title>Dış dünya acemi askeri</OffworldRecruit91.title>
   <OffworldRecruit91.titleFemale>Dış dünya acemi askeri</OffworldRecruit91.titleFemale>
@@ -1457,14 +1457,14 @@
   <Orphan15.titleShort>yetim</Orphan15.titleShort>
   
   <!-- EN: Left alone in the world without parents, [PAWN_nameDef] did the best [PAWN_pronoun] could to adapt.\n\nHaving to take care both of [PAWN_objective]self and younger kids at the orphanage, [PAWN_pronoun] learned a lot about humans and how to interact with them. -->
-  <Orphan25.description>Ebeveynleri olmadan dünyada tek başına kalan [PAWN_nameDef], uyum sağlamak için elinden gelenin en iyisini yaptı.\n\n Yetimhanede hem kendisine hem de daha küçük çocuklara bakmak zorunda olduğundan, insanlar ve onlarla nasıl etkileşime geçeceği hakkında çok şey öğrendi.</Orphan25.description>
+  <Orphan25.description>Ebeveynleri olmadan dünyada tek başına kalan [PAWN_nameDef], uyum sağlamak için elinden gelenin en iyisini yaptı.\n\nYetimhanede hem kendisine hem de daha küçük çocuklara bakmak zorunda olduğundan, insanlar ve onlarla nasıl etkileşime geçeceği hakkında çok şey öğrendi.</Orphan25.description>
   <!-- EN: orphan -->
   <Orphan25.title>yetim</Orphan25.title>
   <!-- EN: orphan -->
   <Orphan25.titleShort>yetim</Orphan25.titleShort>
   
   <!-- EN: Born a quiet urbworld orphan, [PAWN_nameDef] was invited to join a traveling circus. [PAWN_possessive] small size and observant nature helped [PAWN_nameDef] become a noted acrobat.\n\nUnfortunately, [PAWN_possessive] violent tendencies brought [PAWN_possessive] acrobatic career to an early end. -->
-  <OrphanedAcrobat84.description>Sessiz bir urbworld yetimi olarak dünyaya gelen [PAWN_nameDef], gezici bir sirke katılmaya davet edildi. Küçük boyutu ve gözlemci yapısı [PAWN_nameDef]'in ünlü bir akrobat olmasına yardımcı oldu.\n\n Ne yazık ki, şiddetli eğilimleri akrobatik kariyerini erken sona erdirdi.</OrphanedAcrobat84.description>
+  <OrphanedAcrobat84.description>Sessiz bir urbworld yetimi olarak dünyaya gelen [PAWN_nameDef], gezici bir sirke katılmaya davet edildi. Küçük boyutu ve gözlemci yapısı [PAWN_nameDef]'in ünlü bir akrobat olmasına yardımcı oldu.\n\nNe yazık ki, şiddetli eğilimleri akrobatik kariyerini erken sona erdirdi.</OrphanedAcrobat84.description>
   <!-- EN: orphaned acrobat -->
   <OrphanedAcrobat84.title>yetim kalmış akrobat</OrphanedAcrobat84.title>
   <OrphanedAcrobat84.titleFemale>yetim kalmış akrobat</OrphanedAcrobat84.titleFemale>
@@ -1473,14 +1473,14 @@
   <OrphanedAcrobat84.titleShortFemale>akrobat</OrphanedAcrobat84.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] lost [PAWN_possessive] family and home early in life. [PAWN_possessive] life became emotionally hollow, but [PAWN_possessive] painful memories drove [PAWN_objective] to survive.\n\n[PAWN_pronoun] took several jobs, but never achieved more than a basic education. -->
-  <OrphanOfWar60.description>[PAWN_nameDef], [PAWN_possessive] ailesini ve evini erken yaşta kaybetti. Hayatı duygusal olarak boştu ama acı dolu hatıraları onu hayata tutunmaya itti.\n\n Birkaç işte çalıştı, ancak hiçbir zaman temel bir eğitimden fazlasını elde edemedi.</OrphanOfWar60.description>
+  <OrphanOfWar60.description>[PAWN_nameDef], [PAWN_possessive] ailesini ve evini erken yaşta kaybetti. Hayatı duygusal olarak boştu ama acı dolu hatıraları onu hayata tutunmaya itti.\n\nBirkaç işte çalıştı, ancak hiçbir zaman temel bir eğitimden fazlasını elde edemedi.</OrphanOfWar60.description>
   <!-- EN: orphan of war -->
   <OrphanOfWar60.title>yetimlerin savaşı</OrphanOfWar60.title>
   <!-- EN: orphan -->
   <OrphanOfWar60.titleShort>yetim</OrphanOfWar60.titleShort>
   
   <!-- EN: Born on a decadent glitterworld, [PAWN_nameDef] was given every expensive toy.\n\nThis pampered lifestyle caused [PAWN_objective] to miss many basic life lessons. [PAWN_pronoun] developed a special aversion to cooking, and always ordered the staff to do the kitchen work. -->
-  <Pampered87.description>Çökmekte olan bir glitterworld'de doğan [PAWN_nameDef]'e her pahalı oyuncak verildi.\n\n Bu şımartılmış yaşam tarzı, birçok temel yaşam dersini kaçırmasına neden oldu. Yemek pişirmeye karşı özel bir isteksizlik geliştirdi ve her zaman personele mutfak işlerini yapmalarını emretti.</Pampered87.description>
+  <Pampered87.description>Çökmekte olan bir glitterworld'de doğan [PAWN_nameDef]'e her pahalı oyuncak verildi.\n\nBu şımartılmış yaşam tarzı, birçok temel yaşam dersini kaçırmasına neden oldu. Yemek pişirmeye karşı özel bir isteksizlik geliştirdi ve her zaman personele mutfak işlerini yapmalarını emretti.</Pampered87.description>
   <!-- EN: pampered -->
   <Pampered87.title>şımartılmış</Pampered87.title>
   <!-- EN: pampered -->
@@ -1488,7 +1488,7 @@
   <Pampered87.titleShortFemale>şımartılmış</Pampered87.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] spent most of [PAWN_possessive] childhood tending the animals [PAWN_pronoun] had bought or rescued.\n\n[PAWN_pronoun] saw beauty in natural things more than fabricated objects, and chose the company of [PAWN_possessive] animals over that of [PAWN_possessive] peers. -->
-  <PetKeeper7.description>PAWN_nameDef] çocukluğunun çoğunu satın aldığı veya kurtardığı hayvanlara bakarak geçirdi.\n\n Yapay nesnelerden çok doğal şeylerdeki güzelliği gördü ve hayvanlarının arkadaşlığını akranlarınınkine tercih etti.</PetKeeper7.description>
+  <PetKeeper7.description>PAWN_nameDef] çocukluğunun çoğunu satın aldığı veya kurtardığı hayvanlara bakarak geçirdi.\n\nYapay nesnelerden çok doğal şeylerdeki güzelliği gördü ve hayvanlarının arkadaşlığını akranlarınınkine tercih etti.</PetKeeper7.description>
   <!-- EN: pet keeper -->
   <PetKeeper7.title>hayvan bakıcı</PetKeeper7.title>
   <PetKeeper7.titleFemale>hayvan bakıcı</PetKeeper7.titleFemale>
@@ -1497,7 +1497,7 @@
   <PetKeeper7.titleShortFemale>hayvan bakıcı</PetKeeper7.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was a student on a glitterworld. [PAWN_pronoun] had a hard time in school, since the other kids thought [PAWN_objective] rather strange.\n\n[PAWN_pronoun] always maintained a distance from these events, being continuously surprised by the many interesting and awkward ways life can go. -->
-  <Philosopher82.description>[PAWN_nameDef], bir glitterworld'de öğrenciydi. Diğer çocuklar onu oldukça tuhaf bulduğu için okulda zor zamanlar geçirdi.\n\n Hayatın gidebileceği birçok ilginç ve garip yol karşısında sürekli şaşırarak bu olaylardan her zaman uzak durdu.</Philosopher82.description>
+  <Philosopher82.description>[PAWN_nameDef], bir glitterworld'de öğrenciydi. Diğer çocuklar onu oldukça tuhaf bulduğu için okulda zor zamanlar geçirdi.\n\nHayatın gidebileceği birçok ilginç ve garip yol karşısında sürekli şaşırarak bu olaylardan her zaman uzak durdu.</Philosopher82.description>
   <!-- EN: philosopher -->
   <Philosopher82.title>filozof</Philosopher82.title>
   <Philosopher82.titleFemale>filozof</Philosopher82.titleFemale>
@@ -1524,7 +1524,7 @@
   <Pickpocket82.titleShortFemale>yankesici</Pickpocket82.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef]'s father was a starfighter pilot, and [PAWN_pronoun] always idolized the old man.\n\nFrom a young age, [PAWN_pronoun] collected pilot memorabilia and studied pilot books, preparing to join the deep space navy and follow in [PAWN_possessive] father's footsteps. -->
-  <PilotFan16.description>[PAWN_nameDef]'in babası bir yıldız savaşçısı pilotuydu ve yaşlı adamı her zaman idolü olarak gördü.\n\n Küçük yaşlardan itibaren pilot hatıraları topladı ve pilot kitapları okudu, derin uzay donanmasına katılmaya ve babasının izinden gitmeye hazırlanıyor.</PilotFan16.description>
+  <PilotFan16.description>[PAWN_nameDef]'in babası bir yıldız savaşçısı pilotuydu ve yaşlı adamı her zaman idolü olarak gördü.\n\nKüçük yaşlardan itibaren pilot hatıraları topladı ve pilot kitapları okudu, derin uzay donanmasına katılmaya ve babasının izinden gitmeye hazırlanıyor.</PilotFan16.description>
   <!-- EN: pilot fan -->
   <PilotFan16.title>pilot hayranı</PilotFan16.title>
   <PilotFan16.titleFemale>pilot hayranı</PilotFan16.titleFemale>
@@ -1532,7 +1532,7 @@
   <PilotFan16.titleShort>pilot hayranı</PilotFan16.titleShort>
   
   <!-- EN: [PAWN_nameDef] was enslaved as a child and forced to fight creatures and other people in an underground fighting arena.\n\n[PAWN_pronoun] showed an affinity for the sport, and eventually bought [PAWN_possessive] own freedom. However, [PAWN_possessive] time in the pits never brought [PAWN_objective] much intellectual stimulation. -->
-  <PitGladiator19.description>[PAWN_nameDef] çocukken köleleştirildi ve bir yeraltı dövüş arenasında yaratıklarla ve diğer insanlarla savaşmak zorunda kaldı.\n\n Dövüşe yatkınlık gösterdi ve sonunda kendi özgürlüğünü satın aldı. Bununla birlikte çukurlarda geçirdiği zaman ona hiçbir zaman çok fazla entelektüel etkileşim getirmedi.</PitGladiator19.description>
+  <PitGladiator19.description>[PAWN_nameDef] çocukken köleleştirildi ve bir yeraltı dövüş arenasında yaratıklarla ve diğer insanlarla savaşmak zorunda kaldı.\n\nDövüşe yatkınlık gösterdi ve sonunda kendi özgürlüğünü satın aldı. Bununla birlikte çukurlarda geçirdiği zaman ona hiçbir zaman çok fazla entelektüel etkileşim getirmedi.</PitGladiator19.description>
   <!-- EN: pit gladiator -->
   <PitGladiator19.title>çukur gladyatörü</PitGladiator19.title>
   <PitGladiator19.titleFemale>çukur gladyatörü</PitGladiator19.titleFemale>
@@ -1541,28 +1541,28 @@
   <PitGladiator19.titleShortFemale>gladyatör</PitGladiator19.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] loved boomrat pizza intensely. Rarely eating anything else, [PAWN_pronoun] was prone to bad health and low oxygen uptake.\n\n[PAWN_pronoun] loved bashing in the skulls of random creatures to see what was inside. -->
-  <PizzaLover94.description>[PAWN_nameDef] bumrat pizzayı çok severdi. Nadiren başka bir şey yiyordu, kötü sağlık ve düşük oksijen alımına eğilimliydi.\n\n. İçinde ne olduğunu görmek için rastgele yaratıkların kafataslarına vurmayı severdi.</PizzaLover94.description>
+  <PizzaLover94.description>[PAWN_nameDef] bumrat pizzayı çok severdi. Nadiren başka bir şey yiyordu, kötü sağlık ve düşük oksijen alımına eğilimliydi.\n\nİçinde ne olduğunu görmek için rastgele yaratıkların kafataslarına vurmayı severdi.</PizzaLover94.description>
   <!-- EN: pizza lover -->
   <PizzaLover94.title>pizza seven</PizzaLover94.title>
   <!-- EN: pizza kid -->
   <PizzaLover94.titleShort>pizza çocuk</PizzaLover94.titleShort>
   
-  <!-- EN: Born on a world wracked by plague, both of [PAWN_nameDef]'s parents were doctors. \n\n[PAWN_nameDef] was raised in reverse-quarantine, under the Hippocratic oath. [PAWN_pronoun] experienced little social interaction. However, [PAWN_pronoun] gained a lot of medical experience assisting in treatments. -->
-  <PlagueChild44.description>Veba tarafından harap edilmiş bir dünyada doğan [PAWN_nameDef]'in her iki ebeveyni de doktordu. \n\n [PAWN_nameDef], Hipokrat yemini altında ters karantinada yetiştirildi. Çok az sosyal etkileşim yaşadı. Bununla birlikte, tedavilere yardımcı olarak çok fazla tıbbi deneyim kazandı.</PlagueChild44.description>
+  <!-- EN: Born on a world wracked by plague, both of [PAWN_nameDef]'s parents were doctors.\n\n[PAWN_nameDef] was raised in reverse-quarantine, under the Hippocratic oath. [PAWN_pronoun] experienced little social interaction. However, [PAWN_pronoun] gained a lot of medical experience assisting in treatments. -->
+  <PlagueChild44.description>Veba tarafından harap edilmiş bir dünyada doğan [PAWN_nameDef]'in her iki ebeveyni de doktordu.\n\n[PAWN_nameDef], Hipokrat yemini altında ters karantinada yetiştirildi. Çok az sosyal etkileşim yaşadı. Bununla birlikte, tedavilere yardımcı olarak çok fazla tıbbi deneyim kazandı.</PlagueChild44.description>
   <!-- EN: plague child -->
   <PlagueChild44.title>vebalı çocuk</PlagueChild44.title>
   <!-- EN: child -->
   <PlagueChild44.titleShort>çocuk</PlagueChild44.titleShort>
   
   <!-- EN: [PAWN_nameDef]'s childhood was cut short when a mysterious plague hit [PAWN_possessive] homeworld.\n\n[PAWN_pronoun] watched [PAWN_possessive] friends die, and [PAWN_possessive] compassion for humanity died with them. In its place a new thirst for knowledge emerged. -->
-  <PlagueProdigy12.description>[PAWN_nameDef]'in çocukluğu, anavatanına gizemli bir veba vurduğunda kısa kesildi.\n\n Arkadaşlarının ölümünü izledi ve insanlığa duyduğu şefkat onlarla birlikte öldü. Yerine yeni bir bilgi açlığı doğdu.</PlagueProdigy12.description>
+  <PlagueProdigy12.description>[PAWN_nameDef]'in çocukluğu, anavatanına gizemli bir veba vurduğunda kısa kesildi.\n\nArkadaşlarının ölümünü izledi ve insanlığa duyduğu şefkat onlarla birlikte öldü. Yerine yeni bir bilgi açlığı doğdu.</PlagueProdigy12.description>
   <!-- EN: plague prodigy -->
   <PlagueProdigy12.title>vebalı dahi</PlagueProdigy12.title>
   <!-- EN: prodigy -->
   <PlagueProdigy12.titleShort>dahi</PlagueProdigy12.titleShort>
   
   <!-- EN: [PAWN_nameDef] watched as a mysterious plague spread through [PAWN_possessive] town, killing [PAWN_possessive] family and friends.\n\n[PAWN_pronoun] learned some medicine from watching the plague doctors, but was mentally scarred by the ordeal. -->
-  <PlagueSurvivor39.description>[PAWN_nameDef], kasabasına yayılan, ailesini ve arkadaşlarını öldüren gizemli bir vebayı izledi.\n\n Veba doktorlarını izleyerek biraz ilaç yapmayı öğrendi, ancak çektiği çileden dolayı zihinsel olarak yaralandı.</PlagueSurvivor39.description>
+  <PlagueSurvivor39.description>[PAWN_nameDef], kasabasına yayılan, ailesini ve arkadaşlarını öldüren gizemli bir vebayı izledi.\n\nVeba doktorlarını izleyerek biraz ilaç yapmayı öğrendi, ancak çektiği çileden dolayı zihinsel olarak yaralandı.</PlagueSurvivor39.description>
   <!-- EN: plague survivor -->
   <PlagueSurvivor39.title>vebadan kurtulan</PlagueSurvivor39.title>
   <PlagueSurvivor39.titleFemale>vebadan kurtulan</PlagueSurvivor39.titleFemale>
@@ -1588,22 +1588,22 @@
   <PowerMadScholar30.titleShortFemale>akademisyen</PowerMadScholar30.titleShortFemale>
   
   <!-- EN: Born to an upper-class family, [PAWN_nameDef] grew up with all the best things - the best education, the best social contacts, and of course the best technology money could buy.\n\nUnfortunately, living in such decadence left [PAWN_nameDef] rather spoiled when it came to labor. -->
-  <PrivilegedChild86.description>Üst sınıf bir ailede doğan [PAWN_nameDef] en iyi şeylerle büyüdü - en iyi eğitim, en iyi sosyal ilişkiler ve elbette paranın satın alabileceği en iyi teknoloji.\n\n Ne yazık ki, böyle bir lüks yaşam içinde yaşamak,[PAWN_nameDef]'yi iş gücü söz konusu olduğunda oldukça şımarık yaptı.</PrivilegedChild86.description>
+  <PrivilegedChild86.description>Üst sınıf bir ailede doğan [PAWN_nameDef] en iyi şeylerle büyüdü - en iyi eğitim, en iyi sosyal ilişkiler ve elbette paranın satın alabileceği en iyi teknoloji.\n\nNe yazık ki, böyle bir lüks yaşam içinde yaşamak,[PAWN_nameDef]'yi iş gücü söz konusu olduğunda oldukça şımarık yaptı.</PrivilegedChild86.description>
   <!-- EN: privileged child -->
-  <PrivilegedChild86.title>imtiyazlı çocuk</PrivilegedChild86.title>
+  <PrivilegedChild86.title>İmtiyazlı çocuk</PrivilegedChild86.title>
   <!-- EN: privileged -->
-  <PrivilegedChild86.titleShort>imtiyazlı</PrivilegedChild86.titleShort>
-  <PrivilegedChild86.titleShortFemale>imtiyazlı</PrivilegedChild86.titleShortFemale>
+  <PrivilegedChild86.titleShort>İmtiyazlı</PrivilegedChild86.titleShort>
+  <PrivilegedChild86.titleShortFemale>İmtiyazlı</PrivilegedChild86.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was recognized as gifted early in [PAWN_possessive] glitterworld upbringing. Luckily, [PAWN_possessive] family was in a position to cultivate that genius through advanced education. [PAWN_possessive] training included science, leadership, and the arts. -->
   <PrivilegedProdigy70.description>[PAWN_nameDef], glitterworld'de yetiştirilmesinin ilk yıllarında yetenekli olarak tanındı. Neyse ki ailesi, ileri eğitim yoluyla bu dehayı geliştirebilecek durumdaydı. Eğitimi bilim, liderlik ve sanatı içeriyordu.</PrivilegedProdigy70.description>
   <!-- EN: privileged prodigy -->
-  <PrivilegedProdigy70.title>imtiyazlı dahi</PrivilegedProdigy70.title>
+  <PrivilegedProdigy70.title>İmtiyazlı dahi</PrivilegedProdigy70.title>
   <!-- EN: prodigy -->
   <PrivilegedProdigy70.titleShort>dahi</PrivilegedProdigy70.titleShort>
   
   <!-- EN: [PAWN_nameDef] was a faithful student, and was dedicated to learning anything and everything [PAWN_pronoun] could about humanity and its creations.\n\nWhile [PAWN_pronoun] was shunned as a nerd, [PAWN_pronoun] didn't mind. [PAWN_pronoun] hoped for a brighter future. -->
-  <ProdigalStudent67.description>[PAWN_nameDef] sadık bir öğrenciydi ve kendini insanlık ve yarattıkları hakkında öğrenebildiği her şeyi öğrenmeye adamıştı.\n\n Bir nerd olarak dışlanırken, aldırmadı. Daha parlak bir gelecek için umutlanıyordu.</ProdigalStudent67.description>
+  <ProdigalStudent67.description>[PAWN_nameDef] sadık bir öğrenciydi ve kendini insanlık ve yarattıkları hakkında öğrenebildiği her şeyi öğrenmeye adamıştı.\n\nBir nerd olarak dışlanırken, aldırmadı. Daha parlak bir gelecek için umutlanıyordu.</ProdigalStudent67.description>
   <!-- EN: prodigal student -->
   <ProdigalStudent67.title>müsrif öğrenci</ProdigalStudent67.title>
   <ProdigalStudent67.titleFemale>müsrif öğrenci</ProdigalStudent67.titleFemale>
@@ -1612,7 +1612,7 @@
   <ProdigalStudent67.titleShortFemale>öğrenci</ProdigalStudent67.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was obsessed with video games since [PAWN_possessive] hands were big enough to grip a joystick.\n\n[PAWN_pronoun] achieved middling finishes in several local tournaments during the 16-bit era. Nobody noticed when [PAWN_pronoun] retired early in [PAWN_possessive] teenage years. -->
-  <ProfessionalGamer76.description>[PAWN_nameDef], elleri bir joystick'i tutacak kadar büyük olduğunda video oyunlarına takıntısı başladı.\n\n. 16 bitlik dönemde birkaç yerel turnuvada orta dereceli sonuçlar elde etti. Gençlik yıllarının başlarında emekli olduğunu kimse fark etmedi.</ProfessionalGamer76.description>
+  <ProfessionalGamer76.description>[PAWN_nameDef], elleri bir joystick'i tutacak kadar büyük olduğunda video oyunlarına takıntısı başladı.\n\n16 bitlik dönemde birkaç yerel turnuvada orta dereceli sonuçlar elde etti. Gençlik yıllarının başlarında emekli olduğunu kimse fark etmedi.</ProfessionalGamer76.description>
   <!-- EN: professional gamer -->
   <ProfessionalGamer76.title>profesyonel oyuncu</ProfessionalGamer76.title>
   <ProfessionalGamer76.titleFemale>profesyonel oyuncu</ProfessionalGamer76.titleFemale>
@@ -1620,14 +1620,14 @@
   <ProfessionalGamer76.titleShort>pro oyuncu</ProfessionalGamer76.titleShort>
   
   <!-- EN: [PAWN_nameDef] was picked by government agents for the mysterious "Frame Project".\n\nDue to memory blockages, however, [PAWN_pronoun] remembers very little about this project or its true agenda - only that there were few survivors. -->
-  <ProjectSubject99.description>[PAWN_nameDef], gizemli "Çerçeve Projesi" için hükümet ajanları tarafından seçildi.\n\n. Ancak hafıza blokajları nedeniyle bu proje veya gerçek gündemi hakkında çok az şey hatırlıyor - sadece birkaç kurtulan olduğunu.</ProjectSubject99.description>
+  <ProjectSubject99.description>[PAWN_nameDef], gizemli "Çerçeve Projesi" için hükümet ajanları tarafından seçildi.\n\nAncak hafıza blokajları nedeniyle bu proje veya gerçek gündemi hakkında çok az şey hatırlıyor - sadece birkaç kurtulan olduğunu.</ProjectSubject99.description>
   <!-- EN: project subject -->
   <ProjectSubject99.title>proje deneği</ProjectSubject99.title>
   <!-- EN: subject -->
   <ProjectSubject99.titleShort>denek</ProjectSubject99.titleShort>
   
-  <!-- EN: [PAWN_nameDef] researched new religions and traditions and often dreamt of distant stars. \n\n[PAWN_possessive] dreams prompted [PAWN_objective] to ask what lay beyond the lights in the sky. -->
-  <PsychologyStudent15.description>[PAWN_nameDef] yeni dinleri ve gelenekleri araştırdı ve genellikle uzak yıldızların hayalini kurdu.\n\n Rüyaları onu gökyüzündeki ışıkların ötesinde ne olduğunu sormaya sevk etti.</PsychologyStudent15.description>
+  <!-- EN: [PAWN_nameDef] researched new religions and traditions and often dreamt of distant stars.\n\n[PAWN_possessive] dreams prompted [PAWN_objective] to ask what lay beyond the lights in the sky. -->
+  <PsychologyStudent15.description>[PAWN_nameDef] yeni dinleri ve gelenekleri araştırdı ve genellikle uzak yıldızların hayalini kurdu.\n\nRüyaları onu gökyüzündeki ışıkların ötesinde ne olduğunu sormaya sevk etti.</PsychologyStudent15.description>
   <!-- EN: psychology student -->
   <PsychologyStudent15.title>psikoloji öğrencisi</PsychologyStudent15.title>
   <PsychologyStudent15.titleFemale>psikoloji öğrencisi</PsychologyStudent15.titleFemale>
@@ -1643,7 +1643,7 @@
   <Punk30.titleShort>serseri</Punk30.titleShort>
   
   <!-- EN: On an industrial world, [PAWN_nameDef] learned early that if [PAWN_pronoun] wanted to eat, [PAWN_pronoun] had to work. So work [PAWN_pronoun] did. Kids fit in places adults can't, and where [PAWN_pronoun] was from, the safety laws were quite flexible.\n\n[PAWN_pronoun] was always a bit of a pyromaniac, and was banned from the kitchen after an unfortunate incident. -->
-  <PyroAssistant82.description>Endüstriyel bir dünyada, [PAWN_nameDef] yemek yemek istiyorsa çalışması gerektiğini erken öğrendi. Yani çalıştı. Çocuklar yetişkinlerin giremeyeceği yerlere sığardı ve yaşadığı yerin güvenlik yasaları oldukça esnekti.\n\n Her zaman biraz piromanik biriydi ve talihsiz bir olaydan sonra mutfaktan men edildi.</PyroAssistant82.description>
+  <PyroAssistant82.description>Endüstriyel bir dünyada, [PAWN_nameDef] yemek yemek istiyorsa çalışması gerektiğini erken öğrendi. Yani çalıştı. Çocuklar yetişkinlerin giremeyeceği yerlere sığardı ve yaşadığı yerin güvenlik yasaları oldukça esnekti.\n\nHer zaman biraz piromanik biriydi ve talihsiz bir olaydan sonra mutfaktan men edildi.</PyroAssistant82.description>
   <!-- EN: pyro assistant -->
   <PyroAssistant82.title>ateş yardımcısı</PyroAssistant82.title>
   <PyroAssistant82.titleFemale>ateş yardımcısı</PyroAssistant82.titleFemale>
@@ -1652,38 +1652,38 @@
   <PyroAssistant82.titleShortFemale>asistan</PyroAssistant82.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was raised by doting parents on a midworld. Instead of playing with other children, [PAWN_pronoun] read books voraciously.\n\n[PAWN_pronoun] was not particularly rugged, and struggled with physical labor. -->
-  <QuietNerd97.description>[PAWN_nameDef], bir orta dünyada ebeveynlerini sevenler tarafından yetiştirildi. Diğer çocuklarla oynamak yerine açgözlülükle kitap okur.\n\n Özellikle dayanıklı değildi ve fiziksel güç için mücadele etti.</QuietNerd97.description>
+  <QuietNerd97.description>[PAWN_nameDef], bir orta dünyada ebeveynlerini sevenler tarafından yetiştirildi. Diğer çocuklarla oynamak yerine açgözlülükle kitap okur.\n\nÖzellikle dayanıklı değildi ve fiziksel güç için mücadele etti.</QuietNerd97.description>
   <!-- EN: quiet nerd -->
   <QuietNerd97.title>sessiz nerd</QuietNerd97.title>
   <!-- EN: nerd -->
   <QuietNerd97.titleShort>nerd</QuietNerd97.titleShort>
   
   <!-- EN: [PAWN_nameDef] was raised in a forest. [PAWN_possessive] father taught [PAWN_objective] to hunt and live off the land, so that [PAWN_pronoun] could live without the need of others when father died.\n\nAccustomed to manual labor and with an intuitive mind, [PAWN_nameDef] could survive weeks alone. -->
-  <RangerChild57.description>[PAWN_nameDef] bir ormanda yetiştirildi. Babası ona avlanmayı ve arazide yaşamayı öğretti, böylece babası öldüğünde başkalarına ihtiyaç duymadan yaşayabildi.\n\n El emeğine alışkın ve sezgisel bir zihinle [PAWN_nameDef] tek başına haftalarca hayatta kalabilir.</RangerChild57.description>
+  <RangerChild57.description>[PAWN_nameDef] bir ormanda yetiştirildi. Babası ona avlanmayı ve arazide yaşamayı öğretti, böylece babası öldüğünde başkalarına ihtiyaç duymadan yaşayabildi.\n\nEl emeğine alışkın ve sezgisel bir zihinle [PAWN_nameDef] tek başına haftalarca hayatta kalabilir.</RangerChild57.description>
   <!-- EN: ranger child -->
   <RangerChild57.title>korucu çocuk</RangerChild57.title>
   <!-- EN: ranger kid -->
   <RangerChild57.titleShort>korucu çocuk</RangerChild57.titleShort>
   
   <!-- EN: [PAWN_nameDef] was born under authoritarian rule. Despite intense oppression from family and community, [PAWN_pronoun] never gave up fighting for [PAWN_possessive] dignity and [PAWN_possessive] freedom.\n\n[PAWN_pronoun] was often put into hopeless situations where even family would try to terrorize [PAWN_objective] into propriety. [PAWN_pronoun] learned to trust no one. -->
-  <RebelChild8.description>PAWN_nameDef] otoriter yönetim altında doğdu. Ailesinden ve toplumundan gelen yoğun baskıya rağmen, haysiyeti ve özgürlüğü için savaşmaktan asla vazgeçmedi.\n\n Sık sık, ailesinin bile onu uygun hale getirmek için korkutmaya çalıştığı umutsuz durumlara düştü. Kimseye güvenmemeyi öğrendi.</RebelChild8.description>
+  <RebelChild8.description>PAWN_nameDef] otoriter yönetim altında doğdu. Ailesinden ve toplumundan gelen yoğun baskıya rağmen, haysiyeti ve özgürlüğü için savaşmaktan asla vazgeçmedi.\n\nSık sık, ailesinin bile onu uygun hale getirmek için korkutmaya çalıştığı umutsuz durumlara düştü. Kimseye güvenmemeyi öğrendi.</RebelChild8.description>
   <!-- EN: rebel child -->
   <RebelChild8.title>asi çocuk</RebelChild8.title>
   <!-- EN: rebel -->
   <RebelChild8.titleShort>asi</RebelChild8.titleShort>
   <RebelChild8.titleShortFemale>asi</RebelChild8.titleShortFemale>
   
-  <!-- EN: [PAWN_nameDef] had a shot at an education, but [PAWN_pronoun] rebelled against the injustices [PAWN_pronoun] saw and was expelled from three schools. This left [PAWN_objective] with a sense of integrity, but a lack of social skills.\n\n        [PAWN_nameDef] sought self-actualization. [PAWN_pronoun] spent [PAWN_possessive] days meditating and practicing katana and staff fighting techniques. -->
-  <RebelliousStudent74.description>[PAWN_nameDef] bir eğitim şansı buldu ama gördüğü adaletsizliklere isyan etti ve üç okuldan atıldı. Sahip olduğu adalet duygusu yüzünden yalnız kaldı.\n\n [PAWN_nameDef] kendini gerçekleştirmenin peşindeydi. Günlerini meditasyon yaparak ve katana ve personel dövüş teknikleri uygulayarak geçirdi.</RebelliousStudent74.description>
+  <!-- EN: [PAWN_nameDef] had a shot at an education, but [PAWN_pronoun] rebelled against the injustices [PAWN_pronoun] saw and was expelled from three schools. This left [PAWN_objective] with a sense of integrity, but a lack of social skills.\n\n[PAWN_nameDef] sought self-actualization. [PAWN_pronoun] spent [PAWN_possessive] days meditating and practicing katana and staff fighting techniques. -->
+  <RebelliousStudent74.description>[PAWN_nameDef] bir eğitim şansı buldu ama gördüğü adaletsizliklere isyan etti ve üç okuldan atıldı. Sahip olduğu adalet duygusu yüzünden yalnız kaldı.\n\n[PAWN_nameDef] kendini gerçekleştirmenin peşindeydi. Günlerini meditasyon yaparak ve katana ve personel dövüş teknikleri uygulayarak geçirdi.</RebelliousStudent74.description>
   <!-- EN: rebellious student -->
-  <RebelliousStudent74.title>isyankar öğrenci</RebelliousStudent74.title>
-  <RebelliousStudent74.titleFemale>isyankar öğrenci</RebelliousStudent74.titleFemale>
+  <RebelliousStudent74.title>İsyankar öğrenci</RebelliousStudent74.title>
+  <RebelliousStudent74.titleFemale>İsyankar öğrenci</RebelliousStudent74.titleFemale>
   <!-- EN: student -->
   <RebelliousStudent74.titleShort>öğrenci</RebelliousStudent74.titleShort>
   <RebelliousStudent74.titleShortFemale>öğrenci</RebelliousStudent74.titleShortFemale>
   
-  <!-- EN: [PAWN_nameDef] was born into corporate slavery and raised to perform menial tasks for minimum pay. [PAWN_pronoun] was just another cog in the machine. \n\n[PAWN_nameDef] found [PAWN_possessive] freedom by joining a rebel organization whose goal was to break free from their corporate masters. -->
-  <RebelSlave14.description>[PAWN_nameDef] kurumsal köleliğin içine doğdu ve asgari ücret karşılığında sıradan görevleri yerine getirmek için yetiştirildi. O, makinedeki bir başka dişliydi.\n\n. [PAWN_nameDef], amaçları kurumsal efendilerinden kurtulmak olan bir isyancı örgüte katılarak özgürlüğünü buldu.</RebelSlave14.description>
+  <!-- EN: [PAWN_nameDef] was born into corporate slavery and raised to perform menial tasks for minimum pay. [PAWN_pronoun] was just another cog in the machine.\n\n[PAWN_nameDef] found [PAWN_possessive] freedom by joining a rebel organization whose goal was to break free from their corporate masters. -->
+  <RebelSlave14.description>[PAWN_nameDef] kurumsal köleliğin içine doğdu ve asgari ücret karşılığında sıradan görevleri yerine getirmek için yetiştirildi. O, makinedeki bir başka dişliydi.\n\n[PAWN_nameDef], amaçları kurumsal efendilerinden kurtulmak olan bir isyancı örgüte katılarak özgürlüğünü buldu.</RebelSlave14.description>
   <!-- EN: rebel slave -->
   <RebelSlave14.title>asi köle</RebelSlave14.title>
   <RebelSlave14.titleFemale>asi köle</RebelSlave14.titleFemale>
@@ -1692,7 +1692,7 @@
   <RebelSlave14.titleShortFemale>asi</RebelSlave14.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] grew up in a modest but privileged family who encouraged [PAWN_objective] to play chess and shoot skeet at a young age.\n\nAs a bored student, [PAWN_pronoun] found joy in challenging [PAWN_possessive] teachers about the contradictions between [PAWN_possessive] planet's official values and their government's policies. -->
-  <RebelStudent14.description>[PAWN_nameDef] mütevazı ama ayrıcalıklı bir ailede büyüdü, ailesi onu küçük yaşta satranç oynamaya ve skeet atmaya teşvik etti.\n\n. Canı sıkılan bir öğrenci olarak, öğretmenlerine gezegeninin resmi değerleri ile hükümetlerinin politikaları arasındaki çelişkiler konusunda meydan okumaktan keyif alırdı.</RebelStudent14.description>
+  <RebelStudent14.description>[PAWN_nameDef] mütevazı ama ayrıcalıklı bir ailede büyüdü, ailesi onu küçük yaşta satranç oynamaya ve skeet atmaya teşvik etti.\n\nCanı sıkılan bir öğrenci olarak, öğretmenlerine gezegeninin resmi değerleri ile hükümetlerinin politikaları arasındaki çelişkiler konusunda meydan okumaktan keyif alırdı.</RebelStudent14.description>
   <!-- EN: rebel student -->
   <RebelStudent14.title>asi öğrenci</RebelStudent14.title>
   <RebelStudent14.titleFemale>asi öğrenci</RebelStudent14.titleFemale>
@@ -1710,22 +1710,22 @@
   <RebelWriter82.titleShortFemale>yazar</RebelWriter82.titleShortFemale>
   
   <!-- EN: Growing up on a flourishing glitterworld afforded [PAWN_nameDef] the chance to fully devote [PAWN_objective]self to [PAWN_possessive] studies.\n\nHaving taken a keen interest in genetic modification and neural augmentation from a young age, [PAWN_pronoun] had little time (or desire) for a regular childhood. -->
-  <ReclusiveProdigy96.description>Gelişen bir glitterworld'de büyümek, [PAWN_nameDef]'e kendini tamamen çalışmalarına adama şansı verdi.\n\n. Küçük yaşlardan itibaren genetik modifikasyon ve nöral güçlendirme ile yakından ilgilendiğinden, düzenli bir çocukluk için çok az zamanı (ya da arzusu) vardı.</ReclusiveProdigy96.description>
+  <ReclusiveProdigy96.description>Gelişen bir glitterworld'de büyümek, [PAWN_nameDef]'e kendini tamamen çalışmalarına adama şansı verdi.\n\nKüçük yaşlardan itibaren genetik modifikasyon ve nöral güçlendirme ile yakından ilgilendiğinden, düzenli bir çocukluk için çok az zamanı (ya da arzusu) vardı.</ReclusiveProdigy96.description>
   <!-- EN: reclusive prodigy -->
   <ReclusiveProdigy96.title>münzevi dahi</ReclusiveProdigy96.title>
   <!-- EN: prodigy -->
   <ReclusiveProdigy96.titleShort>dahi</ReclusiveProdigy96.titleShort>
   
-  <!-- EN: [PAWN_nameDef] lived on a midworld where the government cared about the youth. \n\n[PAWN_pronoun] was one of the many children who were taken from their parents and forced into the new education programs. -->
-  <ReEducatedYouth23.description>[PAWN_nameDef], hükümetin gençleri önemsediği bir orta dünyada yaşıyordu. \n\n Ebeveynlerinden alınan ve yeni eğitim programlarına zorlanan çok sayıdaki çocuktan biriydi.</ReEducatedYouth23.description>
+  <!-- EN: [PAWN_nameDef] lived on a midworld where the government cared about the youth.\n\n[PAWN_pronoun] was one of the many children who were taken from their parents and forced into the new education programs. -->
+  <ReEducatedYouth23.description>[PAWN_nameDef], hükümetin gençleri önemsediği bir orta dünyada yaşıyordu.\n\nEbeveynlerinden alınan ve yeni eğitim programlarına zorlanan çok sayıdaki çocuktan biriydi.</ReEducatedYouth23.description>
   <!-- EN: re-educated youth -->
   <ReEducatedYouth23.title>eğitilmiş genç</ReEducatedYouth23.title>
   <!-- EN: reeducated -->
-  <ReEducatedYouth23.titleShort>işveren</ReEducatedYouth23.titleShort>
-  <ReEducatedYouth23.titleShortFemale>işveren</ReEducatedYouth23.titleShortFemale>
+  <ReEducatedYouth23.titleShort>İşveren</ReEducatedYouth23.titleShort>
+  <ReEducatedYouth23.titleShortFemale>İşveren</ReEducatedYouth23.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] grew up on a midworld with loving parents, a cute pet and a lot of money - but no friends.\n\n[PAWN_pronoun] was always told by [PAWN_possessive] father that 'those peasants just want your money'. So, [PAWN_pronoun] spent most of [PAWN_possessive] time alone, or fighting other kids. -->
-  <RichBoy9.description>[PAWN_nameDef], sevgi dolu ebeveynleri,sevimli bir evcil hayvanı ve çok parası olan ama hiç arkadaşı olmayan birisi olarak  orta dünyada büyüdü.\n\n Babası ona her zaman 'bu köylüler sadece paranızı istiyor' derdi. Bu yüzden zamanının çoğunu yalnız ya da diğer çocuklarla savaşarak geçirdi.</RichBoy9.description>
+  <RichBoy9.description>[PAWN_nameDef], sevgi dolu ebeveynleri, sevimli bir evcil hayvanı ve çok parası olan ama hiç arkadaşı olmayan birisi olarak  orta dünyada büyüdü.\n\nBabası ona her zaman 'bu köylüler sadece paranızı istiyor' derdi. Bu yüzden zamanının çoğunu yalnız ya da diğer çocuklarla savaşarak geçirdi.</RichBoy9.description>
   <!-- EN: rich boy -->
   <RichBoy9.title>zengin çocuk</RichBoy9.title>
   <!-- EN: rich boy -->
@@ -1733,14 +1733,14 @@
   <RichBoy9.titleShortFemale>zengin çocuk</RichBoy9.titleShortFemale>
   
   <!-- EN: Born with a special mark on [PAWN_possessive] neck, [PAWN_nameDef]'s tribe chose to sacrifice [PAWN_objective] in a blood ritual. They left [PAWN_objective] in the forest to die. A pack of arctic wolves found and adopted [PAWN_objective].\n\nOver time, [PAWN_pronoun] learned to make tools to hunt with the pack. -->
-  <RitualChild20.description>Boynunda özel bir işaretle doğan [PAWN_nameDef]'nin kabilesi onu bir kan ritüelinde kurban etmeyi seçti. Onu ormanda ölüme terk ettiler. Bir kutup kurdu sürüsü onu buldu ve sahiplendi.\n\n Zamanla, sürüyle birlikte avlanmak için aletler yapmayı öğrendi.</RitualChild20.description>
+  <RitualChild20.description>Boynunda özel bir işaretle doğan [PAWN_nameDef]'nin kabilesi onu bir kan ritüelinde kurban etmeyi seçti. Onu ormanda ölüme terk ettiler. Bir kutup kurdu sürüsü onu buldu ve sahiplendi.\n\nZamanla, sürüyle birlikte avlanmak için aletler yapmayı öğrendi.</RitualChild20.description>
   <!-- EN: ritual child -->
   <RitualChild20.title>ritüel çocuk</RitualChild20.title>
   <!-- EN: sacrifice -->
   <RitualChild20.titleShort>kurban</RitualChild20.titleShort>
   
   <!-- EN: [PAWN_nameDef] grew up in one of the few remaining cities on a world ravaged by nuclear war.\n\n[PAWN_pronoun] learned to survive on [PAWN_possessive] own in this post-apocalyptic wasteland by scavenging for technology and supplies. -->
-  <Scavenger62.description>[PAWN_nameDef], nükleer savaşın harap ettiği bir dünyada kalan birkaç şehirden birinde büyüdü.\n\n. Bu kıyamet sonrası çorak arazide teknoloji ve malzeme toplayarak kendi başına hayatta kalmayı öğrendi.</Scavenger62.description>
+  <Scavenger62.description>[PAWN_nameDef], nükleer savaşın harap ettiği bir dünyada kalan birkaç şehirden birinde büyüdü.\n\nBu kıyamet sonrası çorak arazide teknoloji ve malzeme toplayarak kendi başına hayatta kalmayı öğrendi.</Scavenger62.description>
   <!-- EN: scavenger -->
   <Scavenger62.title>çöpçü</Scavenger62.title>
   <Scavenger62.titleFemale>çöpçü</Scavenger62.titleFemale>
@@ -1749,7 +1749,7 @@
   <Scavenger62.titleShortFemale>çöpçü</Scavenger62.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] had a modest but proper upbringing. Despite a good family background and plenty of support, [PAWN_pronoun] struggled to make friends and was often bullied. [PAWN_pronoun] learned to work or play alone, and avoided socializing to avoid conflict.\n\nWhen conflict did arise, [PAWN_nameDef] would retaliate violently. -->
-  <SchoolyardOutcast11.description>[PAWN_nameDef] mütevazı ama uygun bir şekilde yetiştirildi. İyi bir aile geçmişine ve çok sayıda desteğe rağmen, arkadaş edinmekte zorlandı ve sık sık zorbalığa uğradı. Tek başına çalışmayı veya oyun oynamayı öğrendi ve çatışmadan kaçınmak için sosyalleşmekten kaçındı.\n\n Çatışma ortaya çıktığında [PAWN_nameDef] şiddetle misilleme yapardı.</SchoolyardOutcast11.description>
+  <SchoolyardOutcast11.description>[PAWN_nameDef] mütevazı ama uygun bir şekilde yetiştirildi. İyi bir aile geçmişine ve çok sayıda desteğe rağmen, arkadaş edinmekte zorlandı ve sık sık zorbalığa uğradı. Tek başına çalışmayı veya oyun oynamayı öğrendi ve çatışmadan kaçınmak için sosyalleşmekten kaçındı.\n\nÇatışma ortaya çıktığında [PAWN_nameDef] şiddetle misilleme yapardı.</SchoolyardOutcast11.description>
   <!-- EN: schoolyard outcast -->
   <SchoolyardOutcast11.title>okullu parya</SchoolyardOutcast11.title>
   <SchoolyardOutcast11.titleFemale>okullu parya</SchoolyardOutcast11.titleFemale>
@@ -1758,23 +1758,23 @@
   <SchoolyardOutcast11.titleShortFemale>parya</SchoolyardOutcast11.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was top of [PAWN_possessive] class in chemistry, physics, exobiology, astronomy and opera.\n\nAn unfortunate lab accident left [PAWN_objective] with a deathly fear of fire. -->
-  <ScienceProdigy65.description>PAWN_nameDef] kimya, fizik, exobiyoloji, astronomi ve operada sınıfının birincisiydi.\n\n Talihsiz bir laboratuvar kazası onu ölümcül bir yangın korkusu bıraktı.</ScienceProdigy65.description>
+  <ScienceProdigy65.description>PAWN_nameDef] kimya, fizik, exobiyoloji, astronomi ve operada sınıfının birincisiydi.\n\nTalihsiz bir laboratuvar kazası onu ölümcül bir yangın korkusu bıraktı.</ScienceProdigy65.description>
   <!-- EN: science prodigy -->
   <ScienceProdigy65.title>bilim dahisi</ScienceProdigy65.title>
   <!-- EN: prodigy -->
   <ScienceProdigy65.titleShort>dahi</ScienceProdigy65.titleShort>
   
   <!-- EN: [PAWN_nameDef] loved being outdoors. [PAWN_possessive] parents enrolled [PAWN_objective] in a program that taught military scouting skills. [PAWN_pronoun] thrived when [PAWN_pronoun] was left alone in the wilderness.\n\nUnfortunately, [PAWN_nameDef] did not learn the basic technological skills that are taken for granted by many others. -->
-  <Scout6.description>[PAWN_nameDef] açık havada olmayı severdi. Ailesi onu askeri keşif becerileri öğreten bir programa kaydettirdi. Vahşi doğada tek başına kalarak büyüdü.\n\n Ne yazık ki, [PAWN_nameDef] başkaları tarafından hafife alınan temel teknolojik becerileri öğrenemedi.</Scout6.description>
+  <Scout6.description>[PAWN_nameDef] açık havada olmayı severdi. Ailesi onu askeri keşif becerileri öğreten bir programa kaydettirdi. Vahşi doğada tek başına kalarak büyüdü.\n\nNe yazık ki, [PAWN_nameDef] başkaları tarafından hafife alınan temel teknolojik becerileri öğrenemedi.</Scout6.description>
   <!-- EN: scout -->
-  <Scout6.title>izci</Scout6.title>
-  <Scout6.titleFemale>izci</Scout6.titleFemale>
+  <Scout6.title>İzci</Scout6.title>
+  <Scout6.titleFemale>İzci</Scout6.titleFemale>
   <!-- EN: scout -->
-  <Scout6.titleShort>izci</Scout6.titleShort>
-  <Scout6.titleShortFemale>izci</Scout6.titleShortFemale>
+  <Scout6.titleShort>İzci</Scout6.titleShort>
+  <Scout6.titleShortFemale>İzci</Scout6.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] would dive into junk mounds in search for valuables and items of interest.\n\n[PAWN_pronoun] was never bothered by the stink, or dangers that could leave [PAWN_objective] wounded for weeks. -->
-  <Scrounger25.description>[PAWN_nameDef], değerli ve ilgi çekici eşyaları aramak için hurda yığınlarına dalardı.\n\n Kötü kokudan ya da haftalarca yaralanmasına neden olabilecek tehlikelerden asla rahatsız olmadı.</Scrounger25.description>
+  <Scrounger25.description>[PAWN_nameDef], değerli ve ilgi çekici eşyaları aramak için hurda yığınlarına dalardı.\n\nKötü kokudan ya da haftalarca yaralanmasına neden olabilecek tehlikelerden asla rahatsız olmadı.</Scrounger25.description>
   <!-- EN: scrounger -->
   <Scrounger25.title>çöpçü</Scrounger25.title>
   <Scrounger25.titleFemale>çöpçü</Scrounger25.titleFemale>
@@ -1783,7 +1783,7 @@
   <Scrounger25.titleShortFemale>çöpçü</Scrounger25.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was a nice child. When anybody had a problem, [PAWN_pronoun] tried to fix it. But, being a child, [PAWN_pronoun] did not always succeed. This hurt [PAWN_possessive] sensitive soul.\n\n[PAWN_pronoun] dreamed of being a soldier who fights raiders and aliens. -->
-  <SentimentalChild55.description>[PAWN_nameDef] iyi bir çocuktu. Birinin bir sorunu olduğunda, onu düzeltmeye çalışırdı. Ancak, bir çocuk olarak her zaman başarılı olmadı. Bu onun hassas ruhunu incitti.\n\n Akıncılar ve uzaylılarla savaşan bir asker olmayı hayal etti.</SentimentalChild55.description>
+  <SentimentalChild55.description>[PAWN_nameDef] iyi bir çocuktu. Birinin bir sorunu olduğunda, onu düzeltmeye çalışırdı. Ancak, bir çocuk olarak her zaman başarılı olmadı. Bu onun hassas ruhunu incitti.\n\nAkıncılar ve uzaylılarla savaşan bir asker olmayı hayal etti.</SentimentalChild55.description>
   <!-- EN: sentimental child -->
   <SentimentalChild55.title>duygusal çocuk</SentimentalChild55.title>
   <!-- EN: nice kid -->
@@ -1791,14 +1791,14 @@
   <SentimentalChild55.titleShortFemale>harika çocuk</SentimentalChild55.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef]'s family were space traders. One day, [PAWN_nameDef]'s cryptosleep pod failed in transit. [PAWN_pronoun] had to spend years awake on the ship as the other slept.\n\n[PAWN_pronoun] filled [PAWN_possessive] days creating beautiful contraptions from the ship's cargo - but [PAWN_pronoun] didn't learn a lot of basic planetary living skills. -->
-  <ShipChild46.description>[PAWN_nameDef]'in ailesi uzay tüccarlarıydı. Bir gün, [PAWN_nameDef]'in kripto uyku bölmesi aktarım sırasında başarısız oldu. Diğerleri uyurken o yıllarını gemide uyanık geçirmek zorunda kaldı.\n\n Günlerini geminin kargosundan güzel mekanizmalar yaratarak doldurdu - pek çok temel yaşam becerisini öğrenmedi.</ShipChild46.description>
+  <ShipChild46.description>[PAWN_nameDef]'in ailesi uzay tüccarlarıydı. Bir gün, [PAWN_nameDef]'in kripto uyku bölmesi aktarım sırasında başarısız oldu. Diğerleri uyurken o yıllarını gemide uyanık geçirmek zorunda kaldı.\n\nGünlerini geminin kargosundan güzel mekanizmalar yaratarak doldurdu - pek çok temel yaşam becerisini öğrenmedi.</ShipChild46.description>
   <!-- EN: ship child -->
   <ShipChild46.title>gemi çocuğu</ShipChild46.title>
   <!-- EN: ship child -->
   <ShipChild46.titleShort>gemi çocuğu</ShipChild46.titleShort>
   
   <!-- EN: [PAWN_nameDef] was an apprentice technician on trade ships plying their routes between the stations and planets of [PAWN_possessive] home system. In this job, [PAWN_pronoun] learned to fix and improve many machines.\n\nSometimes, [PAWN_possessive] ship was assigned to short exploratory jaunts into dangerous regions of space. -->
-  <ShipTechnician0.description>[PAWN_nameDef], ana sisteminin istasyonları ve gezegenleri arasındaki rotayı dolaşan ticaret gemilerinde çırak teknisyendi. Bu işte birçok makineyi tamir etmeyi ve geliştirmeyi öğrendi.\n\n Bazen gemisi, uzayın tehlikeli bölgelerine kısa keşif gezilerine atandı.</ShipTechnician0.description>
+  <ShipTechnician0.description>[PAWN_nameDef], ana sisteminin istasyonları ve gezegenleri arasındaki rotayı dolaşan ticaret gemilerinde çırak teknisyendi. Bu işte birçok makineyi tamir etmeyi ve geliştirmeyi öğrendi.\n\nBazen gemisi, uzayın tehlikeli bölgelerine kısa keşif gezilerine atandı.</ShipTechnician0.description>
   <!-- EN: ship technician -->
   <ShipTechnician0.title>gemi teknisyeni</ShipTechnician0.title>
   <ShipTechnician0.titleFemale>gemi teknisyeni</ShipTechnician0.titleFemale>
@@ -1823,7 +1823,7 @@
   <ShunnedGirl30.titleShortFemale>sersemlemiş</ShunnedGirl30.titleShortFemale>
   
   <!-- EN: It is not uncommon for a sickly child to be cast away. What is uncommon is for that child to survive and even thrive with such a weak body.\n\nUsing [PAWN_possessive] quick wit and silver tongue, [PAWN_nameDef] was able to get out of almost any situation - most of the time at the cost others around him. -->
-  <SicklyLiar3.description>Hasta bir çocuğun evden atılması nadir değildir. Nadir olan, bu çocuğun böyle zayıf bir vücutla hayatta kalması ve hatta gelişmesidir.\n\n [PAWN_nameDef] hızlı zekasını ve gümüş dilini kullanarak hemen hemen her durumdan kurtulmayı başardı - çoğu zaman etrafındaki diğer insanlara zarar verdi.</SicklyLiar3.description>
+  <SicklyLiar3.description>Hasta bir çocuğun evden atılması nadir değildir. Nadir olan, bu çocuğun böyle zayıf bir vücutla hayatta kalması ve hatta gelişmesidir.\n\n[PAWN_nameDef] hızlı zekasını ve gümüş dilini kullanarak hemen hemen her durumdan kurtulmayı başardı - çoğu zaman etrafındaki diğer insanlara zarar verdi.</SicklyLiar3.description>
   <!-- EN: sickly liar -->
   <SicklyLiar3.title>hasta yalancı</SicklyLiar3.title>
   <SicklyLiar3.titleFemale>hasta yalancı</SicklyLiar3.titleFemale>
@@ -1841,7 +1841,7 @@
   <SlaveFarmer99.titleShortFemale>köle</SlaveFarmer99.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] grew up in an isolated midworld village, surrounded by opticows and countryside.\n\n[PAWN_possessive] parents taught [PAWN_objective] a wide range of useful domestic skills, but a peaceful and secure childhood left [PAWN_objective] with little understanding of the harder parts of life. -->
-  <SmallTownKid41.description>[PAWN_nameDef], optik hayvanlar ve kırsal alanla çevrili, izole bir orta dünya köyünde büyüdü.\n\n Ailesi ona çok çeşitli ev becerileri öğretti, ancak huzurlu ve güvenli bir çocukluk hayatın zor kısımlarını çok az anlamasını sağladı.</SmallTownKid41.description>
+  <SmallTownKid41.description>[PAWN_nameDef], optik hayvanlar ve kırsal alanla çevrili, izole bir orta dünya köyünde büyüdü.\n\nAilesi ona çok çeşitli ev becerileri öğretti, ancak huzurlu ve güvenli bir çocukluk hayatın zor kısımlarını çok az anlamasını sağladı.</SmallTownKid41.description>
   <!-- EN: small town kid -->
   <SmallTownKid41.title>küçük kasaba çocuğu</SmallTownKid41.title>
   <!-- EN: town kid -->
@@ -1857,14 +1857,14 @@
   <SocialPariah3.titleShortFemale>parya</SocialPariah3.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] grew up believing [PAWN_pronoun] was a normal, albeit slightly sheltered child.\n\nIn truth, [PAWN_pronoun] was part of an elaborate experiment. Researchers were conditioning [PAWN_objective] using social interactions and mechanite injections to try to produce an elite soldier. -->
-  <SoldierExperiment50.description>[PAWN_nameDef] biraz korunaklı olsa da normal bir çocuk olduğuna inanarak büyüdü.\n\n Gerçekte, ayrıntılı bir deneyin parçasıydı. Araştırmacılar, seçkin bir asker yaratmaya çalışmak için sosyal etkileşimler ve mekanik enjeksiyonlar kullanarak onu şartlandırıyorlardı.</SoldierExperiment50.description>
+  <SoldierExperiment50.description>[PAWN_nameDef] biraz korunaklı olsa da normal bir çocuk olduğuna inanarak büyüdü.\n\nGerçekte, ayrıntılı bir deneyin parçasıydı. Araştırmacılar, seçkin bir asker yaratmaya çalışmak için sosyal etkileşimler ve mekanik enjeksiyonlar kullanarak onu şartlandırıyorlardı.</SoldierExperiment50.description>
   <!-- EN: soldier experiment -->
   <SoldierExperiment50.title>denek asker</SoldierExperiment50.title>
   <!-- EN: experiment -->
   <SoldierExperiment50.titleShort>denek</SoldierExperiment50.titleShort>
   
   <!-- EN: [PAWN_nameDef]'s entire tribe was wiped out by a mysterious disease.\n\nFound alone and adopted by another band, [PAWN_pronoun] never became close with the other tribe members. [PAWN_pronoun] preferred to stay away from [PAWN_possessive] new home, wandering the woods and tending the animals. -->
-  <SoleSurvivor63.description>[PAWN_nameDef]'in tüm kabilesi gizemli bir hastalık tarafından yok edildi.\n\n Tek başına bulunup başka bir grup tarafından evlat edinildi, diğer kabile üyeleriyle asla yakınlaşmadı. Yeni evinden uzak durmayı, ormanda dolaşmayı ve hayvanlara bakmayı tercih etti.</SoleSurvivor63.description>
+  <SoleSurvivor63.description>[PAWN_nameDef]'in tüm kabilesi gizemli bir hastalık tarafından yok edildi.\n\nTek başına bulunup başka bir grup tarafından evlat edinildi, diğer kabile üyeleriyle asla yakınlaşmadı. Yeni evinden uzak durmayı, ormanda dolaşmayı ve hayvanlara bakmayı tercih etti.</SoleSurvivor63.description>
   <!-- EN: sole survivor -->
   <SoleSurvivor63.title>tek kurtulan</SoleSurvivor63.title>
   <SoleSurvivor63.titleFemale>tek kurtulan</SoleSurvivor63.titleFemale>
@@ -1873,7 +1873,7 @@
   <SoleSurvivor63.titleShortFemale>kurtulan</SoleSurvivor63.titleShortFemale>
   
   <!-- EN: In the mountains of the planet Ticonderoga, [PAWN_nameDef] was raised by [PAWN_possessive] tribal mother. She taught [PAWN_objective] survival skills - trapping, tracking, shooting, skinning, cooking and healing.\n\n[PAWN_possessive] departed father had left behind an old bolt-action rifle, and [PAWN_nameDef] practiced with it every chance [PAWN_pronoun] got. -->
-  <SonOfAHuntress75.description>Ticonderoga gezegeninin dağlarında [PAWN_nameDef], annesi tarafından büyütüldü. Ona hayatta kalma becerilerini öğretti - tuzak kurma, takip etme, ateş etme, deri yüzme, yemek pişirme ve iyileştirme.\n\n Ölen babası, eski bir sürgü mekanizmalı tüfek bırakmıştı ve [PAWN_nameDef], her fırsatta onunla pratik yaptı.</SonOfAHuntress75.description>
+  <SonOfAHuntress75.description>Ticonderoga gezegeninin dağlarında [PAWN_nameDef], annesi tarafından büyütüldü. Ona hayatta kalma becerilerini öğretti - tuzak kurma, takip etme, ateş etme, deri yüzme, yemek pişirme ve iyileştirme.\n\nÖlen babası, eski bir sürgü mekanizmalı tüfek bırakmıştı ve [PAWN_nameDef], her fırsatta onunla pratik yaptı.</SonOfAHuntress75.description>
   <!-- EN: son of a huntress -->
   <SonOfAHuntress75.title>bir avcının çocuğu</SonOfAHuntress75.title>
   <!-- EN: hunter -->
@@ -1904,14 +1904,14 @@
   <SpaceNerd97.titleShort>uzay nerd</SpaceNerd97.titleShort>
   
   <!-- EN: Born among stars to a spacefaring family, the [PAWN_nameDef] was the only survivor when [PAWN_possessive] family's ship was destroyed.\n\n[PAWN_pronoun] was forced to find a way to survive, and seek the joy of knowing another family. -->
-  <SpacerOrphan77.description>Uzayda yolculuk yapan bir ailenin yıldızları arasında doğan [PAWN_nameDef], ailesinin gemisi yok edildiğinde hayatta kalan tek kişiydi.\n\n. Hayatta kalmanın bir yolunu bulmaya ve başka bir aileyi tanımanın sevincini aramaya zorlandı.</SpacerOrphan77.description>
+  <SpacerOrphan77.description>Uzayda yolculuk yapan bir ailenin yıldızları arasında doğan [PAWN_nameDef], ailesinin gemisi yok edildiğinde hayatta kalan tek kişiydi.\n\nHayatta kalmanın bir yolunu bulmaya ve başka bir aileyi tanımanın sevincini aramaya zorlandı.</SpacerOrphan77.description>
   <!-- EN: spacer orphan -->
   <SpacerOrphan77.title>uzaylı yetim</SpacerOrphan77.title>
   <!-- EN: orphan -->
   <SpacerOrphan77.titleShort>yetim</SpacerOrphan77.titleShort>
   
   <!-- EN: [PAWN_nameDef]'s parents used [PAWN_objective] to help smuggle contraband between a cluster of rimworlds.\n\nAided by [PAWN_possessive] small size, [PAWN_nameDef] became very adept at carrying out [PAWN_possessive] parents' missions, learning weaponry, negotiations, and most of all smuggling. -->
-  <SpaceSmuggler6.description>[PAWN_nameDef]'nin ebeveynleri, onu bir grup rimworld arasında kaçak mal kaçırmak için kullandı.\n\n [PAWN_nameDef], küçük boyutunun yardımıyla, ebeveynlerinin görevlerini yerine getirmede, silahları öğrenmede, müzakerelerde ve hepsinden önemlisi kaçakçılıkta çok ustalaştı.</SpaceSmuggler6.description>
+  <SpaceSmuggler6.description>[PAWN_nameDef]'nin ebeveynleri, onu bir grup rimworld arasında kaçak mal kaçırmak için kullandı.\n\n[PAWN_nameDef], küçük boyutunun yardımıyla, ebeveynlerinin görevlerini yerine getirmede, silahları öğrenmede, müzakerelerde ve hepsinden önemlisi kaçakçılıkta çok ustalaştı.</SpaceSmuggler6.description>
   <!-- EN: space smuggler -->
   <SpaceSmuggler6.title>uzay kaçakçısı</SpaceSmuggler6.title>
   <SpaceSmuggler6.titleFemale>uzay kaçakçısı</SpaceSmuggler6.titleFemale>
@@ -1919,8 +1919,8 @@
   <SpaceSmuggler6.titleShort>kaçakçı</SpaceSmuggler6.titleShort>
   <SpaceSmuggler6.titleShortFemale>kaçakçı</SpaceSmuggler6.titleShortFemale>
   
-  <!-- EN: [PAWN_nameDef] ferried wealthy businessmen and politicians to and from [PAWN_possessive] home world.\n\n        Witnessing the depths of hedonism these people descended to changed [PAWN_objective] in ways not even [PAWN_pronoun] understood. -->
-  <SpaceyachtPilot89.description>[PAWN_nameDef] zengin işadamlarını ve politikacıları kendi dünyasına ve oradan oraya taşıdı.\n\n. Hedonizmin derinliklerine tanık olan bu insanlar, onu kendisinin bile anlamadığı şekillerde değiştirmek için soyundular.</SpaceyachtPilot89.description>
+  <!-- EN: [PAWN_nameDef] ferried wealthy businessmen and politicians to and from [PAWN_possessive] home world.\n\nWitnessing the depths of hedonism these people descended to changed [PAWN_objective] in ways not even [PAWN_pronoun] understood. -->
+  <SpaceyachtPilot89.description>[PAWN_nameDef] zengin işadamlarını ve politikacıları kendi dünyasına ve oradan oraya taşıdı.\n\nHedonizmin derinliklerine tanık olan bu insanlar, onu kendisinin bile anlamadığı şekillerde değiştirmek için soyundular.</SpaceyachtPilot89.description>
   <!-- EN: spaceyacht pilot -->
   <SpaceyachtPilot89.title>uzay yatı pilotu</SpaceyachtPilot89.title>
   <SpaceyachtPilot89.titleFemale>uzay yatı pilotu</SpaceyachtPilot89.titleFemale>
@@ -1929,7 +1929,7 @@
   <SpaceyachtPilot89.titleShortFemale>pilot</SpaceyachtPilot89.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was the son of a fern farmer in the towering forests of Khalderia.\n\n[PAWN_pronoun] found [PAWN_possessive] first love in speeder racing, zipping in and out of the massive canopies and gorgeous vistas of [PAWN_possessive] homeworld. The seedy underworld of racing also forced [PAWN_objective] to learn to defend [PAWN_objective]self with a quick word or a quicker shot. -->
-  <SpeederRacer71.description>[PAWN_nameDef], Khalderia'nın yüksek ormanlarındaki bir eğrelti otu çiftçisinin oğluydu.\n\n İlk aşkını, anavatanının devasa gölgeliklerine ve muhteşem manzaralarına girip çıkan speeder yarışlarında buldu. Yarışın köhne yeraltı dünyasında onu hızlı bir kelimeyle veya daha hızlı bir atışla kendini savunmayı öğrenmeye zorladı.</SpeederRacer71.description>
+  <SpeederRacer71.description>[PAWN_nameDef], Khalderia'nın yüksek ormanlarındaki bir eğrelti otu çiftçisinin oğluydu.\n\nİlk aşkını, anavatanının devasa gölgeliklerine ve muhteşem manzaralarına girip çıkan speeder yarışlarında buldu. Yarışın köhne yeraltı dünyasında onu hızlı bir kelimeyle veya daha hızlı bir atışla kendini savunmayı öğrenmeye zorladı.</SpeederRacer71.description>
   <!-- EN: speeder racer -->
   <SpeederRacer71.title>speeder yerışçısı</SpeederRacer71.title>
   <SpeederRacer71.titleFemale>speeder yerışçısı</SpeederRacer71.titleFemale>
@@ -1938,7 +1938,7 @@
   <SpeederRacer71.titleShortFemale>yarışcı</SpeederRacer71.titleShortFemale>
   
   <!-- EN: Born in a rich family, [PAWN_nameDef] was given everything, and never developed basic work ethic or the foundations of a non-dependent personality.\n\n[PAWN_pronoun] was expected to become one of the best doctors in the world. -->
-  <SpoiledBrat59.description>Zengin bir ailede dünyaya gelen [PAWN_nameDef]'ye her şey verildi ve hiçbir zaman temel çalışma etiği veya bağımlı olmayan bir kişiliğin temelleri geliştirmedi.\n\n. Dünyanın en iyi doktorlarından biri olması bekleniyordu.</SpoiledBrat59.description>
+  <SpoiledBrat59.description>Zengin bir ailede dünyaya gelen [PAWN_nameDef]'ye her şey verildi ve hiçbir zaman temel çalışma etiği veya bağımlı olmayan bir kişiliğin temelleri geliştirmedi.\n\nDünyanın en iyi doktorlarından biri olması bekleniyordu.</SpoiledBrat59.description>
   <!-- EN: spoiled brat -->
   <SpoiledBrat59.title>şımartılmış velet</SpoiledBrat59.title>
   <SpoiledBrat59.titleFemale>şımartılmış velet</SpoiledBrat59.titleFemale>
@@ -1955,7 +1955,7 @@
   <SpoiledChild33.titleShortFemale>velet</SpoiledChild33.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was the child of an industrious space engineer. [PAWN_possessive] parents forbade most manual and dangerous tasks, so [PAWN_pronoun] learned art and music instead.\n\n[PAWN_pronoun] loved animals, but [PAWN_possessive] parents never let [PAWN_objective] have a pet - though [PAWN_pronoun] played with other people's pets a lot. -->
-  <SpoiledChild80.description>[PAWN_nameDef] çalışkan bir uzay mühendisinin çocuğuydu. Ailesi manuel ve tehlikeli görevlerin çoğunu yasakladı, bu yüzden onun yerine sanat ve müzik öğrendi.\n\n Hayvanları severdi ama ebeveynleri asla evcil hayvan beslemesine izin vermezdi - diğer insanların evcil hayvanlarıyla oynardı.</SpoiledChild80.description>
+  <SpoiledChild80.description>[PAWN_nameDef] çalışkan bir uzay mühendisinin çocuğuydu. Ailesi manuel ve tehlikeli görevlerin çoğunu yasakladı, bu yüzden onun yerine sanat ve müzik öğrendi.\n\nHayvanları severdi ama ebeveynleri asla evcil hayvan beslemesine izin vermezdi - diğer insanların evcil hayvanlarıyla oynardı.</SpoiledChild80.description>
   <!-- EN: spoiled child -->
   <SpoiledChild80.title>şımartılmış velet</SpoiledChild80.title>
   <!-- EN: spoiled -->
@@ -1963,14 +1963,14 @@
   <SpoiledChild80.titleShortFemale>velet</SpoiledChild80.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was a stableboy on a medieval planet, mucking dung almost every day to earn [PAWN_possessive] keep.\n\nBy the time [PAWN_pronoun] was exiting childhood, [PAWN_nameDef] had saved up enough money to pay a space trader to take [PAWN_objective] offworld. -->
-  <Stableboy49.description>[PAWN_nameDef], bir orta çağ gezegeninde geçimini sağlamak için neredeyse her gün gübre atan seyis bir çocuktu.\n\n [PAWN_nameDef], çocukluğu bittikten sonra onu dünya dışına çıkarması için bir uzay tüccarına ödeme yapacak kadar para biriktirmişti.</Stableboy49.description>
+  <Stableboy49.description>[PAWN_nameDef], bir orta çağ gezegeninde geçimini sağlamak için neredeyse her gün gübre atan seyis bir çocuktu.\n\n[PAWN_nameDef], çocukluğu bittikten sonra onu dünya dışına çıkarması için bir uzay tüccarına ödeme yapacak kadar para biriktirmişti.</Stableboy49.description>
   <!-- EN: stableboy -->
   <Stableboy49.title>seyis</Stableboy49.title>
   <!-- EN: stableboy -->
   <Stableboy49.titleShort>seyis</Stableboy49.titleShort>
   
   <!-- EN: Raised on Amen-Ti, glitterworld capital of the Star Empire, [PAWN_nameFull] had an easy childhood.\n\nAs a youth, [PAWN_nameDef] decided that joining the Starforce would be [PAWN_possessive] way of giving back to the Empire. -->
-  <StarforceCadet79.description>Yıldız İmparatorluğu'nun glitterworld başkenti Amen-Ti'de büyüyen [PAWN_nameFull] kolay bir çocukluk geçirdi.\n\n [PAWN_nameDef] bir genç olarak, Starforce'a katılmanın İmparatorluk'a geri ödemenin yolu olacağına karar verdi.</StarforceCadet79.description>
+  <StarforceCadet79.description>Yıldız İmparatorluğu'nun glitterworld başkenti Amen-Ti'de büyüyen [PAWN_nameFull] kolay bir çocukluk geçirdi.\n\n[PAWN_nameDef] bir genç olarak, Starforce'a katılmanın İmparatorluk'a geri ödemenin yolu olacağına karar verdi.</StarforceCadet79.description>
   <!-- EN: starforce cadet -->
   <StarforceCadet79.title>yıldız kuvvetleri öğrencisi</StarforceCadet79.title>
   <StarforceCadet79.titleFemale>yıldız kuvvetleri öğrencisi</StarforceCadet79.titleFemale>
@@ -1978,8 +1978,8 @@
   <StarforceCadet79.titleShort>askeri öğrenci</StarforceCadet79.titleShort>
   <StarforceCadet79.titleShortFemale>askeri öğrenci</StarforceCadet79.titleShortFemale>
   
-  <!-- EN: Born on a medieval world, [PAWN_nameDef]'s first memory is of gazing up into the night's sky. \n\nEver since, [PAWN_pronoun] dreamed of squiring for a knight amidst the star-filled heavens. [PAWN_possessive] focus on that vision left [PAWN_objective] somewhat single-minded. -->
-  <StarSquire9.description>Bir ortaçağ dünyasında doğan [PAWN_nameDef]'in ilk anısı, gece gökyüzüne bakmaktır. \n\n. O zamandan beri, yıldızlarla dolu göklerin ortasında bir şövalye için kıvranmayı hayal etti. Bu vizyona odaklanması onu biraz kararlı bıraktı.</StarSquire9.description>
+  <!-- EN: Born on a medieval world, [PAWN_nameDef]'s first memory is of gazing up into the night's sky.\n\nEver since, [PAWN_pronoun] dreamed of squiring for a knight amidst the star-filled heavens. [PAWN_possessive] focus on that vision left [PAWN_objective] somewhat single-minded. -->
+  <StarSquire9.description>Bir ortaçağ dünyasında doğan [PAWN_nameDef]'in ilk anısı, gece gökyüzüne bakmaktır.\n\nO zamandan beri, yıldızlarla dolu göklerin ortasında bir şövalye için kıvranmayı hayal etti. Bu vizyona odaklanması onu biraz kararlı bıraktı.</StarSquire9.description>
   <!-- EN: star squire -->
   <StarSquire9.title>yıldız yaveri</StarSquire9.title>
   <!-- EN: squire -->
@@ -1988,11 +1988,11 @@
   <!-- EN: [PAWN_nameDef] spent [PAWN_possessive] childhood as a penniless orphan living on a space station. [PAWN_pronoun] managed to scrape by doing filthy jobs and stealing. [PAWN_pronoun] became so violent due to poor treatment by [PAWN_possessive] “betters” that [PAWN_pronoun] was banished from the station, just to be picked up by space pirates. -->
   <StationWhelp94.description>[PAWN_nameDef] çocukluğunu bir uzay istasyonunda yaşayan beş parasız bir yetim olarak geçirdi. Pis işler yaparak ve hırsızlık yaparak geçinmeyi başardı. “Daha iyilerinin” kötü muamelesi nedeniyle o kadar şiddetli oldu ki, sadece uzay korsanları tarafından yakalanmak için istasyondan sürgün edildi.</StationWhelp94.description>
   <!-- EN: station whelp -->
-  <StationWhelp94.title>istasyon eniği</StationWhelp94.title>
+  <StationWhelp94.title>İstasyon eniği</StationWhelp94.title>
   <!-- EN: whelp -->
   <StationWhelp94.titleShort>enik</StationWhelp94.titleShort>
   
-  <!-- EN: In the slums of a steamworld, [PAWN_nameDef] developed a fascination with machines and contraptions. [PAWN_pronoun] found [PAWN_pronoun] preferred their company to that of other people. \n\n[PAWN_possessive] remarkable dexterity earned [PAWN_objective] a steady stream of pocket change, and [PAWN_pronoun] spent every penny on spare parts and tools to play with. -->
+  <!-- EN: In the slums of a steamworld, [PAWN_nameDef] developed a fascination with machines and contraptions. [PAWN_pronoun] found [PAWN_pronoun] preferred their company to that of other people.\n\n[PAWN_possessive] remarkable dexterity earned [PAWN_objective] a steady stream of pocket change, and [PAWN_pronoun] spent every penny on spare parts and tools to play with. -->
   <SteamworldTinker38.description>Bir buhar dünyasının kenar mahallelerinde [PAWN_nameDef], makinelere ve mekanizmalara karşı bir hayranlık geliştirdi. Onların arkadaşlığını diğer insanlara tercih ettiğini fark etti.\n\nOlağanüstü el becerisi, ona sürekli ceplerdekini değiştirmesini sağlıyordu ve her kuruşunu oynamak için yedek parçalara ve aletlere harcadı.</SteamworldTinker38.description>
   <!-- EN: steamworld tinker -->
   <SteamworldTinker38.title>buhar dünyası tamircisi</SteamworldTinker38.title>
@@ -2027,14 +2027,14 @@
   <StreetChild4.titleShort>sokak çocuğu</StreetChild4.titleShort>
   
   <!-- EN: Growing up on the streets and fields of a rimworld, [PAWN_nameDef]'s [PAWN_possessive] only friend was a dog named Rest. The pair scraped by, finding just enough food to survive.\n\nWhen [PAWN_pronoun] was 13 years old, a criminal group took [PAWN_objective] under their wing. -->
-  <StreetKid19.description>Bir rimworld'ün sokaklarında ve tarlalarında büyüyen [PAWN_nameDef]'in tek arkadaşı Rest adında bir köpekti. İkili hayatta kalmaya yetecek kadar yiyecek toplayarak oradan uzaklaştı.\n\n 13 yaşındayken bir suç örgütü onu kanatlarının altına aldı.</StreetKid19.description>
+  <StreetKid19.description>Bir rimworld'ün sokaklarında ve tarlalarında büyüyen [PAWN_nameDef]'in tek arkadaşı Rest adında bir köpekti. İkili hayatta kalmaya yetecek kadar yiyecek toplayarak oradan uzaklaştı.\n\n13 yaşındayken bir suç örgütü onu kanatlarının altına aldı.</StreetKid19.description>
   <!-- EN: street kid -->
   <StreetKid19.title>sokak çocuğu</StreetKid19.title>
   <!-- EN: street kid -->
   <StreetKid19.titleShort>sokak çocuğu</StreetKid19.titleShort>
   
   <!-- EN: Growing up on an industrial midworld where robberies and muggings weren't uncommon, [PAWN_nameDef] helped support [PAWN_possessive] family by making small trinkets and novelties to sell to passers-by.\n\n[PAWN_pronoun] learned early on that it wasn't always what [PAWN_pronoun] knew, but who [PAWN_pronoun] knew that would get [PAWN_objective] far in life. -->
-  <StreetPeddler66.description>Soygunların ve gaspların olağandışı olmadığı endüstriyel bir orta dünyada büyüyen [PAWN_nameDef], yoldan geçenlere satmak için küçük biblolar ve yenilikler yaparak ailesine destek oldu.\n\n Her zaman bildiklerinin değil, bildiği kişilerin onu hayatta çok ileriye taşıyacağını erken öğrendi.</StreetPeddler66.description>
+  <StreetPeddler66.description>Soygunların ve gaspların olağandışı olmadığı endüstriyel bir orta dünyada büyüyen [PAWN_nameDef], yoldan geçenlere satmak için küçük biblolar ve yenilikler yaparak ailesine destek oldu.\n\nHer zaman bildiklerinin değil, bildiği kişilerin onu hayatta çok ileriye taşıyacağını erken öğrendi.</StreetPeddler66.description>
   <!-- EN: street peddler -->
   <StreetPeddler66.title>sokak seyyar satıcısı</StreetPeddler66.title>
   <StreetPeddler66.titleFemale>sokak seyyar satıcıs</StreetPeddler66.titleFemale>
@@ -2043,14 +2043,14 @@
   <StreetPeddler66.titleShortFemale>seyyar satcı</StreetPeddler66.titleShortFemale>
   
   <!-- EN: Born to a poor family, [PAWN_nameDef] was a sickly child who never quite developed the strength of [PAWN_possessive] siblings.\n\n[PAWN_possessive] parents, unable to afford to provide for [PAWN_objective] and certain [PAWN_pronoun] couldn't pay [PAWN_possessive] own way, threw [PAWN_objective] to the streets. [PAWN_pronoun] learned hard and fast how to survive by any means necessary. -->
-  <StreetUrchin45.description>Fakir bir ailede dünyaya gelen [PAWN_nameDef], kardeşlik gücünü hiçbir zaman tam olarak geliştiremeyen hastalıklı bir çocuktu.\n\n Onun geçimini ve ihtiyaçlarını karşılamayan birisi olduğuna emin olan anne-babası onu sokaklara attı. Her ne pahasına olursa olsun hayatta kalmayı sert ve hızlı bir şekilde öğrendi.</StreetUrchin45.description>
+  <StreetUrchin45.description>Fakir bir ailede dünyaya gelen [PAWN_nameDef], kardeşlik gücünü hiçbir zaman tam olarak geliştiremeyen hastalıklı bir çocuktu.\n\nOnun geçimini ve ihtiyaçlarını karşılamayan birisi olduğuna emin olan anne-babası onu sokaklara attı. Her ne pahasına olursa olsun hayatta kalmayı sert ve hızlı bir şekilde öğrendi.</StreetUrchin45.description>
   <!-- EN: street urchin -->
   <StreetUrchin45.title>sokak haylazı</StreetUrchin45.title>
   <!-- EN: street rat -->
   <StreetUrchin45.titleShort>sokak faresi</StreetUrchin45.titleShort>
   
   <!-- EN: Born to a poor family on an urbworld, [PAWN_nameDef] was abandoned on the streets at a young age.\n\n[PAWN_pronoun] learned to steal and kill to survive the ruthless streets, gaining skills in melee and ranged combat. There was little time for talk in [PAWN_possessive] life. -->
-  <StreetUrchin53.description>Kentsel bir dünyada fakir bir ailede dünyaya gelen [PAWN_nameDef] genç yaşta sokaklara terk edildi.\n\n Acımasız sokaklarda hayatta kalmak için çalmayı ve öldürmeyi öğrendi, yakın dövüşte ve menzilli dövüşte beceriler kazandı.Sosyalleşebilmek için çok az zamanı vardı.</StreetUrchin53.description>
+  <StreetUrchin53.description>Kentsel bir dünyada fakir bir ailede dünyaya gelen [PAWN_nameDef] genç yaşta sokaklara terk edildi.\n\nAcımasız sokaklarda hayatta kalmak için çalmayı ve öldürmeyi öğrendi, yakın dövüşte ve menzilli dövüşte beceriler kazandı.Sosyalleşebilmek için çok az zamanı vardı.</StreetUrchin53.description>
   <!-- EN: street urchin -->
   <StreetUrchin53.title>sokak serserisi</StreetUrchin53.title>
   <!-- EN: urchin -->
@@ -2065,7 +2065,7 @@
   <StreetUrchin74.titleShortFemale>dolandırıcı</StreetUrchin74.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] studied chemistry and quantum mechanics for entertainment.\n\n[PAWN_pronoun] was very good at convincing others to do [PAWN_possessive] physical work, and made it a goal in life to avoid manual labor. -->
-  <Student65.description>[PAWN_nameDef] eğlence için kimya ve kuantum mekaniği okudu.\n\n Başkalarını kendi fiziksel işini yapmaya ikna etmekte çok iyiydi ve el emeğinden kaçınmayı hayatta bir hedef haline getirdi.</Student65.description>
+  <Student65.description>[PAWN_nameDef] eğlence için kimya ve kuantum mekaniği okudu.\n\nBaşkalarını kendi fiziksel işini yapmaya ikna etmekte çok iyiydi ve el emeğinden kaçınmayı hayatta bir hedef haline getirdi.</Student65.description>
   <!-- EN: student -->
   <Student65.title>öğrenci</Student65.title>
   <Student65.titleFemale>öğrenci</Student65.titleFemale>
@@ -2074,7 +2074,7 @@
   <Student65.titleShortFemale>öğrenci</Student65.titleShortFemale>
   
   <!-- EN: A genius child, [PAWN_nameDef] was put in a special training program covering aerospace warfare and engineering.\n\nOne day, [PAWN_pronoun] tried to befriend a squirrel by giving it a bracelet. The squirrel bit [PAWN_objective], earning [PAWN_objective] the nickname “Squirrel {PAWN_gender ? Boy : Girl}”.\n\n[PAWN_nameDef] came to believe that work involving manual labor is beneath [PAWN_objective]. -->
-  <StudentEngineer34.description>Dahi bir çocuk olan [PAWN_nameDef], uzay savaşı ve mühendisliğini kapsayan özel bir eğitim programına alındı.\n\n Bir gün bir sincaba kelepçe takarak onunla arkadaş olmaya çalıştı. Sincap onu sikti ve ona “Sincabın maniti"lakabını kazandı...\n\n. [PAWN_nameDef], el emeği içeren işlerin kendisine göre olmadığına inanmaya başladı.</StudentEngineer34.description>
+  <StudentEngineer34.description>Dahi bir çocuk olan [PAWN_nameDef], uzay savaşı ve mühendisliğini kapsayan özel bir eğitim programına alındı.\n\nBir gün bir sincaba kelepçe takarak onunla arkadaş olmaya çalıştı. Sincap onu sikti ve ona “Sincabın maniti"lakabını kazandı...\n\n[PAWN_nameDef], el emeği içeren işlerin kendisine göre olmadığına inanmaya başladı.</StudentEngineer34.description>
   <!-- EN: student engineer -->
   <StudentEngineer34.title>mühendislik öğrencisi</StudentEngineer34.title>
   <StudentEngineer34.titleFemale>mühendislik öğrencisi</StudentEngineer34.titleFemale>
@@ -2083,7 +2083,7 @@
   <StudentEngineer34.titleShortFemale>mühendis</StudentEngineer34.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] learned politics in an elite training school for socially gifted students on Kalthas IV.\n\nWhile [PAWN_pronoun] was naturally adept at reading and manipulating people, [PAWN_pronoun] found no joy in it. [PAWN_pronoun] left the academy several years before graduation. -->
-  <StudentSocialite89.description>[PAWN_nameDef], Kalthas IV'te sosyal açıdan yetenekli öğrenciler için seçkin bir eğitim okulunda siyaset öğrendi.\n\n İnsanları okumakta ve manipüle etmekte doğal olarak usta olsa da bundan hiç zevk almıyordu. Mezun olmadan birkaç yıl önce akademiden ayrıldı.</StudentSocialite89.description>
+  <StudentSocialite89.description>[PAWN_nameDef], Kalthas IV'te sosyal açıdan yetenekli öğrenciler için seçkin bir eğitim okulunda siyaset öğrendi.\n\nİnsanları okumakta ve manipüle etmekte doğal olarak usta olsa da bundan hiç zevk almıyordu. Mezun olmadan birkaç yıl önce akademiden ayrıldı.</StudentSocialite89.description>
   <!-- EN: student socialite -->
   <StudentSocialite89.title>sosyetik öğrenci</StudentSocialite89.title>
   <StudentSocialite89.titleFemale>sosyetik öğrenci</StudentSocialite89.titleFemale>
@@ -2091,7 +2091,7 @@
   <StudentSocialite89.titleShort>sosyetik</StudentSocialite89.titleShort>
   
   <!-- EN: [PAWN_nameDef]'s government ran an experimental super-soldier development program. They kidnapped thousands of infants, conditioned their minds with drugs and machines, and trained them to fight.\n\nMost infants died, but [PAWN_nameDef] did not. [PAWN_pronoun] killed [PAWN_possessive] first man at age six, and was fighting in field operations not long after. -->
-  <SuperSoldier99.description>[PAWN_nameDef]'nin hükümeti deneysel bir süper asker geliştirme programı yürüttü. Binlerce bebeği kaçırdılar, zihinlerini uyuşturucu ve makinelerle şartlandırdılar ve onları savaşmaları için eğittiler.\n\n Bebeklerin çoğu öldü, ancak [PAWN_nameDef] ölmedi. İlk kez altı yaşında birini öldürdü ve kısa bir süre sonra saha operasyonlarında savaştı.</SuperSoldier99.description>
+  <SuperSoldier99.description>[PAWN_nameDef]'nin hükümeti deneysel bir süper asker geliştirme programı yürüttü. Binlerce bebeği kaçırdılar, zihinlerini uyuşturucu ve makinelerle şartlandırdılar ve onları savaşmaları için eğittiler.\n\nBebeklerin çoğu öldü, ancak [PAWN_nameDef] ölmedi. İlk kez altı yaşında birini öldürdü ve kısa bir süre sonra saha operasyonlarında savaştı.</SuperSoldier99.description>
   <!-- EN: super soldier -->
   <SuperSoldier99.title>süper asker</SuperSoldier99.title>
   <SuperSoldier99.titleFemale>süper asker</SuperSoldier99.titleFemale>
@@ -2108,7 +2108,7 @@
   <TechEnthusiast28.titleShort>teknoloji nerd</TechEnthusiast28.titleShort>
   
   <!-- EN: Standing on the ship hull with [PAWN_possessive] father in an child-size EVA suit, [PAWN_nameDef] loved space from a young age.\n\n[PAWN_pronoun] was put in a Civil Academics Program. While pretending to be like [PAWN_possessive] father, [PAWN_pronoun] spent [PAWN_possessive] time taking care of plants in [PAWN_possessive] messy room. [PAWN_possessive] nickname was given for [PAWN_possessive] love of circles. -->
-  <TechHead8.description>Çocuk beden bir EVA suiti içinde babasıyla birlikte gemi gövdesinde uzayı izliyordu. [PAWN_nameDef] küçüklüğünden beri uzayı severdi.\n\n Sivil Akademisyenler Programına alındı. Babası gibi davranarak vaktini dağınık odasında bitkilerle ilgilenerek geçirdi. Lakabı çevrelere olan sevgisinden dolayı verilmiştir.</TechHead8.description>
+  <TechHead8.description>Çocuk beden bir EVA suiti içinde babasıyla birlikte gemi gövdesinde uzayı izliyordu. [PAWN_nameDef] küçüklüğünden beri uzayı severdi.\n\nSivil Akademisyenler Programına alındı. Babası gibi davranarak vaktini dağınık odasında bitkilerle ilgilenerek geçirdi. Lakabı çevrelere olan sevgisinden dolayı verilmiştir.</TechHead8.description>
   <!-- EN: tech-head -->
   <TechHead8.title>teknoloji meraklısı</TechHead8.title>
   <!-- EN: tech-head -->
@@ -2122,7 +2122,7 @@
   <TechnicalKid1.titleShort>teknik çocuk</TechnicalKid1.titleShort>
   
   <!-- EN: [PAWN_nameDef] hung around a group of local luddite farmers on [PAWN_possessive] midworld. They helped [PAWN_objective] practice shooting every single day, and passed on some basic farming skills. They also taught [PAWN_nameDef] how to focus on working hard with your hands instead of getting distracted by highfalutin' ideas and clever machines. -->
-  <TechScholar75.description>[PAWN_nameDef], bilim ve teknoloji dünyasının genç bir akademisyeniydi.\n\n Entelektüel yeteneklerini geliştirmek için her gün çabaladı.</TechScholar75.description>
+  <TechScholar75.description>[PAWN_nameDef], bilim ve teknoloji dünyasının genç bir akademisyeniydi.\n\nEntelektüel yeteneklerini geliştirmek için her gün çabaladı.</TechScholar75.description>
   <!-- EN: farm kid -->
   <TechScholar75.title>teknoloji akademisyeni</TechScholar75.title>
   <TechScholar75.titleFemale>teknoloji akademisyeni</TechScholar75.titleFemale>
@@ -2131,14 +2131,14 @@
   <TechScholar75.titleShortFemale>akademisyen</TechScholar75.titleShortFemale>
   
   <!-- EN: Test subject #11,529,914 of experiment #56,048 spent [PAWN_possessive] childhood in white rooms performing mental and physical tests.\n\n[PAWN_possessive] only companion was a voice that called itself Mother. Mother rewarded success with praise - and failure with harsh punishment. -->
-  <TestSubject82.description>56,048 numaralı deneyin denek #11,529,914'ü çocukluğunu beyaz odalarda zihinsel ve fiziksel testler yaparak geçirdi.\n\n. Tek arkadaşı, kendisine Anne diyen bir sesti. Annem başarıyı övgüyle, başarısızlığı ise sert bir cezayla ödüllendirdi.</TestSubject82.description>
+  <TestSubject82.description>56,048 numaralı deneyin denek #11,529,914'ü çocukluğunu beyaz odalarda zihinsel ve fiziksel testler yaparak geçirdi.\n\nTek arkadaşı, kendisine Anne diyen bir sesti. Annem başarıyı övgüyle, başarısızlığı ise sert bir cezayla ödüllendirdi.</TestSubject82.description>
   <!-- EN: test subject -->
   <TestSubject82.title>denek</TestSubject82.title>
   <!-- EN: subject -->
   <TestSubject82.titleShort>denek</TestSubject82.titleShort>
   
   <!-- EN: [PAWN_nameDef] spent [PAWN_possessive] spare time creating things from [PAWN_possessive] imagination out of scrap metal and discarded machinery.\n\n[PAWN_pronoun] created simple robots and small tools, for both for fun and for utility. -->
-  <Tinkerer11.description>[PAWN_nameDef] boş zamanını hurda metallerden ve atılmış makinelerden hayal gücüyle bir şeyler yaratmak için harcadı.\n\n Hem eğlenmek hem de fayda sağlamak için basit robotlar ve küçük araçlar yarattı.</Tinkerer11.description>
+  <Tinkerer11.description>[PAWN_nameDef] boş zamanını hurda metallerden ve atılmış makinelerden hayal gücüyle bir şeyler yaratmak için harcadı.\n\nHem eğlenmek hem de fayda sağlamak için basit robotlar ve küçük araçlar yarattı.</Tinkerer11.description>
   <!-- EN: tinkerer -->
   <Tinkerer11.title>tamirci</Tinkerer11.title>
   <Tinkerer11.titleFemale>tamirci</Tinkerer11.titleFemale>
@@ -2156,14 +2156,14 @@
   <Tinkerer79.titleShortFemale>tamirci</Tinkerer79.titleShortFemale>
   
   <!-- EN: Growing up on a an industrial planet, [PAWN_nameDef] started working in a chemical plant at age of six. Years of exposure to industrial toxins left [PAWN_objective] mentally scarred.\n\n[PAWN_pronoun] eventually blew up the facility and escaped the planet in a stolen cargo ship. -->
-  <ToxicChild96.description>Endüstriyel bir gezegende büyüyen [PAWN_nameDef], altı yaşında bir kimya fabrikasında çalışmaya başladı. Yıllarca endüstriyel toksinlere maruz kalması onu zihinsel olarak yaraladı.\n\n. Sonunda tesisi havaya uçurdu ve çalıntı bir kargo gemisiyle gezegenden kaçtı.</ToxicChild96.description>
+  <ToxicChild96.description>Endüstriyel bir gezegende büyüyen [PAWN_nameDef], altı yaşında bir kimya fabrikasında çalışmaya başladı. Yıllarca endüstriyel toksinlere maruz kalması onu zihinsel olarak yaraladı.\n\nSonunda tesisi havaya uçurdu ve çalıntı bir kargo gemisiyle gezegenden kaçtı.</ToxicChild96.description>
   <!-- EN: toxic child -->
   <ToxicChild96.title>toksik çocuk</ToxicChild96.title>
   <!-- EN: toxic -->
   <ToxicChild96.titleShort>toksik</ToxicChild96.titleShort>
   
   <!-- EN: [PAWN_nameDef] grew up in a family of nomadic traders, making a living from selling and buying goods on many worlds.\n\n[PAWN_nameDef] learned the customs and methods of trade of many cultures by participating in [PAWN_possessive] parents' business. -->
-  <TradersChild62.description>[PAWN_nameDef], göçebe tüccarlardan oluşan bir ailede büyüdü ve geçimini birçok dünyada mal alıp satarak alarak sağladı.\n\n [PAWN_nameDef], ebeveynlerinin işine katılarak birçok kültürün geleneklerini ve ticaret yöntemlerini öğrendi.</TradersChild62.description>
+  <TradersChild62.description>[PAWN_nameDef], göçebe tüccarlardan oluşan bir ailede büyüdü ve geçimini birçok dünyada mal alıp satarak alarak sağladı.\n\n[PAWN_nameDef], ebeveynlerinin işine katılarak birçok kültürün geleneklerini ve ticaret yöntemlerini öğrendi.</TradersChild62.description>
   <!-- EN: traders' child -->
   <TradersChild62.title>tüccarın çocuğu</TradersChild62.title>
   <!-- EN: trader -->
@@ -2171,7 +2171,7 @@
   <TradersChild62.titleShortFemale>tüccar</TradersChild62.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was involved in a traumatic accident that resulted in [PAWN_objective] killing [PAWN_possessive] own family.\n\nCast out from society, [PAWN_pronoun] was left with only [PAWN_possessive] animal companions and several engineering textbooks to keep [PAWN_objective] company. -->
-  <TragicLoner87.description>[PAWN_nameDef], kendi ailesini öldürmesiyle sonuçlanan travmatik bir kazaya karıştı.\n\n. Toplumdan dışlandı, ona sadece hayvan dostları ve ona eşlik edecek birkaç mühendislik kitabı kaldı.</TragicLoner87.description>
+  <TragicLoner87.description>[PAWN_nameDef], kendi ailesini öldürmesiyle sonuçlanan travmatik bir kazaya karıştı.\n\nToplumdan dışlandı, ona sadece hayvan dostları ve ona eşlik edecek birkaç mühendislik kitabı kaldı.</TragicLoner87.description>
   <!-- EN: tragic loner -->
   <TragicLoner87.title>trajedik yalnız</TragicLoner87.title>
   <TragicLoner87.titleFemale>trajedik yalnız</TragicLoner87.titleFemale>
@@ -2189,7 +2189,7 @@
   <TraineeAlchemist64.titleShortFemale>simyager</TraineeAlchemist64.titleShortFemale>
   
   <!-- EN: A midworld child, [PAWN_nameDef]'s wealthy parents sent [PAWN_objective] to a nearby glitterworld to receive a better education.\n\n[PAWN_nameDef] was a talented student. However, due to [PAWN_possessive] family's wealth, [PAWN_pronoun] never had to do dumb labor. -->
-  <TransferStudent10.description>Bir orta dünya çocuğu olan [PAWN_nameDef]'in varlıklı ebeveynleri onu daha iyi bir eğitim alması için yakındaki bir glitterworld'e gönderdi.\n\n [PAWN_nameDef] yetenekli bir öğrenciydi. Ailesinin zenginliği nedeniyle hiçbir zaman basit iş yapmak zorunda kalmadı.</TransferStudent10.description>
+  <TransferStudent10.description>Bir orta dünya çocuğu olan [PAWN_nameDef]'in varlıklı ebeveynleri onu daha iyi bir eğitim alması için yakındaki bir glitterworld'e gönderdi.\n\n[PAWN_nameDef] yetenekli bir öğrenciydi. Ailesinin zenginliği nedeniyle hiçbir zaman basit iş yapmak zorunda kalmadı.</TransferStudent10.description>
   <!-- EN: transfer student -->
   <TransferStudent10.title>transfer öğrenci</TransferStudent10.title>
   <TransferStudent10.titleFemale>transfer öğrenci</TransferStudent10.titleFemale>
@@ -2198,7 +2198,7 @@
   <TransferStudent10.titleShortFemale>öğrenci</TransferStudent10.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] lived on a pleasant midworld.\n\n[PAWN_possessive] body purist mother fell sick with heart disease. In desperation, [PAWN_nameDef]'s father abducted innocent people and harvested their hearts. [PAWN_nameDef]'s father was arrested, but the child remained scarred from the experience. -->
-  <TraumatizedYouth87.description>[PAWN_nameDef] hoş bir orta dünyada yaşadı.\n\n Saf ve temiz annesi kalp hastalığına yakalandı. Çaresizlik içinde [PAWN_nameDef]'in babası masum insanları kaçırdı ve kalplerini hasat etti. [PAWN_nameDef]'nin babası tutuklandı, bu deneyimden dolayı travma geçirdi.</TraumatizedYouth87.description>
+  <TraumatizedYouth87.description>[PAWN_nameDef] hoş bir orta dünyada yaşadı.\n\nSaf ve temiz annesi kalp hastalığına yakalandı. Çaresizlik içinde [PAWN_nameDef]'in babası masum insanları kaçırdı ve kalplerini hasat etti. [PAWN_nameDef]'nin babası tutuklandı, bu deneyimden dolayı travma geçirdi.</TraumatizedYouth87.description>
   <!-- EN: traumatized youth -->
   <TraumatizedYouth87.title>travmalı genç</TraumatizedYouth87.title>
   <!-- EN: trauma -->
@@ -2214,7 +2214,7 @@
   <TribalThunderer45.titleShortFemale>gök gütültüsü</TribalThunderer45.titleShortFemale>
   
   <!-- EN: Born to settler folk, [PAWN_nameDef]'s family had a beloved herd of turtles, who protected them by absorbing shots from raiders.\n\nAt a young age, [PAWN_pronoun] was entrusted with the turtles. [PAWN_pronoun] bred them, successfully - too successfully. The massive turtle herds consumed every food source and destroyed the local ecosystem. -->
-  <TurtleHerder41.description>[PAWN_nameDef]'in ailesinde, akıncıların atışlarına siper olup  onları koruyan çok sevilen bir kaplumbağa sürüsü vardı.\n\n. Küçük yaşta kaplumbağalar ona emanet edildi. Onları başarıyla yetiştirdi - çok başarılı bir şekilde. Devasa kaplumbağa sürüleri her besin kaynağını tüketti ve yerel ekosistemi yok etti.</TurtleHerder41.description>
+  <TurtleHerder41.description>[PAWN_nameDef]'in ailesinde, akıncıların atışlarına siper olup  onları koruyan çok sevilen bir kaplumbağa sürüsü vardı.\n\nKüçük yaşta kaplumbağalar ona emanet edildi. Onları başarıyla yetiştirdi - çok başarılı bir şekilde. Devasa kaplumbağa sürüleri her besin kaynağını tüketti ve yerel ekosistemi yok etti.</TurtleHerder41.description>
   <!-- EN: turtle herder -->
   <TurtleHerder41.title>kaplumbağa çobanı</TurtleHerder41.title>
   <TurtleHerder41.titleFemale>kaplumbağa çobanı</TurtleHerder41.titleFemale>
@@ -2232,7 +2232,7 @@
   <UpperUrbworlder12.titleShortFemale>yüksek urbworld'lü</UpperUrbworlder12.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] grew up on an urbworld military base. [PAWN_pronoun] was too young to fight, but [PAWN_pronoun] learned to make [PAWN_objective]self useful in other ways.\n\n[PAWN_pronoun] became familiar with guns and military equipment, but never really got in touch with the natural world. -->
-  <UrbworldArmyBrat84.description>[PAWN_nameDef] bir urbworld askeri üssünde büyüdü. Savaşmak için çok gençti ama kendini başka şekillerde faydalı kılmayı öğrendi.\n\n Silahlara ve askeri teçhizata aşina oldu, ancak hiçbir zaman silahların gerçek doğası ile temasa geçmedi.</UrbworldArmyBrat84.description>
+  <UrbworldArmyBrat84.description>[PAWN_nameDef] bir urbworld askeri üssünde büyüdü. Savaşmak için çok gençti ama kendini başka şekillerde faydalı kılmayı öğrendi.\n\nSilahlara ve askeri teçhizata aşina oldu, ancak hiçbir zaman silahların gerçek doğası ile temasa geçmedi.</UrbworldArmyBrat84.description>
   <!-- EN: urbworld army brat -->
   <UrbworldArmyBrat84.title>urbworld'lü asker veledi</UrbworldArmyBrat84.title>
   <UrbworldArmyBrat84.titleFemale>urbworld'lü asker veledi</UrbworldArmyBrat84.titleFemale>
@@ -2240,14 +2240,14 @@
   <UrbworldArmyBrat84.titleShort>asker velet</UrbworldArmyBrat84.titleShort>
   
   <!-- EN: [PAWN_nameDef] had an isolated upbringing on an urbworld. [PAWN_possessive] hatred of heights kept [PAWN_objective] indoors often, and made [PAWN_objective] an introverted child.\n\nWhen [PAWN_pronoun] did go out onto the catwalks of the city, [PAWN_pronoun] enjoyed playing war games, becoming proficient with various simulation weapons. -->
-  <UrbworldChild56.description>[PAWN_nameDef] bir urbworld üzerinde izole bir şekilde yetiştirildi. Yükseklik korkusu onu sık sık evde tutuyor ve onu içine kapanık bir çocuk yapıyordu.\n\n Şehrin caddelerine çıktığında savaş oyunları oynamaktan, çeşitli simülasyon silahlarında ustalaşmaktan keyif aldı.</UrbworldChild56.description>
+  <UrbworldChild56.description>[PAWN_nameDef] bir urbworld üzerinde izole bir şekilde yetiştirildi. Yükseklik korkusu onu sık sık evde tutuyor ve onu içine kapanık bir çocuk yapıyordu.\n\nŞehrin caddelerine çıktığında savaş oyunları oynamaktan, çeşitli simülasyon silahlarında ustalaşmaktan keyif aldı.</UrbworldChild56.description>
   <!-- EN: urbworld child -->
   <UrbworldChild56.title>urbworld'lü çocuk</UrbworldChild56.title>
   <!-- EN: urbkid -->
   <UrbworldChild56.titleShort>cadde çocuğu</UrbworldChild56.titleShort>
   
   <!-- EN: Born into bad circumstance on an overpopulated urbworld, [PAWN_nameDef] turned to small-time crime as a way to avoid starvation and hypothermia.\n\nRobbery and murder were daily activities for [PAWN_objective]. [PAWN_nameDef] learned that surviving was winning. -->
-  <UrbworldCriminal6.description>Aşırı nüfuslu bir urbworld'de kötü koşullarda doğan [PAWN_nameDef], açlıktan ve hipotermiden kaçınmanın bir yolu olarak küçük çaplı suçlara yöneldi.\n\n. Hırsızlık ve cinayet onun için günlük aktivitelerdi. [PAWN_nameDef] hayatta kalmanın kazanmak olduğunu öğrendi.</UrbworldCriminal6.description>
+  <UrbworldCriminal6.description>Aşırı nüfuslu bir urbworld'de kötü koşullarda doğan [PAWN_nameDef], açlıktan ve hipotermiden kaçınmanın bir yolu olarak küçük çaplı suçlara yöneldi.\n\nHırsızlık ve cinayet onun için günlük aktivitelerdi. [PAWN_nameDef] hayatta kalmanın kazanmak olduğunu öğrendi.</UrbworldCriminal6.description>
   <!-- EN: urbworld criminal -->
   <UrbworldCriminal6.title>urbworld'lü suçlu</UrbworldCriminal6.title>
   <UrbworldCriminal6.titleFemale>urbworld'lü suçlu</UrbworldCriminal6.titleFemale>
@@ -2294,7 +2294,7 @@
   <VatgrownMedic53.titleShortFemale>sıhhiye doktor</VatgrownMedic53.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was grown to be a perfect scientist, with a mind perfectly tuned for physics and chemistry.\n\n[PAWN_possessive] creators used [PAWN_objective] as a teaching aid on mind design, hoping [PAWN_pronoun] would eventually grow to be a great mind and continue their research. -->
-  <VatgrownScientist91.description>[PAWN_nameDef], fizik ve kimya için mükemmel şekilde ayarlanmış bir zihinle mükemmel bir bilim insanı olarak yetiştirildi.\n\n. Yaratıcıları, sonunda büyüyüp harika bir beyne sahip olarak araştırmalarına devam edeceğini umarak onu zihin tasarımı konusunda bir öğretim yardımcısı olarak kullandılar.</VatgrownScientist91.description>
+  <VatgrownScientist91.description>[PAWN_nameDef], fizik ve kimya için mükemmel şekilde ayarlanmış bir zihinle mükemmel bir bilim insanı olarak yetiştirildi.\n\nYaratıcıları, sonunda büyüyüp harika bir beyne sahip olarak araştırmalarına devam edeceğini umarak onu zihin tasarımı konusunda bir öğretim yardımcısı olarak kullandılar.</VatgrownScientist91.description>
   <!-- EN: vatgrown scientist -->
   <VatgrownScientist91.title>klonoid bilim adamı</VatgrownScientist91.title>
   <VatgrownScientist91.titleFemale>klonoid bilim adamı</VatgrownScientist91.titleFemale>
@@ -2310,7 +2310,7 @@
   <VatgrownSlavegirl8.titleShort>köle kız</VatgrownSlavegirl8.titleShort>
   
   <!-- EN: [PAWN_nameDef] grew up on a midworld, mostly locked in [PAWN_possessive] room, playing video games. [PAWN_pronoun] was warm-hearted, with a deep fondness for animals.\n\nAs [PAWN_pronoun] grew up, [PAWN_pronoun] turned to drugs to enhance [PAWN_possessive] reality. During these trying times [PAWN_pronoun] found passion and refuge in the gym. -->
-  <VideoGamer16.description>[PAWN_nameDef] bir orta dünyada büyüdü, çoğunlukla odasına kapandı ve video oyunları oynadı. Hayvanlara karşı derin bir düşkünlüğü olan, sıcak kalpli biriydi.\n\n. Büyüdükçe gerçekliğini geliştirmek için uyuşturucuya başladı. Bu sancılı zamanlarında spor salonunda tutku ve sağınma buldu.</VideoGamer16.description>
+  <VideoGamer16.description>[PAWN_nameDef] bir orta dünyada büyüdü, çoğunlukla odasına kapandı ve video oyunları oynadı. Hayvanlara karşı derin bir düşkünlüğü olan, sıcak kalpli biriydi.\n\nBüyüdükçe gerçekliğini geliştirmek için uyuşturucuya başladı. Bu sancılı zamanlarında spor salonunda tutku ve sağınma buldu.</VideoGamer16.description>
   <!-- EN: video gamer -->
   <VideoGamer16.title>video oyuncusu</VideoGamer16.title>
   <VideoGamer16.titleFemale>video oyuncusu</VideoGamer16.titleFemale>
@@ -2326,7 +2326,7 @@
   <VideoGamer55.titleShort>oyuncu</VideoGamer55.titleShort>
   
   <!-- EN: [PAWN_nameDef]'s hobby was making videos for the popular video sharing service Vidtube. [PAWN_pronoun] made everything from video game reviews to pasta cooking guides.\n\n[PAWN_pronoun] gained over a million followers. -->
-  <VidtubeStar98.description>[PAWN_nameDef]'in hobisi, popüler video paylaşım hizmeti Vidtube için videolar yapmaktı. Video oyunu incelemelerinden makarna pişirme kılavuzlarına kadar her şeyi yaptı.\n\n Bir milyondan fazla takipçi kazandı.</VidtubeStar98.description>
+  <VidtubeStar98.description>[PAWN_nameDef]'in hobisi, popüler video paylaşım hizmeti Vidtube için videolar yapmaktı. Video oyunu incelemelerinden makarna pişirme kılavuzlarına kadar her şeyi yaptı.\n\nBir milyondan fazla takipçi kazandı.</VidtubeStar98.description>
   <!-- EN: vidtube star -->
   <VidtubeStar98.title>vitube yıldızı</VidtubeStar98.title>
   <!-- EN: vidtuber -->
@@ -2334,7 +2334,7 @@
   <VidtubeStar98.titleShortFemale>vidtuber</VidtubeStar98.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was raised on an R&D starship, and spent most of [PAWN_possessive] childhood travelling through the void.\n\nApproaching a mysterious planetoid, the ship was severely damaged. [PAWN_possessive] next memory is of the ship heading out of orbit, fully repaired. [PAWN_pronoun] soon developed an unnatural gift for technological research. -->
-  <VoyagerChild94.description>[PAWN_nameDef] bir Ar-Ge yıldız gemisinde büyüdü ve çocukluğunun çoğunu boşlukta seyahat ederek geçirdi.\n\n Gizemli bir gezegenoide yaklaşan gemi ağır hasar gördü. Bir sonraki anısı yörüngeden çıkan geminin tamamen onarılmış olduğu. Kısa süre sonra teknolojik araştırma için doğal olmayan bir yetenek geliştirdi.</VoyagerChild94.description>
+  <VoyagerChild94.description>[PAWN_nameDef] bir Ar-Ge yıldız gemisinde büyüdü ve çocukluğunun çoğunu boşlukta seyahat ederek geçirdi.\n\nGizemli bir gezegenoide yaklaşan gemi ağır hasar gördü. Bir sonraki anısı yörüngeden çıkan geminin tamamen onarılmış olduğu. Kısa süre sonra teknolojik araştırma için doğal olmayan bir yetenek geliştirdi.</VoyagerChild94.description>
   <!-- EN: voyager child -->
   <VoyagerChild94.title>seyyah çocuk</VoyagerChild94.title>
   <!-- EN: voyager -->
@@ -2358,14 +2358,14 @@
   <WarChild24.titleShort>savaşın çocuğu</WarChild24.titleShort>
   
   <!-- EN: A war broke on out [PAWN_nameDef]'s home planet.\n\nGathering what little food and belongings they could, [PAWN_nameDef] and [PAWN_possessive] father stole a ship and escaped into space. -->
-  <WarRefugee96.description>[PAWN_nameDef]'nin ana gezegeninde bir savaş çıktı.\n\n [PAWN_nameDef] ve babası toplayabildikleri kadar az yiyecek ve eşyayı alarak bir gemi çalıp uzaya kaçtılar.</WarRefugee96.description>
+  <WarRefugee96.description>[PAWN_nameDef]'nin ana gezegeninde bir savaş çıktı.\n\n[PAWN_nameDef] ve babası toplayabildikleri kadar az yiyecek ve eşyayı alarak bir gemi çalıp uzaya kaçtılar.</WarRefugee96.description>
   <!-- EN: war refugee -->
   <WarRefugee96.title>savaş mültecisi</WarRefugee96.title>
   <!-- EN: refugee -->
   <WarRefugee96.titleShort>mülteci</WarRefugee96.titleShort>
   
   <!-- EN: Born into a wealthy family on a desert world, [PAWN_nameDef] was cast out after a hired attack squad destroyed [PAWN_possessive] ancestral home.\n\nThe boy managed to hide in a cooling duct beneath [PAWN_possessive] family's villa. Vowing revenge against the killers and whomever had hired them, [PAWN_nameDef] struck out into the wasteland, alone. -->
-  <WastelandWanderer81.description>Çöl dünyasında varlıklı bir ailenin çocuğu olarak dünyaya gelen [PAWN_nameDef], atalarının evini kiralık bir saldırı timi yok ettikten sonra kovuldu.\n\n. O sırada ailesinin villasının altındaki bir soğutma kanalına saklanmayı başardı. Katillerden ve onları kiralayanlardan intikam alma yemini eden [PAWN_nameDef] tek başına çorak araziye gitti.</WastelandWanderer81.description>
+  <WastelandWanderer81.description>Çöl dünyasında varlıklı bir ailenin çocuğu olarak dünyaya gelen [PAWN_nameDef], atalarının evini kiralık bir saldırı timi yok ettikten sonra kovuldu.\n\nO sırada ailesinin villasının altındaki bir soğutma kanalına saklanmayı başardı. Katillerden ve onları kiralayanlardan intikam alma yemini eden [PAWN_nameDef] tek başına çorak araziye gitti.</WastelandWanderer81.description>
   <!-- EN: wasteland wanderer -->
   <WastelandWanderer81.title>çöl göçebesi</WastelandWanderer81.title>
   <WastelandWanderer81.titleFemale>çöl göçebesi</WastelandWanderer81.titleFemale>
@@ -2374,7 +2374,7 @@
   <WastelandWanderer81.titleShortFemale>göçebe</WastelandWanderer81.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was born on a wealthy glitterworld. [PAWN_pronoun] studied at the Caspian school of Engineering, and excelled in mathematics and computer programming.\n\n[PAWN_nameDef] grew up in clean, sterile environments. [PAWN_pronoun] never saw a farm or livestock. -->
-  <WealthyStudent59.description>[PAWN_nameDef] zengin bir glitterworld'de doğdu. Hazar Mühendislik Okulu'nda okudu ve matematik ve bilgisayar programcılığında uzmanlaştı.\n\n. [PAWN_nameDef] temiz, steril ortamlarda büyüdü. Hiç bir çiftlik ya da hayvan görmedi.</WealthyStudent59.description>
+  <WealthyStudent59.description>[PAWN_nameDef] zengin bir glitterworld'de doğdu. Hazar Mühendislik Okulu'nda okudu ve matematik ve bilgisayar programcılığında uzmanlaştı.\n\n[PAWN_nameDef] temiz, steril ortamlarda büyüdü. Hiç bir çiftlik ya da hayvan görmedi.</WealthyStudent59.description>
   <!-- EN: wealthy student -->
   <WealthyStudent59.title>varlıklı öğrenci</WealthyStudent59.title>
   <WealthyStudent59.titleFemale>varlıklı öğrenci</WealthyStudent59.titleFemale>
@@ -2383,7 +2383,7 @@
   <WealthyStudent59.titleShortFemale>öğrenci</WealthyStudent59.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was abandoned on a toxic world overgrown with hostile plant life. [PAWN_pronoun] became accustomed early to the cold burn of loneliness.\n\n[PAWN_pronoun] learned to fight, but ate [PAWN_possessive] food raw and uncooked. -->
-  <WildChild5.description>[PAWN_nameDef], düşmancıl bitki yaşamıyla dolu zehirli bir dünyada terk edildi.Yalnızlığın soğuk yanığına erkenden alıştı.\n\n Savaşmayı öğrendi ama yemeğini çiğ ve pişmemiş yedi.</WildChild5.description>
+  <WildChild5.description>[PAWN_nameDef], düşmancıl bitki yaşamıyla dolu zehirli bir dünyada terk edildi.Yalnızlığın soğuk yanığına erkenden alıştı.\n\nSavaşmayı öğrendi ama yemeğini çiğ ve pişmemiş yedi.</WildChild5.description>
   <!-- EN: wild child -->
   <WildChild5.title>vahşi çocuk</WildChild5.title>
   <!-- EN: wild child -->
@@ -2391,7 +2391,7 @@
   <WildChild5.titleShortFemale>vahşi çocuk</WildChild5.titleShortFemale>
   
   <!-- EN: Abandoned by [PAWN_possessive] parents, [PAWN_nameDef] was raised by the monks of the Novo Mosteiro dos Jerónimos monastery on Aracena VI.\n\nThe monks taught [PAWN_objective] discipline and hard work. In return, [PAWN_pronoun] would go into the city and 'acquire' exotic wines for the monks' nightly tastings. -->
-  <Winerunner8.description>Ailesi tarafından terk edilen [PAWN_nameDef], Aracena VI'daki Novo Mosteiro dos Jerónimos manastırının keşişleri tarafından büyütüldü.\n\n. Rahipler ona disiplini ve sıkı çalışmayı öğrettiler. Karşılığında, şehre gidecek ve keşişlerin her gece tatmaları için egzotik şaraplar "edinecekti".</Winerunner8.description>
+  <Winerunner8.description>Ailesi tarafından terk edilen [PAWN_nameDef], Aracena VI'daki Novo Mosteiro dos Jerónimos manastırının keşişleri tarafından büyütüldü.\n\nRahipler ona disiplini ve sıkı çalışmayı öğrettiler. Karşılığında, şehre gidecek ve keşişlerin her gece tatmaları için egzotik şaraplar "edinecekti".</Winerunner8.description>
   <!-- EN: winerunner -->
   <Winerunner8.title>şarap ayakçısı</Winerunner8.title>
   <Winerunner8.titleFemale>şarap ayakçısı</Winerunner8.titleFemale>
@@ -2400,18 +2400,18 @@
   <Winerunner8.titleShortFemale>şarap ayakçısı</Winerunner8.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was discarded by [PAWN_possessive] family. Raised by wolves, [PAWN_pronoun] ran, hunted, and defended [PAWN_possessive] pack.\n\n[PAWN_pronoun] learned to fight efficiently by tooth and claw. [PAWN_pronoun] also learned brutally effective primal hunting strategies. -->
-  <WolfPackMember26.description>[PAWN_nameDef] ailesi tarafından atıldı. Kurtlar tarafından büyütüldü, koştu, avlandı ve sürüsünü savundu.\n\n. Diş ve pençe ile verimli bir şekilde savaşmayı öğrendi. Ayrıca vahşice etkili ilkel avlanma stratejilerini de öğrendi.</WolfPackMember26.description>
+  <WolfPackMember26.description>[PAWN_nameDef] ailesi tarafından atıldı. Kurtlar tarafından büyütüldü, koştu, avlandı ve sürüsünü savundu.\n\nDiş ve pençe ile verimli bir şekilde savaşmayı öğrendi. Ayrıca vahşice etkili ilkel avlanma stratejilerini de öğrendi.</WolfPackMember26.description>
   <!-- EN: wolf pack member -->
   <WolfPackMember26.title>kurt sürüsü üyesi</WolfPackMember26.title>
   <!-- EN: feral -->
   <WolfPackMember26.titleShort>vahşi</WolfPackMember26.titleShort>
   <WolfPackMember26.titleShortFemale>vahşi</WolfPackMember26.titleShortFemale>
   
-  <!-- EN: [PAWN_nameDef] grew up as a slave to a particularly nasty noble family on a medieval world. \n\nWhile [PAWN_pronoun] received no formal education, the harsh labor regimen made [PAWN_possessive] body strong. -->
-  <WorkCampSlave37.description>[PAWN_nameDef] bir orta çağ dünyasında, özellikle kötü bir soylu ailenin kölesi olarak büyüdü. \n\n. Resmi bir eğitim almamış olsa da, zorlu çalışma rejimi vücudunu güçlendirdi.</WorkCampSlave37.description>
+  <!-- EN: [PAWN_nameDef] grew up as a slave to a particularly nasty noble family on a medieval world.\n\nWhile [PAWN_pronoun] received no formal education, the harsh labor regimen made [PAWN_possessive] body strong. -->
+  <WorkCampSlave37.description>[PAWN_nameDef] bir orta çağ dünyasında, özellikle kötü bir soylu ailenin kölesi olarak büyüdü.\n\nResmi bir eğitim almamış olsa da, zorlu çalışma rejimi vücudunu güçlendirdi.</WorkCampSlave37.description>
   <!-- EN: work camp slave -->
-  <WorkCampSlave37.title>işçi kampı kölesi</WorkCampSlave37.title>
-  <WorkCampSlave37.titleFemale>işçi kampı kölesi</WorkCampSlave37.titleFemale>
+  <WorkCampSlave37.title>İşçi kampı kölesi</WorkCampSlave37.title>
+  <WorkCampSlave37.titleFemale>İşçi kampı kölesi</WorkCampSlave37.titleFemale>
   <!-- EN: slave -->
   <WorkCampSlave37.titleShort>köle</WorkCampSlave37.titleShort>
   <WorkCampSlave37.titleShortFemale>köle</WorkCampSlave37.titleShortFemale>
@@ -2425,7 +2425,7 @@
   <WorldSlider42.titleShort>Silici</WorldSlider42.titleShort>
   
   <!-- EN: Born to two medics, [PAWN_nameDef] longed for power. [PAWN_possessive] keen intellect and charisma helped [PAWN_objective] gain the respect of [PAWN_possessive] peers.\n\nDeciding that the best way to gain power was to climb the ranks of the imperial military, [PAWN_pronoun] joined at the youngest possible age. -->
-  <YoungMaster23.description>İki sağlık görevlisinin çocuğu olan [PAWN_nameDef] güce özlem duyuyordu. Keskin zekası ve karizması, yaşıtlarının saygısını kazanmasına yardımcı oldu.\n\n. Güç kazanmanın en iyi yolunun imparatorluk ordusunun saflarına katılmak olduğuna karar vererek, mümkün olan en genç yaşta katıldı.</YoungMaster23.description>
+  <YoungMaster23.description>İki sağlık görevlisinin çocuğu olan [PAWN_nameDef] güce özlem duyuyordu. Keskin zekası ve karizması, yaşıtlarının saygısını kazanmasına yardımcı oldu.\n\nGüç kazanmanın en iyi yolunun imparatorluk ordusunun saflarına katılmak olduğuna karar vererek, mümkün olan en genç yaşta katıldı.</YoungMaster23.description>
   <!-- EN: young master -->
   <YoungMaster23.title>genç usta</YoungMaster23.title>
   <YoungMaster23.titleFemale>genç usta</YoungMaster23.titleFemale>
@@ -2434,7 +2434,7 @@
   <YoungMaster23.titleShortFemale>usta</YoungMaster23.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was born to pirates, in a dirty metal room that smelled of motor oil.\n\n[PAWN_pronoun] was never exactly taught anything, but [PAWN_pronoun] still learned the ways of survival, barter, and combat. -->
-  <YoungPirate71.description>[PAWN_nameDef], motor yağı kokan kirli bir metal odada korsanların çocuğu olarak doğdu.\n\n. Ona hiçbir zaman tam olarak bir şey öğretilmedi, ama yine de hayatta kalma, takas ve dövüş yollarını öğrendi.</YoungPirate71.description>
+  <YoungPirate71.description>[PAWN_nameDef], motor yağı kokan kirli bir metal odada korsanların çocuğu olarak doğdu.\n\nOna hiçbir zaman tam olarak bir şey öğretilmedi, ama yine de hayatta kalma, takas ve dövüş yollarını öğrendi.</YoungPirate71.description>
   <!-- EN: young pirate -->
   <YoungPirate71.title>genç korsan</YoungPirate71.title>
   <YoungPirate71.titleFemale>genç korsan</YoungPirate71.titleFemale>
@@ -2443,7 +2443,7 @@
   <YoungPirate71.titleShortFemale>korsan</YoungPirate71.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was born and raised on a poor midworld, in the front passenger seat of [PAWN_possessive] mother's cab.\n\nWatching pedestrians and listening to the taxi passengers all day long, [PAWN_pronoun] soon became very good at figuring out someone's real purpose. -->
-  <YoungPsychologist58.description>[PAWN_nameDef] fakir bir orta dünyada, annesinin taksisinin ön koltuğunda doğdu ve büyüdü.\n\n Bütün gün yayaları izleyerek ve taksi yolcularını dinleyerek, kısa sürede birinin gerçek amacını bulmada çok başarılı oldu.</YoungPsychologist58.description>
+  <YoungPsychologist58.description>[PAWN_nameDef] fakir bir orta dünyada, annesinin taksisinin ön koltuğunda doğdu ve büyüdü.\n\nBütün gün yayaları izleyerek ve taksi yolcularını dinleyerek, kısa sürede birinin gerçek amacını bulmada çok başarılı oldu.</YoungPsychologist58.description>
   <!-- EN: young psychologist -->
   <YoungPsychologist58.title>genç psikolog</YoungPsychologist58.title>
   <YoungPsychologist58.titleFemale>genç psikolog</YoungPsychologist58.titleFemale>
@@ -2452,7 +2452,7 @@
   <YoungPsychologist58.titleShortFemale>psişik</YoungPsychologist58.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] was the only child of celebrity sommeliers. [PAWN_possessive] parents expected [PAWN_objective] to take up the family profession, but after [PAWN_possessive] third admission to a youth detention center, this career path became unlikely.\n\nWhile in detention, [PAWN_nameDef] became skilled at making shanks and developed an interest in ornithology. -->
-  <YouthDelinquent30.description>[PAWN_nameDef] ünlü Sommelier'lerin tek çocuğuydu. Ailesi onun aile mesleğini üstlenmesini bekliyordu ancak bir gençlik gözaltı merkezinende gözaltına alındı.Bu kariyer yolu pek mümkün olmadı.\n\n Gözaltındayken, [PAWN_nameDef] incik yapma becerisi kazandı ve ornitolojiye ilgi duymaya başladı.</YouthDelinquent30.description>
+  <YouthDelinquent30.description>[PAWN_nameDef] ünlü Sommelier'lerin tek çocuğuydu. Ailesi onun aile mesleğini üstlenmesini bekliyordu ancak bir gençlik gözaltı merkezinende gözaltına alındı.Bu kariyer yolu pek mümkün olmadı.\n\nGözaltındayken, [PAWN_nameDef] incik yapma becerisi kazandı ve ornitolojiye ilgi duymaya başladı.</YouthDelinquent30.description>
   <!-- EN: youth delinquent -->
   <YouthDelinquent30.title>genç suçlu</YouthDelinquent30.title>
   <YouthDelinquent30.titleFemale>genç suçlu</YouthDelinquent30.titleFemale>
@@ -2461,7 +2461,7 @@
   <YouthDelinquent30.titleShortFemale>genç suçlu</YouthDelinquent30.titleShortFemale>
   
   <!-- EN: Born to a long line of soldiers, [PAWN_nameDef] joined a military training program.\n\n[PAWN_pronoun] excelled in physical training, and even passed most of the intellectual exams. While [PAWN_pronoun] was never particularly bright or nimble, [PAWN_nameDef] learned the value of hard work and suffering. -->
-  <YouthSoldier99.description>Uzun bir asker soyundan gelen [PAWN_nameDef] bir askeri eğitim programına katıldı.\n\n. Beden eğitiminde mükemmeldi ve hatta entelektüel sınavların çoğunu geçti.Göze çarpan veya çevik değildi. [PAWN_nameDef] sıkı çalışmanın ve acı çekmenin değerini öğrendi.</YouthSoldier99.description>
+  <YouthSoldier99.description>Uzun bir asker soyundan gelen [PAWN_nameDef] bir askeri eğitim programına katıldı.\n\nBeden eğitiminde mükemmeldi ve hatta entelektüel sınavların çoğunu geçti.Göze çarpan veya çevik değildi. [PAWN_nameDef] sıkı çalışmanın ve acı çekmenin değerini öğrendi.</YouthSoldier99.description>
   <!-- EN: youth soldier -->
   <YouthSoldier99.title>genç asker</YouthSoldier99.title>
   <YouthSoldier99.titleFemale>genç asker</YouthSoldier99.titleFemale>

--- a/Core/DefInjected/BackstoryDef/Solid_Rare.xml
+++ b/Core/DefInjected/BackstoryDef/Solid_Rare.xml
@@ -86,7 +86,7 @@
   <NathanCustomChildhood.titleShort>mağara çocuğu</NathanCustomChildhood.titleShort>
   
   <!-- EN: [PAWN_nameDef] designed combat modifications for frontline soldiers.\n\nOne night, in a nightmare, [PAWN_nameDef] was confronted by all the men and women killed by [PAWN_possessive] work. [PAWN_pronoun] decided to travel to the rimworlds and use [PAWN_possessive] skills for good. -->
-  <OskarCustomAdulthood.description>TODO</OskarCustomAdulthood.description>
+  <OskarCustomAdulthood.description>[PAWN_nameDef] cephe askerleri için savaş modifikasyonları tasarladı.\n\nBir gece, bir kabusta, [PAWN_nameDef] [PAWN_possessive] çalışmasıyla öldürülen tüm erkek ve kadınlarla yüzleşti. [PAWN_pronoun] kenar dünyalara seyahat etmeye ve kendi becerilerini iyilik için kullanmaya karar verdi.</OskarCustomAdulthood.description>
   <!-- EN: mod designer -->
   <OskarCustomAdulthood.title>mod tasarımcısı</OskarCustomAdulthood.title>
   <!-- EN: modder -->

--- a/Core/DefInjected/BackstoryDef/Tribal_Adult.xml
+++ b/Core/DefInjected/BackstoryDef/Tribal_Adult.xml
@@ -128,7 +128,7 @@
   <Herder33.titleShortFemale>Çoban</Herder33.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] tracked, trapped and killed animals for their meat and leather.\n\n[PAWN_nameDef] used both ranged and melee weapons. Sometimes, [PAWN_pronoun] hunted alongside animals. -->
-  <Hunter74.description>[PAWN_nameDef], etleri ve derileri için hayvanları takip etti, tuzağa düşürdü ve öldürdü.\n\n [PAWN_nameDef] hem menzilli hem de yakın dövüş silahları kullandı. Bazen hayvanlarla birlikte avlanırdı.</Hunter74.description>
+  <Hunter74.description>[PAWN_nameDef], etleri ve derileri için hayvanları takip etti, tuzağa düşürdü ve öldürdü.\n\n[PAWN_nameDef] hem menzilli hem de yakın dövüş silahları kullandı. Bazen hayvanlarla birlikte avlanırdı.</Hunter74.description>
   <!-- EN: hunter -->
   <Hunter74.title>avcı</Hunter74.title>
   <Hunter74.titleFemale>avcı</Hunter74.titleFemale>
@@ -146,7 +146,7 @@
   <Logger16.titleShortFemale>oduncu</Logger16.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] never much liked the tribal council or the yearly festivals. [PAWN_pronoun] preferred the open plain and the whistle of wind through the rocks.\n\n[PAWN_pronoun] visited [PAWN_possessive] tribe from time to time, but mostly took care of [PAWN_objective]self using [PAWN_possessive] own survival skills. -->
-  <Loner61.description>[PAWN_nameDef] kabile konseyini veya yıllık festivalleri hiç sevmezdi.Açık ovayı ve kayaların arasından esen rüzgarın ıslığını tercih ederdi.\n\n Zaman zaman kabilesini ziyaret ederdi ama çoğunlukla kabilesine hayata kalmaya yetecek şeyler için giderdi.</Loner61.description>
+  <Loner61.description>[PAWN_nameDef] kabile konseyini veya yıllık festivalleri hiç sevmezdi.Açık ovayı ve kayaların arasından esen rüzgarın ıslığını tercih ederdi.\n\nZaman zaman kabilesini ziyaret ederdi ama çoğunlukla kabilesine hayata kalmaya yetecek şeyler için giderdi.</Loner61.description>
   <!-- EN: loner -->
   <Loner61.title>yalnız</Loner61.title>
   <Loner61.titleFemale>yalnız</Loner61.titleFemale>
@@ -157,8 +157,8 @@
   <!-- EN: [PAWN_nameDef] was one of a long line of lore keepers in [PAWN_possessive] tribe. Every night around the fire, [PAWN_pronoun] would pass on ancient knowledge and helpful wisdom through stories. -->
   <LoreKeeper51.description>[PAWN_nameDef], kabilesindeki uzun bir irfan bekçisi soyundan biriydi. Her gece ateşin etrafında, hikayeler aracılığıyla eski bilgileri ve faydalı bilgeliği aktarırdı.</LoreKeeper51.description>
   <!-- EN: lore keeper -->
-  <LoreKeeper51.title>irfan bekçisi</LoreKeeper51.title>
-  <LoreKeeper51.titleFemale>irfan bekçisi</LoreKeeper51.titleFemale>
+  <LoreKeeper51.title>İrfan bekçisi</LoreKeeper51.title>
+  <LoreKeeper51.titleFemale>İrfan bekçisi</LoreKeeper51.titleFemale>
   <!-- EN: keeper -->
   <LoreKeeper51.titleShort>bekçi</LoreKeeper51.titleShort>
   <LoreKeeper51.titleShortFemale>bekçi</LoreKeeper51.titleShortFemale>
@@ -193,11 +193,11 @@
   <!-- EN: Since [PAWN_possessive] tribe made contact with local outlanders, [PAWN_nameDef] contracted [PAWN_possessive] services out as a guide. Frequent contact with ancient technology made [PAWN_objective] comfortable with the lost machines. -->
   <Scout59.description>[PAWN_nameDef], kabilesi yerel yabancılarla temas kurduğundan yeteneklerini bir rehber olarak gösterdi. Eski teknolojiyle sık sık temas etmesi onu kayıp makinelerle ilgi geliştirmesine neden oldu.</Scout59.description>
   <!-- EN: scout -->
-  <Scout59.title>izci</Scout59.title>
-  <Scout59.titleFemale>izci</Scout59.titleFemale>
+  <Scout59.title>İzci</Scout59.title>
+  <Scout59.titleFemale>İzci</Scout59.titleFemale>
   <!-- EN: scout -->
-  <Scout59.titleShort>izci</Scout59.titleShort>
-  <Scout59.titleShortFemale>izci</Scout59.titleShortFemale>
+  <Scout59.titleShort>İzci</Scout59.titleShort>
+  <Scout59.titleShortFemale>İzci</Scout59.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] prepared meals from the plants and animals brought in by gatherers, farmers, and hunters of [PAWN_possessive] tribe. [PAWN_pronoun] had to make sure it was calorie-efficient, long-lasting, and healthy. [PAWN_pronoun] often processed and sometime gathered plants [PAWN_objective]self. -->
   <StewKeeper95.description>[PAWN_nameDef] kabilesinin toplayıcıları, çiftçileri ve avcıları tarafından getirilen bitki ve hayvanlardan yemekler hazırladı. Kalori açısından verimli, uzun ömürlü ve sağlıklı olduğundan emin olmak zorundaydı. Bitkileri sık sık işliyor, bazen de kendisi topluyordu.</StewKeeper95.description>

--- a/Core/DefInjected/BackstoryDef/Tribal_Child.xml
+++ b/Core/DefInjected/BackstoryDef/Tribal_Child.xml
@@ -73,7 +73,7 @@
   <Hideaway7.titleShortFemale>gizlenen</Hideaway7.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] didn't learn to speak until [PAWN_pronoun] was nearly five years old. Even then [PAWN_pronoun] preferred to keep to [PAWN_objective]self.\n\nTo the chagrin of [PAWN_possessive] caretakers, [PAWN_pronoun] made a habit of wandering off to live in the wilderness for weeks at a time. -->
-  <ReclusiveChild81.description>[PAWN_nameDef] neredeyse beş yaşına gelene kadar konuşmayı öğrenmedi. O zaman bile kendine saklamayı tercih etti.\n\n Bakıcılarını üzmek için haftalarca vahşi doğada yaşamayı ve dolaşmayı bir alışkanlık haline getirdi.</ReclusiveChild81.description>
+  <ReclusiveChild81.description>[PAWN_nameDef] neredeyse beş yaşına gelene kadar konuşmayı öğrenmedi. O zaman bile kendine saklamayı tercih etti.\n\nBakıcılarını üzmek için haftalarca vahşi doğada yaşamayı ve dolaşmayı bir alışkanlık haline getirdi.</ReclusiveChild81.description>
   <!-- EN: reclusive child -->
   <ReclusiveChild81.title>münzevi çocuk</ReclusiveChild81.title>
   <!-- EN: reclusive -->
@@ -99,7 +99,7 @@
   <SoleSurvivor21.titleShortFemale>kurtulan</SoleSurvivor21.titleShortFemale>
   
   <!-- EN: [PAWN_nameDef] grew up in a tribe, running around the village, moving with the muffalo herds, learning essential skills from [PAWN_possessive] parents.\n\n[PAWN_pronoun] never learned to read and never saw a machine that wasn't an ancient ruin. -->
-  <TribeChild40.description>[PAWN_nameDef] bir kabilede büyüdü, köyün etrafında koşturdu, muffalo sürüleriyle birlikte hareket etti, ebeveynlerinden temel becerileri öğrendi.\n\n Okumayı asla öğrenmedi ve eski bir harabe veya bir makine görmedi.</TribeChild40.description>
+  <TribeChild40.description>[PAWN_nameDef] bir kabilede büyüdü, köyün etrafında koşturdu, muffalo sürüleriyle birlikte hareket etti, ebeveynlerinden temel becerileri öğrendi.\n\nOkumayı asla öğrenmedi ve eski bir harabe veya bir makine görmedi.</TribeChild40.description>
   <!-- EN: tribe child -->
   <TribeChild40.title>kabile çocuğu</TribeChild40.title>
   <!-- EN: tribal -->

--- a/Core/DefInjected/ChemicalDef/Psychite_Yayo.xml
+++ b/Core/DefInjected/ChemicalDef/Psychite_Yayo.xml
@@ -2,6 +2,6 @@
 <LanguageData>
   
   <!-- EN: psychite -->
-  <Psychite.label>Yayo</Psychite.label>
+  <Psychite.label>yayo</Psychite.label>
   
 </LanguageData>

--- a/Core/DefInjected/ConceptDef/Concepts_NotedOpportunistic.xml
+++ b/Core/DefInjected/ConceptDef/Concepts_NotedOpportunistic.xml
@@ -7,7 +7,7 @@
   <AnimalsDontAttackDoors.helpText>İnsan avcısı hayvanlar, kolonistlerinizden birinin kapıdan geçtiğini görürlerse kapıya saldırırlar. Ayrıca devre dışı taretlerede saldırırlar.</AnimalsDontAttackDoors.helpText>
   
   <!-- EN: Bills tab -->
-  <BillsTab.label>Tasarı Sekmesi</BillsTab.label>
+  <BillsTab.label>Tasarı sekmesi</BillsTab.label>
   <!-- EN: To make colonists work at a table, select the table and open the Bills tab. Here, you can say what meals to cook, what things to craft, what creatures to butcher. -->
   <BillsTab.helpText>Kolonistini herhangi bir çalışma masasında çalıştırmak için, çalışma masasını seç ve Tasarı sekmesini aç. Burada, hangi yemeklerin pişirileceğini, nelerin üretileceğini, hangi yaratıkların kesileceğini belirleyebilirsin.</BillsTab.helpText>
   
@@ -49,7 +49,7 @@
   <DrugBurning.helpText>Uyuşturucular kullanışlı olabilir, ama aynı zamanda tehlikeli bağımlılıklar oluşturabilir.\n\nEğer koloninde uyuşturucu kullanılsın istemiyorsan, onları kampateşinde yakma imkanın var.</DrugBurning.helpText>
   
   <!-- EN: Drug policies -->
-  <DrugPolicies.label>Uyuşturucu poliçeleri</DrugPolicies.label>
+  <DrugPolicies.label>Uyuşturucu politikaları</DrugPolicies.label>
   <!-- EN: You can assign colonists to take specific drugs on a specific schedule. For example, you can make them take infection-blocking drugs regularly, or drink a beer a day to stay happy.\n\nOpen the ASSIGN tab and press the 'Manage drug policies' button. Create a new drug policy. Then, you can assign this policy to colonists.\n\nColonists can still take drugs not in their policy. You can tell them what to do, but they also follow their own desires! -->
   <DrugPolicies.helpText>Kolonistlerinin hangi uyuşturucuyu ne sıklıkla alacağını ayarlayabilirsin. Örnek olarak, onların düzenli olarak enfeksiyon önleyici uyuşturucu almalarını sağlayabilirsin ya da mutlu kalmalarını sağlamak için günde bir bira içirebilirsin.\n\nATAMA sekmesini aç ve 'Uyuşturucu poliçelerini yönet' tuşuna tıkla. Yeni bir uyuşturucu poliçesi oluştur. Artık bunu kolonistlerine atayabilirsin.\n\nKolonistler poliçelerinde olmayan uyuşturucuları alabilirler. Onlara ne yapmaları gerektiğini söyleyebilirsin, ama kendi isteklerini de takip edebilirler!</DrugPolicies.helpText>
   
@@ -104,7 +104,7 @@
   <SetGrowingZonePlant.helpText>Tarlada ne yetişeceğini ayarlayabilirsin. Ağaç bile yetiştirebilirsin!\n\nSadece tarlayı seç, Tarım sekmesini aç, ve 'ek' tuşuna tıkla.</SetGrowingZonePlant.helpText>
   
   <!-- EN: Shelves -->
-  <Shelves.label>raflar</Shelves.label>
+  <Shelves.label>Raflar</Shelves.label>
   <!-- EN: Shelves store three times as much as empty ground. Items on shelves will also never deteriorate and don't affect the beauty of their surroundings.\n\nYou can link shelves into groups and configure them as one. First, select two or more shelves, then click 'Link storage settings'. -->
   <Shelves.helpText>Raflar boş zeminin üç katı kadar depolar. Raflardaki ürünler de asla bozulmaz ve çevrelerinin güzelliğini etkilemez.\n\n. Rafları gruplara bağlayabilir ve tek olarak yapılandırabilirsiniz. Önce iki veya daha fazla raf seçin, ardından 'Depolama ayarlarını bağla'yı tıklayın.</Shelves.helpText>
   

--- a/Core/DefInjected/CultureDef/Cultures.xml
+++ b/Core/DefInjected/CultureDef/Cultures.xml
@@ -7,7 +7,7 @@
   <Astropolitan.description>Sık uzay yolcuları arasında yaygın olan geniş kültürler koleksiyonu.</Astropolitan.description>
   
   <!-- EN: corunan -->
-  <Corunan.label>Corunan</Corunan.label>
+  <Corunan.label>corunan</Corunan.label>
   <!-- EN: An ancient culture common among rimworld tribes. -->
   <Corunan.description>Rimworld kabileleri arasında yaygın olan antik bir kültür.</Corunan.description>
   

--- a/Core/DefInjected/DifficultyDef/Difficulties.xml
+++ b/Core/DefInjected/DifficultyDef/Difficulties.xml
@@ -12,27 +12,27 @@
   <Easy.description>Bir tutam tehlikeyle bir topluluk kur. Tehditler görülür ama zayıflatılmışlardır.\n\n(*SectionTitle)Tavsiye edilir:(/SectionTitle)\n\n- Bu tür oyunlara yeni olanlara.\n- Mükemmel bir koloni inşa etmek isteyenlere.\n- Rahatlamak isteyenlere.</Easy.description>
   
   <!-- EN: losing is fun -->
-  <Extreme.label>kayıp neşedir</Extreme.label>
+  <Extreme.label>kaybetmek eğlenceli</Extreme.label>
   <!-- EN: This setting is designed to be unfair. Huge threats will crash upon you without mercy until your colony dies. Only choose this setting if you are happy with the drama of struggling and dying.\n\n(*SectionTitle)Recommended for:(/SectionTitle)\n\n- Experienced players who want to face a brutal, unfair challenge where even great skill may not prevent death.\n- Lovers of tragedy.\n- Digital masochists. -->
   <Extreme.description>Bu mod adil olmayacak şekilde tasarlanmıştır. Kolonin yok olana kadar büyük tehditler karşısında acımasızca ezilecek. Bu modu sadece ölümlerden ve mücadeleden zevk alıyorsan seç.\n\n(*SectionTitle)Tavsiye edilir:(/SectionTitle)\n\n- Acımasız, sert, yetenekli oyuncuları bile zorlayacak tehlikelerle yüzleşmek isteyen tecrübeli oyunculara.\n- Trajedi aşıklarına.\n- Dijital mazoşistlere.</Extreme.description>
   
   <!-- EN: blood and dust -->
-  <Hard.label>Kan ve toz</Hard.label>
+  <Hard.label>kan ve toz</Hard.label>
   <!-- EN: Face brutal survival challenges. Even if you play well, people will die. You will need to anticipate threats before they arrive, and seek out every advantage.\n\n(*SectionTitle)Recommended for:(/SectionTitle)\n\n- Experienced players who want to struggle to survive. -->
   <Hard.description>Hayatta kalmak için acımasız zorluklarla yüzleş. Ne kadar iyi oynarsan oyna insanlar yine de ölür. Gelecek tehditleri tahmin etmen ve hayatta kalmak için her türlü avantajı gözden geçirmen gerekecek.\n\n(*SectionTitle)Tavsiye edilir:(/SectionTitle)\n\n- Hayatta kalmak için deli gibi çabalamak isteyen tecrübeli oyunculara.</Hard.description>
   
   <!-- EN: adventure story -->
-  <Medium.label>Macera hikayesi</Medium.label>
+  <Medium.label>macera hikayesi</Medium.label>
   <!-- EN: There's room to grow and thrive, but it's still a dangerous planet.\n\n(*SectionTitle)Recommended for:(/SectionTitle)\n\n- Experienced strategy gamers on their first game of RimWorld.\n- Experienced RimWorld players who want some breathing room to pursue funny or weird goals. -->
   <Medium.description>Büyümek ve gelişmek için izin var ama hala tehlikeli bir gezegen.\n\n(*SectionTitle)Tavsiye edilir:(/SectionTitle)\n\n- İlk kez RimWorld oynayan tecrübeli strateji oyuncularına.\n- Eğlence peşinde olan ya da tuhaf amaçları olan tecrübeli RimWorld oyuncularına.</Medium.description>
   
   <!-- EN: peaceful -->
-  <Peaceful.label>Barışçıl</Peaceful.label>
+  <Peaceful.label>barışçıl</Peaceful.label>
   <!-- EN: Build a community in a sandbox environment. Major direct threats are disabled, but challenges like disease, mental breaks, and mad animals can still occur.\n\n(*SectionTitle)Recommended for:(/SectionTitle)\n\n- Players who want to learn the game mechanics with minimal pressure.\n- Players who just want to build.\n- Players who just want to relax. -->
   <Peaceful.description>Rahatça koloni kur. Büyük tehditler devre dışı ama hastalık, ruhsal çöküş, kızgın hayvanlar gibi olaylar hala görülebilir.\n\n(*SectionTitle)Tavsiye edilir:(/SectionTitle)\n\n- Oyun mekaniklerini öğrenmek isteyenlere.\n- Sadece koloni kurmak isteyenlere.\n- Sadece rahatlamak isteyenlere.</Peaceful.description>
   
   <!-- EN: strive to survive -->
-  <Rough.label>Hayatta kalma savaşı</Rough.label>
+  <Rough.label>hayatta kalma savaşı</Rough.label>
   <!-- EN: Strive to survive on a rough, tough planet. There will be triumph and tragedy.\n\n(*SectionTitle)Recommended for:(/SectionTitle)\n\n- Experienced players who want a rough story requiring skill to survive. -->
   <Rough.description>Bu sert, çetin gezegende hayatta kalmak için savaşman gerekecek. Zafer ve trajedi olacak.\n\n(*SectionTitle)Tavsiye edilir:(/SectionTitle)\n\n- Zorlu bir mücadele isteyen tecrübeli oyunculara.</Rough.description>
   

--- a/Core/DefInjected/GeneCategoryDef/GeneDefs_Endogenes.xml
+++ b/Core/DefInjected/GeneCategoryDef/GeneDefs_Endogenes.xml
@@ -5,10 +5,10 @@
   <Cosmetic.label>kozmetik</Cosmetic.label>
   
   <!-- EN: cosmetic - hair -->
-  <Cosmetic_Hair.label>kozmetik-saç</Cosmetic_Hair.label>
+  <Cosmetic_Hair.label>kozmetik - saç</Cosmetic_Hair.label>
   
   <!-- EN: cosmetic - skin -->
-  <Cosmetic_Skin.label>kozmetik-deri</Cosmetic_Skin.label>
+  <Cosmetic_Skin.label>kozmetik - deri</Cosmetic_Skin.label>
   
   <!-- EN: miscellaneous -->
   <Miscellaneous.label>muhtelif</Miscellaneous.label>

--- a/Core/DefInjected/HistoryAutoRecorderDef/HistoryAutoRecorders.xml
+++ b/Core/DefInjected/HistoryAutoRecorderDef/HistoryAutoRecorders.xml
@@ -13,12 +13,12 @@
   <FreeColonists.label>boş kolonistler</FreeColonists.label>
   
   <!-- EN: pop recovery -->
-  <PopAdaptation.label>Pop. kurtarma</PopAdaptation.label>
+  <PopAdaptation.label>pop. kurtarma</PopAdaptation.label>
   <!-- EN: {0} days -->
   <PopAdaptation.valueFormat>{0} gün</PopAdaptation.valueFormat>
   
   <!-- EN: pop intent x10 -->
-  <PopIntent.label>Pop. niyet x10</PopIntent.label>
+  <PopIntent.label>pop. niyet x10</PopIntent.label>
   <!-- EN: {0} days -->
   <PopIntent.valueFormat>{0} gün</PopIntent.valueFormat>
   

--- a/Core/DefInjected/MainButtonDef/MainButtons.xml
+++ b/Core/DefInjected/MainButtonDef/MainButtons.xml
@@ -55,7 +55,7 @@
   <Wildlife.description>Bölgedeki listelenmiş hayvanları avlamak veya evcilleştirmek için işaretle.</Wildlife.description>
   
   <!-- EN: work -->
-  <Work.label>iş</Work.label>
+  <Work.label>İş</Work.label>
   <!-- EN: Choose which colonist does what kinds of work, and in what order. -->
   <Work.description>Hangi kolonistin hangi işleri hangi sırayla yapacağını seç.</Work.description>
   

--- a/Core/DefInjected/PawnColumnDef/PawnColumns_Misc.xml
+++ b/Core/DefInjected/PawnColumnDef/PawnColumns_Misc.xml
@@ -23,17 +23,17 @@
   <HostilityResponse.headerTip>Düşmanca tepki</HostilityResponse.headerTip>
   
   <!-- EN: name -->
-  <Label.label>isim</Label.label>
+  <Label.label>İsim</Label.label>
   <!-- EN: Name -->
   <Label.headerTip>İsim</Label.headerTip>
   
   <!-- EN: name -->
-  <LabelShortWithIcon.label>isim</LabelShortWithIcon.label>
+  <LabelShortWithIcon.label>İsim</LabelShortWithIcon.label>
   <!-- EN: Name -->
   <LabelShortWithIcon.headerTip>İsim</LabelShortWithIcon.headerTip>
   
   <!-- EN: name -->
-  <LabelWithIcon.label>isim</LabelWithIcon.label>
+  <LabelWithIcon.label>İsim</LabelWithIcon.label>
   <!-- EN: Name -->
   <LabelWithIcon.headerTip>İsim</LabelWithIcon.headerTip>
   

--- a/Core/DefInjected/PawnKindDef/Races_Animal_CowGroup.xml
+++ b/Core/DefInjected/PawnKindDef/Races_Animal_CowGroup.xml
@@ -40,8 +40,8 @@
   <Cow.lifeStages.calf.labelPlural>buzağılar</Cow.lifeStages.calf.labelPlural>
   
   <!-- EN: donkey -->
-  <Donkey.label>eşşek</Donkey.label>
-  <Donkey.labelPlural>eşşekler</Donkey.labelPlural>
+  <Donkey.label>eşek</Donkey.label>
+  <Donkey.labelPlural>eşekler</Donkey.labelPlural>
   <!-- EN: donkey foal -->
   <Donkey.lifeStages.donkey_foal.label>sıpa</Donkey.lifeStages.donkey_foal.label>
   <Donkey.lifeStages.donkey_foal.labelPlural>sıpalar</Donkey.lifeStages.donkey_foal.labelPlural>

--- a/Core/DefInjected/PawnRelationDef/PawnRelations_FamilyByBlood.xml
+++ b/Core/DefInjected/PawnRelationDef/PawnRelations_FamilyByBlood.xml
@@ -11,8 +11,8 @@
   <Cousin.labelFemale>kuzeni</Cousin.labelFemale>
   
   <!-- EN: cousin once removed -->
-  <CousinOnceRemoved.label>1. derece kuzeni</CousinOnceRemoved.label>
-  <CousinOnceRemoved.labelFemale>1. derece kuzeni</CousinOnceRemoved.labelFemale>
+  <CousinOnceRemoved.label>1. dereceden kuzeni</CousinOnceRemoved.label>
+  <CousinOnceRemoved.labelFemale>1. dereceden kuzeni</CousinOnceRemoved.labelFemale>
   
   <!-- EN: grandson -->
   <Grandchild.label>erkek torunu</Grandchild.label>
@@ -35,9 +35,9 @@
   <GranduncleOrGrandaunt.labelFemale>büyük hala/teyze</GranduncleOrGrandaunt.labelFemale>
   
   <!-- EN: great grandson -->
-  <GreatGrandchild.label>erkek torun</GreatGrandchild.label>
+  <GreatGrandchild.label>küçük erkek torun</GreatGrandchild.label>
   <!-- EN: great granddaughter -->
-  <GreatGrandchild.labelFemale>kız torun</GreatGrandchild.labelFemale>
+  <GreatGrandchild.labelFemale>küçük kız torun</GreatGrandchild.labelFemale>
   
   <!-- EN: great grandfather -->
   <GreatGrandparent.label>büyük büyükbaba</GreatGrandparent.label>
@@ -64,8 +64,8 @@
   <Parent.labelFemale>anne</Parent.labelFemale>
   
   <!-- EN: second cousin -->
-  <SecondCousin.label>2.dereceden kuzen</SecondCousin.label>
-  <SecondCousin.labelFemale>2.dereceden kuzen</SecondCousin.labelFemale>
+  <SecondCousin.label>2. dereceden kuzen</SecondCousin.label>
+  <SecondCousin.labelFemale>2. dereceden kuzen</SecondCousin.labelFemale>
   
   <!-- EN: brother -->
   <Sibling.label>erkek kardeş</Sibling.label>

--- a/Core/DefInjected/PreceptDef/Precepts_AteNutrientPaste.xml
+++ b/Core/DefInjected/PreceptDef/Precepts_AteNutrientPaste.xml
@@ -4,6 +4,6 @@
   <!-- EN: disgusting -->
   <NutrientPasteEating_Disgusting.label>tiksindirici</NutrientPasteEating_Disgusting.label>
   <!-- EN: Nutrient paste is disgusting. -->
-  <NutrientPasteEating_Disgusting.description>Lapa tiksinç.</NutrientPasteEating_Disgusting.description>
+  <NutrientPasteEating_Disgusting.description>Besin ezmesi tiksinç.</NutrientPasteEating_Disgusting.description>
   
 </LanguageData>

--- a/Core/DefInjected/PreceptDef/Precepts_InsectMeat.xml
+++ b/Core/DefInjected/PreceptDef/Precepts_InsectMeat.xml
@@ -2,7 +2,7 @@
 <LanguageData>
   
   <!-- EN: despised -->
-  <InsectMeatEating_Despised_Classic.label>iğrenç</InsectMeatEating_Despised_Classic.label>
+  <InsectMeatEating_Despised_Classic.label>İğrenç</InsectMeatEating_Despised_Classic.label>
   <!-- EN: Insect meat is disgusting to even look at, much less eat. Slimy! -->
   <InsectMeatEating_Despised_Classic.description>Böcek etini yemeyi geçtim bakmak bile iğrenç. Öğğ!</InsectMeatEating_Despised_Classic.description>
   

--- a/Core/DefInjected/PreceptDef/Precepts_SpouseCount.xml
+++ b/Core/DefInjected/PreceptDef/Precepts_SpouseCount.xml
@@ -2,12 +2,12 @@
 <LanguageData>
   
   <!-- EN: one only -->
-  <SpouseCount_Female_MaxOne.label>Tek eşlilik</SpouseCount_Female_MaxOne.label>
+  <SpouseCount_Female_MaxOne.label>tek eşlilik</SpouseCount_Female_MaxOne.label>
   <!-- EN: Women may have one spouse only. -->
   <SpouseCount_Female_MaxOne.description>Kadınlar sadece bir eşe sahip olabilir.</SpouseCount_Female_MaxOne.description>
   
   <!-- EN: one only -->
-  <SpouseCount_Male_MaxOne.label>Tek eşlilik</SpouseCount_Male_MaxOne.label>
+  <SpouseCount_Male_MaxOne.label>tek eşlilik</SpouseCount_Male_MaxOne.label>
   <!-- EN: Men may have one spouse only. -->
   <SpouseCount_Male_MaxOne.description>Erkekler sadece bir eşe sahip olabilir.</SpouseCount_Male_MaxOne.description>
   

--- a/Core/DefInjected/PrisonerInteractionModeDef/PrisonerInteractionMode.xml
+++ b/Core/DefInjected/PrisonerInteractionModeDef/PrisonerInteractionMode.xml
@@ -7,7 +7,7 @@
   <AttemptRecruit.description>Gardiyanlar mahkumu koloniye katmaya çalışacaklar. Gardiyanlar, mahkumun hala direnci varsa düşürmek için onunla konuşacak.</AttemptRecruit.description>
   
   <!-- EN: execute -->
-  <Execution.label>infaz et</Execution.label>
+  <Execution.label>İnfaz et</Execution.label>
   <!-- EN: A warden will execute the prisoner on the spot by cutting. This can affect the mood of other prisoners and colonists. -->
   <Execution.description>Bir gardiyan mahkumu bulunduğu yerde keserek infaz edecek. Bu, diğer mahkumların ve kolonistlerin ruh halini etkileyebilir.</Execution.description>
   

--- a/Core/DefInjected/RecipeDef/Recipes_Production.xml
+++ b/Core/DefInjected/RecipeDef/Recipes_Production.xml
@@ -27,7 +27,7 @@
   <!-- EN: Make a batch of chemfuel by extracting biofuel from organic feedstocks. -->
   <Make_ChemfuelFromOrganics.description>Organik hammadelerden biyoyakıt çıkararak yakıt üret.</Make_ChemfuelFromOrganics.description>
   <!-- EN: feedstock -->
-  <Make_ChemfuelFromOrganics.ingredients.0.filter.customSummary>hammadde</Make_ChemfuelFromOrganics.ingredients.0.filter.customSummary>
+  <Make_ChemfuelFromOrganics.ingredients.0.filter.customSummary>ham madde</Make_ChemfuelFromOrganics.ingredients.0.filter.customSummary>
   <!-- EN: Refining chemfuel from organics. -->
   <Make_ChemfuelFromOrganics.jobString>Organiklerden yakıt üretiyor.</Make_ChemfuelFromOrganics.jobString>
   

--- a/Core/DefInjected/ResearchProjectDef/ResearchProjects_2_Electricity.xml
+++ b/Core/DefInjected/ResearchProjectDef/ResearchProjects_2_Electricity.xml
@@ -374,9 +374,9 @@
   </Mortars.generalRules.rulesStrings>
   
   <!-- EN: nutrient paste -->
-  <NutrientPaste.label>besin macunu</NutrientPaste.label>
+  <NutrientPaste.label>besin ezmesi</NutrientPaste.label>
   <!-- EN: Build nutrient paste dispensers which efficiently produce edible meals from raw nutritive feedstocks, while requiring no labor at all. -->
-  <NutrientPaste.description>Hiçbir işçilik gerektirmeden, çiğ, besleyici hammaddelerden verimli bir şekilde yenilebilir yiyecekler üreten besin dağıtıcısı inşa et.</NutrientPaste.description>
+  <NutrientPaste.description>Hiçbir işçilik gerektirmeden, çiğ, besleyici ham maddelerden verimli bir şekilde yenilebilir yiyecekler üreten besin ezmesi dağıtıcısı inşa et.</NutrientPaste.description>
   <!-- EN:
     <li>subject->nutrient paste</li>
     <li>subject_story->worked in a factory canteen and devised nutrient paste as a way to avoid all labor</li>
@@ -385,10 +385,10 @@
     <li>subject_gerund->building nutrient paste dispensers</li>
   -->
   <NutrientPaste.generalRules.rulesStrings>
-    <li>subject->besin macunu</li>
-    <li>subject_story->bir fabrika kantininde çalıştı ve tüm işçilikten kaçınmanın bir yolu olarak besin macununu geliştirdi</li>
-    <li>subject_story->hastalık nedeniyle koku alma duyularını kaybettiklerinden, ucuz, tatsız bir besin macununu geliştirdiler</li>
-    <li>subject_story->tüm organik maddelerin, hatta cesetlerin bile besin macununa dönüştürülmesini savunmuştur</li>
+    <li>subject->besin ezmesi</li>
+    <li>subject_story->bir fabrika kantininde çalıştı ve tüm işçilikten kaçınmanın bir yolu olarak besin ezmesini geliştirdi</li>
+    <li>subject_story->hastalık nedeniyle koku alma duyularını kaybettiklerinden, ucuz, tatsız bir besin ezmesini geliştirdiler</li>
+    <li>subject_story->tüm organik maddelerin, hatta cesetlerin bile besin ezmesine dönüştürülmesini savunmuştur</li>
     <li>subject_gerund->besin dağıtıcısı inşa ediyor</li>
   </NutrientPaste.generalRules.rulesStrings>
   

--- a/Core/DefInjected/ResearchProjectDef/ResearchProjects_3_Microelectronics.xml
+++ b/Core/DefInjected/ResearchProjectDef/ResearchProjects_3_Microelectronics.xml
@@ -128,7 +128,7 @@
   </LongRangeMineralScanner.generalRules.rulesStrings>
   
   <!-- EN: medicine production -->
-  <MedicineProduction.label>ilaç üretimi</MedicineProduction.label>
+  <MedicineProduction.label>İlaç üretimi</MedicineProduction.label>
   <!-- EN: Produce standard industrial-tech medicine by combining herbal medicine, neutroamine, and cloth. -->
   <MedicineProduction.description>Nötroamini, kumaşı ve bitkisel ilacı karıştırarak sanayi ilacı üret.</MedicineProduction.description>
   <!-- EN:

--- a/Core/DefInjected/RoomRoleDef/RoomRoles.xml
+++ b/Core/DefInjected/RoomRoleDef/RoomRoles.xml
@@ -32,7 +32,7 @@
   <PrisonCell.label>hapishane hücresi</PrisonCell.label>
   
   <!-- EN: rec room -->
-  <RecRoom.label>ortak oda</RecRoom.label>
+  <RecRoom.label>dinlenme odası</RecRoom.label>
   
   <!-- EN: room -->
   <Room.label>oda</Room.label>

--- a/Core/DefInjected/ScenPartDef/ScenParts_Various.xml
+++ b/Core/DefInjected/ScenPartDef/ScenParts_Various.xml
@@ -23,7 +23,7 @@
   <Naked.label>çıplak</Naked.label>
   
   <!-- EN: no possessions -->
-  <NoPossessions.label>Varlık yok</NoPossessions.label>
+  <NoPossessions.label>varlık yok</NoPossessions.label>
   
   <!-- EN: characters explode on death -->
   <OnPawnDeathExplode.label>karakterler öldüğünde patlar</OnPawnDeathExplode.label>

--- a/Core/DefInjected/SkillDef/Skills.xml
+++ b/Core/DefInjected/SkillDef/Skills.xml
@@ -70,7 +70,7 @@
   <Artistic.skillLabel>sanat</Artistic.skillLabel>
   
   <!-- EN: construction -->
-  <Construction.label>inşaat</Construction.label>
+  <Construction.label>İnşaat</Construction.label>
   <!-- EN: Constructing and deconstructing structures and furniture. -->
   <Construction.description>Yapıları ve mobilyaları inşa etme ve yıkma.</Construction.description>
   <!-- EN:
@@ -98,7 +98,7 @@
     <li>subject->altyapı</li>
   </Construction.generalRules.rulesStrings>
   <!-- EN: construction -->
-  <Construction.skillLabel>inşaat</Construction.skillLabel>
+  <Construction.skillLabel>İnşaat</Construction.skillLabel>
   
   <!-- EN: cooking -->
   <Cooking.label>aşçılık</Cooking.label>

--- a/Core/DefInjected/StorytellerDef/Storytellers.xml
+++ b/Core/DefInjected/StorytellerDef/Storytellers.xml
@@ -7,7 +7,7 @@
   <Cassandra.description>Cassandra, zorluğun ve gerginliğin düzgün bir şekilde arttığı hikayesel olayları karşına çıkarır. Seni tehlikeli olaylara itecek, sonra nefes aldıracak, sonra geri gelecek ve bir kez daha itecek.</Cassandra.description>
   
   <!-- EN: Phoebe Chillax -->
-  <Phoebe.label>Phoebe Chillax</Phoebe.label>
+  <Phoebe.label>Phoebe Rahatla</Phoebe.label>
   <!-- EN: Phoebe gives lots of time between disasters to build your colony. But beware - at high difficulties, she'll hit as hard as anyone. -->
   <Phoebe.description>Phoebe, kolonini geliştirmen için felaketler arasına çok fazla zaman koyar. Ama dikkatli ol - eğer Phoebe zorlu bir mücadele yaratmak isterse hayatta kalmak herkesin yapabileceği bir şey değil.</Phoebe.description>
   

--- a/Core/DefInjected/TattooDef/TattooDefs.xml
+++ b/Core/DefInjected/TattooDef/TattooDefs.xml
@@ -2,9 +2,9 @@
 <LanguageData>
   
   <!-- EN: none -->
-  <NoTattoo_Body.label>Yok</NoTattoo_Body.label>
+  <NoTattoo_Body.label>yok</NoTattoo_Body.label>
   
   <!-- EN: none -->
-  <NoTattoo_Face.label>Yok</NoTattoo_Face.label>
+  <NoTattoo_Face.label>yok</NoTattoo_Face.label>
   
 </LanguageData>

--- a/Core/DefInjected/TerrainTemplateDef/Terrain_Floors.xml
+++ b/Core/DefInjected/TerrainTemplateDef/Terrain_Floors.xml
@@ -2,7 +2,7 @@
 <LanguageData>
   
   <!-- EN: carpet ({0}) -->
-  <Carpet.label>Halı ({0})</Carpet.label>
+  <Carpet.label>halı ({0})</Carpet.label>
   <!-- EN: Soft carpet made from fibers dyed a single color. It's welcoming, cozy, and boosts the beauty of the room it's in. It's also quite flammable, and cleaning it is a laborious process. -->
   <Carpet.description>Tek renge boyanmış liflerden yapılmış yumuşak halı. Konukseverdir, rahattır ve bulunduğu odanın güzelliğini artırır. Aynı zamanda oldukça yanıcıdır ve temizlenmesi zahmetli bir işlemdir.</Carpet.description>
   

--- a/Core/DefInjected/ThingDef/Buildings_Furniture.xml
+++ b/Core/DefInjected/ThingDef/Buildings_Furniture.xml
@@ -129,7 +129,7 @@
   <SunLamp.comps.CompSchedule.offMessage>Bitki dinlenme döneminde kapalı</SunLamp.comps.CompSchedule.offMessage>
   
   <!-- EN: table (1x2) -->
-  <Table1x2c.label>masa(1x2)</Table1x2c.label>
+  <Table1x2c.label>masa (1x2)</Table1x2c.label>
   <!-- EN: People eat off tables when chairs are placed facing them. -->
   <Table1x2c.description>Sandalyeler karşılarına konulduğunda insanlar masadan yemek yerler.</Table1x2c.description>
   

--- a/Core/DefInjected/ThingDef/Buildings_Joy.xml
+++ b/Core/DefInjected/ThingDef/Buildings_Joy.xml
@@ -2,22 +2,22 @@
 <LanguageData>
   
   <!-- EN: billiards table -->
-  <BilliardsTable.label>Bilardo Masası</BilliardsTable.label>
+  <BilliardsTable.label>bilardo masası</BilliardsTable.label>
   <!-- EN: A soft-topped bounded table for playing a variety of billiards-type games. It trains shooting ability. -->
   <BilliardsTable.description>Çeşitli bilardo oyunlarını oynamak için sınırları belli, yumuşak ve üstü kaplı masa.</BilliardsTable.description>
   
   <!-- EN: chess table -->
-  <ChessTable.label>Satranç</ChessTable.label>
+  <ChessTable.label>satranç masası</ChessTable.label>
   <!-- EN: The ancient game of kings. Fun for a few hours here and there, even playing alone. It trains intellectual skills.\n\nThis building requires adjacent chairs or stools to use. -->
   <ChessTable.description>Antik zamandan kalma kralların oyunu. Birkaç saatlik eğlence, tek başına oynanırken bile.</ChessTable.description>
   
   <!-- EN: flatscreen television -->
-  <FlatscreenTelevision.label>Düz Ekran Televizyon</FlatscreenTelevision.label>
+  <FlatscreenTelevision.label>düz ekran televizyon</FlatscreenTelevision.label>
   <!-- EN: A high-tech flat-screen television with crystal-clear image and rich color. Picks up transmissions from ancient satellites and ubiquitous data cards. -->
   <FlatscreenTelevision.description>Yüksek teknolojili kristal temizliğinde ve çeşitli renkleri verebilen bir düz ekran televizyon. Eski tüplü televizyona kıyasla daha fazla eğlenceli.</FlatscreenTelevision.description>
   
   <!-- EN: Game-of-Ur board -->
-  <GameOfUrBoard.label>Ur Oyun tahtası</GameOfUrBoard.label>
+  <GameOfUrBoard.label>ur oyunu tahtası</GameOfUrBoard.label>
   <!-- EN: Dating from 2500BC, this exciting yet infuriating board game can be played by one or two people. It trains intellectual skills. -->
   <GameOfUrBoard.description>2500BC'den kalma bu heyecan verici ama çileden çıkaran masa oyunu bir veya iki kişi tarafından oynanabilir. Entelektüel becerileri eğitir.</GameOfUrBoard.description>
   
@@ -27,12 +27,12 @@
   <HoopstoneRing.description>Taşlarla ve yerde büyük bir yüzükle oynanan basit bir antik oyun. Oyuncular belli bir mesafeden halkanın içinden taş atmaya çalışırlar. Rahatlatıcıdır ve atış becerilerini geliştirir.</HoopstoneRing.description>
   
   <!-- EN: horseshoes pin -->
-  <HorseshoesPin.label>Nal Atma</HorseshoesPin.label>
+  <HorseshoesPin.label>nal atma</HorseshoesPin.label>
   <!-- EN: A simple ancient game played with a horseshoes and a large pin in the ground. Players toss horseshoes to try to get them to land on the pin. It's relaxing, and trains shooting skills. -->
   <HorseshoesPin.description>Antik zamandan kalma, birkaç nal ile geniş alanda oynanan oyun. Oyuncular nallara vurarak mesafe katedip raptiyelerin yakınına getirmeye çalışırlar. Rahatlatıcı, ve hatta el-göz koordinasyonu için bir antrenman sayılır.</HorseshoesPin.description>
   
   <!-- EN: megascreen television -->
-  <MegascreenTelevision.label>Büyük Ekran Televizyon</MegascreenTelevision.label>
+  <MegascreenTelevision.label>büyük ekran televizyon</MegascreenTelevision.label>
   <!-- EN: A huge, high-tech television. Gigantic, hyper-vibrant images almost leap out of the screen. Very entertaining. Picks up transmissions from ancient satellites and ubiquitous data cards. -->
   <MegascreenTelevision.description>Kocaman ve yüksek teknolojili televizyon. Devasa, süper hareketli resimler neredeyse ekrandan taşacakmış gibi. Çok eğlendirici.</MegascreenTelevision.description>
   
@@ -42,12 +42,12 @@
   <PokerTable.description>Poker gibi kumar kart oyunları oynamak için tasarlanmış bir masa. Stratejik becerilerinizi ve biraz şansınızı test etmenin harika bir yolu.</PokerTable.description>
   
   <!-- EN: telescope -->
-  <Telescope.label>Teleskop</Telescope.label>
+  <Telescope.label>teleskop</Telescope.label>
   <!-- EN: A telescope for doing amateur astronomy. It's a relaxing hobby for a certain kind of person. Can only be used outdoors. -->
   <Telescope.description>Amatör astronomi için bir teleskop. Belli kesim insanlar için rahatlatıcı ve eğlenceli bir hobi.</Telescope.description>
   
   <!-- EN: tube television -->
-  <TubeTelevision.label>Tüplü Televizyon</TubeTelevision.label>
+  <TubeTelevision.label>tüplü televizyon</TubeTelevision.label>
   <!-- EN: A cathode ray tube display for showing moving pictures with sound. Even on the rimworlds, there is often an old transmitter running something at least marginally interesting. -->
   <TubeTelevision.description>Sesle birlikte hareketleri resimleri izlemek için katota bağlanmış tüplü ekran. Kenar dünyalarında bile, en azından marjinal açıdan ilginç bir şey çalıştıran eski bir verici vardır.</TubeTelevision.description>
   

--- a/Core/DefInjected/ThingDef/Buildings_Misc.xml
+++ b/Core/DefInjected/ThingDef/Buildings_Misc.xml
@@ -7,9 +7,9 @@
   <AncientCryptosleepCasket.description>Bu uyku haznesi yıllardır burda durmuşa benziyor. İçinde ne olduğunu kim bilebilir?</AncientCryptosleepCasket.description>
   
   <!-- EN: caravan hitching spot -->
-  <CaravanPackingSpot.label>karavan otospot noktası</CaravanPackingSpot.label>
+  <CaravanPackingSpot.label>kervan bağlantı noktası</CaravanPackingSpot.label>
   <!-- EN: Designates a spot for hitching animals and forming caravans. Colonists will hitch animals here while loading a caravan. You can also use these during encounters away from home to keep animals from wandering. -->
-  <CaravanPackingSpot.description>karavan otostop noktası Hayvanları otostop çekmek ve karavan oluşturmak için bir nokta belirler. Kolonistler, bir karavan yüklerken hayvanları burada otostop yapacaklar. Bunları, hayvanların dolaşmasını önlemek için evden uzaktaki karşılaşmalar sırasında da kullanabilirsiniz.</CaravanPackingSpot.description>
+  <CaravanPackingSpot.description>Hayvanları bağlamak ve karavan oluşturmak için bir nokta belirler. Kolonistler, bir karavan yüklerken hayvanları burada otostop yapacaklar. Bunları, hayvanların dolaşmasını önlemek için evden uzaktaki karşılaşmalar sırasında da kullanabilirsiniz.</CaravanPackingSpot.description>
   
   <!-- EN: comms console -->
   <CommsConsole.label>iletişim konsolu</CommsConsole.label>
@@ -22,7 +22,7 @@
   <CryptosleepCasket.description>İnsanları yıllarca hayvan saldırısından korumak için dizayn edilmiş bir nevi yarı güçte çalışan lahit.</CryptosleepCasket.description>
   
   <!-- EN: delayed effecter spawner -->
-  <DelayedEffecterSpawner.labely>gecikmeli etkileyen umurtlayıcı</DelayedEffecterSpawner.label>
+  <DelayedEffecterSpawner.label>gecikmeli etkileyen yumurtlayıcı</DelayedEffecterSpawner.label>
   
   <!-- EN: egg box -->
   <EggBox.label>yumurta kutusu</EggBox.label>
@@ -102,7 +102,7 @@
   <SteleLarge.description>Yanlarında oymalar olan uzun, kalın bir levha. Dikilitaşlar, eski zamanlardan beri bireyleri, savaşları ve diğer önemli olayları anmak için kullanılmıştır.</SteleLarge.description>
   
   <!-- EN: tool cabinet -->
-  <ToolCabinet.label>Alet Dolabı</ToolCabinet.label>
+  <ToolCabinet.label>alet dolabı</ToolCabinet.label>
   <!-- EN: Increases work speed when placed near a workbench. One workbench can use up to two tool cabinets. -->
   <ToolCabinet.description>Çalışma hızını arttır. Çalışma masasının yanına yapılmalı. Bir çalışma masası aynı anda sadece iki alet edavat dolabıyla eşleşebilir.</ToolCabinet.description>
   

--- a/Core/DefInjected/ThingDef/Buildings_Natural.xml
+++ b/Core/DefInjected/ThingDef/Buildings_Natural.xml
@@ -19,7 +19,7 @@
   <!-- EN: compacted machinery -->
   <MineableComponentsIndustrial.label>sıkıştırılmış makineler</MineableComponentsIndustrial.label>
   <!-- EN: Ancient machinery, compacted over time. Can be mined for useful components. -->
-  <MineableComponentsIndustrial.description>Zaman içinde sıkışmış eski makinele kullanışlı bileşen elde etmek için kullanılabilir.</MineableComponentsIndustrial.description>
+  <MineableComponentsIndustrial.description>Zamanla sıkışmış eski makineler. Faydalı bileşenler için çıkarılabilir</MineableComponentsIndustrial.description>
   
   <!-- EN: gold ore -->
   <MineableGold.label>altın cevheri</MineableGold.label>

--- a/Core/DefInjected/ThingDef/Buildings_Production.xml
+++ b/Core/DefInjected/ThingDef/Buildings_Production.xml
@@ -89,7 +89,7 @@
   <!-- EN: hopper -->
   <Hopper.label>beslenme hunisi</Hopper.label>
   <!-- EN: Holds resources for use by machines like nutrient paste dispensers. -->
-  <Hopper.description>Sıkıstırılmış besin dağıtıcıları gibi makineler tarafından kullanılmak üzere kaynakları tutar.</Hopper.description>
+  <Hopper.description>Sıkıştırılmış besin dağıtıcıları gibi makineler tarafından kullanılmak üzere kaynakları tutar.</Hopper.description>
   
   <!-- EN: hydroponics basin -->
   <HydroponicsBasin.label>su havzası</HydroponicsBasin.label>
@@ -99,7 +99,7 @@
   <!-- EN: nutrient paste dispenser -->
   <NutrientPasteDispenser.label>besin dağıtıcısı</NutrientPasteDispenser.label>
   <!-- EN: A machine that synthesizes edible nutrient paste from organic feedstocks placed in adjacent hoppers. It consumes less ingredients and time than any other meal production method - but nobody likes eating nutrient paste. Accepts raw food, but not rough plant matter like hay. -->
-  <NutrientPasteDispenser.description>Bitişik haznelere yerleştirilen organik hammaddelerden yenilebilir besin macunu sentezleyen bir makine. Diğer tüm yemek üretim yöntemlerinden daha az malzeme ve zaman tüketir - ancak kimse besin macunu yemekten hoşlanmaz. Çiğ gıdaları kabul eder, ancak saman gibi kaba bitki maddelerini kabul etmez.</NutrientPasteDispenser.description>
+  <NutrientPasteDispenser.description>Bitişik haznelere yerleştirilen organik ham maddelerden yenilebilir besin ezmesi sentezleyen bir makine. Diğer tüm yemek üretim yöntemlerinden daha az malzeme ve zaman tüketir - ancak kimse besin ezmesi yemekten hoşlanmaz. Çiğ gıdaları kabul eder, ancak saman gibi kaba bitki maddelerini kabul etmez.</NutrientPasteDispenser.description>
   
   <!-- EN: simple research bench -->
   <SimpleResearchBench.label>basit araştırma masası</SimpleResearchBench.label>
@@ -112,7 +112,7 @@
   <TableButcher.description>Ölü yaratıkları parçalayıp ham et elde etmek için ağır bir masa.</TableButcher.description>
   
   <!-- EN: machining table -->
-  <TableMachining.label>işleme masası</TableMachining.label>
+  <TableMachining.label>İşleme masası</TableMachining.label>
   <!-- EN: A work station for assembling machinery like guns and ammunition, or breaking down dead mechanoids. -->
   <TableMachining.description>Silah ve mekanik ceset gibi m1akine parçalarını birleştirme ve ayrıştırma yapabileceğin bir çalışma istasyonu.</TableMachining.description>
   

--- a/Core/DefInjected/ThingDef/Items_Food.xml
+++ b/Core/DefInjected/ThingDef/Items_Food.xml
@@ -37,7 +37,7 @@
   <MealLavish_Veg.description>Bedeni, zihni ve ruhu besleyen bu yemek bir mutfak şaheseridir.</MealLavish_Veg.description>
   
   <!-- EN: nutrient paste meal -->
-  <MealNutrientPaste.label>besin macunu</MealNutrientPaste.label>
+  <MealNutrientPaste.label>besin ezmesi</MealNutrientPaste.label>
   <!-- EN: A synthetic mixture of protein, carbohydrates, and vitamins, amino acids and minerals. Everything the body needs, and absolutely disgusting. -->
   <MealNutrientPaste.description>Protein, karbonhidrat, amino asit, mineral ve vitaminin sentetik bir karışımı. Vücudun ihtiyacı olan her şey ve kesinlikle iğrenç.</MealNutrientPaste.description>
   

--- a/Core/DefInjected/ThingDef/Mote_Meta.xml
+++ b/Core/DefInjected/ThingDef/Mote_Meta.xml
@@ -2,21 +2,21 @@
 <LanguageData>
   
   <!-- EN: Mote -->
-  <Mote_Cards.label>Mote</Mote_Cards.label>
+  <Mote_Cards.label>Parçacık</Mote_Cards.label>
   
   <!-- EN: Mote -->
-  <Mote_Clean.label>Mote</Mote_Clean.label>
+  <Mote_Clean.label>Parçacık</Mote_Clean.label>
   
   <!-- EN: Mote -->
-  <Mote_ClearSnow.label>Mote</Mote_ClearSnow.label>
+  <Mote_ClearSnow.label>Parçacık</Mote_ClearSnow.label>
   
   <!-- EN: Mote -->
-  <Mote_Harvest.label>Mote</Mote_Harvest.label>
+  <Mote_Harvest.label>Parçacık</Mote_Harvest.label>
   
   <!-- EN: Mote -->
-  <Mote_Paint.label>Mote</Mote_Paint.label>
+  <Mote_Paint.label>Parçacık</Mote_Paint.label>
   
   <!-- EN: Mote -->
-  <Mote_Sow.label>Mote</Mote_Sow.label>
+  <Mote_Sow.label>Parçacık</Mote_Sow.label>
   
 </LanguageData>

--- a/Core/DefInjected/ThingDef/Mote_MetaStatus.xml
+++ b/Core/DefInjected/ThingDef/Mote_MetaStatus.xml
@@ -2,18 +2,18 @@
 <LanguageData>
   
   <!-- EN: Mote -->
-  <Mote_BerserkBit.label>Mote</Mote_BerserkBit.label>
+  <Mote_BerserkBit.label>Parçacık</Mote_BerserkBit.label>
   
   <!-- EN: Mote -->
-  <Mote_ColonistAttacking.label>Mote</Mote_ColonistAttacking.label>
+  <Mote_ColonistAttacking.label>Parçacık</Mote_ColonistAttacking.label>
   
   <!-- EN: Mote -->
-  <Mote_ColonistFleeing.label>Mote</Mote_ColonistFleeing.label>
+  <Mote_ColonistFleeing.label>Parçacık</Mote_ColonistFleeing.label>
   
   <!-- EN: Mote -->
-  <Mote_DrunkBubble.label>Mote</Mote_DrunkBubble.label>
+  <Mote_DrunkBubble.label>Parçacık</Mote_DrunkBubble.label>
   
   <!-- EN: Mote -->
-  <Mote_Stun.label>Mote</Mote_Stun.label>
+  <Mote_Stun.label>Parçacık</Mote_Stun.label>
   
 </LanguageData>

--- a/Core/DefInjected/ThingDef/Mote_Special.xml
+++ b/Core/DefInjected/ThingDef/Mote_Special.xml
@@ -2,30 +2,30 @@
 <LanguageData>
   
   <!-- EN: Mote -->
-  <Mote_Danger.label>Mote</Mote_Danger.label>
+  <Mote_Danger.label>Parçacık</Mote_Danger.label>
   
   <!-- EN: Mote -->
-  <Mote_ProgressBar.label>Mote</Mote_ProgressBar.label>
+  <Mote_ProgressBar.label>Parçacık</Mote_ProgressBar.label>
   
   <!-- EN: Mote -->
-  <Mote_ProgressBarAlwaysVisible.label>Mote</Mote_ProgressBarAlwaysVisible.label>
+  <Mote_ProgressBarAlwaysVisible.label>Parçacık</Mote_ProgressBarAlwaysVisible.label>
   
   <!-- EN: Mote -->
-  <Mote_Speech.label>Mote</Mote_Speech.label>
+  <Mote_Speech.label>Parçacık</Mote_Speech.label>
   
   <!-- EN: Mote -->
-  <Mote_TempRoof.label>Mote</Mote_TempRoof.label>
+  <Mote_TempRoof.label>Parçacık</Mote_TempRoof.label>
   
   <!-- EN: Mote -->
-  <Mote_Text.label>Mote</Mote_Text.label>
+  <Mote_Text.label>Parçacık</Mote_Text.label>
   
   <!-- EN: Mote -->
-  <Mote_Thought.label>Mote</Mote_Thought.label>
+  <Mote_Thought.label>Parçacık</Mote_Thought.label>
   
   <!-- EN: Mote -->
-  <Mote_ThoughtBad.label>Mote</Mote_ThoughtBad.label>
+  <Mote_ThoughtBad.label>Parçacık</Mote_ThoughtBad.label>
   
   <!-- EN: Mote -->
-  <Mote_ThoughtGood.label>Mote</Mote_ThoughtGood.label>
+  <Mote_ThoughtGood.label>Parçacık</Mote_ThoughtGood.label>
   
 </LanguageData>

--- a/Core/DefInjected/ThingDef/Penoxycyline.xml
+++ b/Core/DefInjected/ThingDef/Penoxycyline.xml
@@ -6,7 +6,7 @@
   <!-- EN: A drug for preventing infections before they take hold. Blocks malaria, sleeping sickness, plague. Must be taken every five days to remain effective.\n\nThis drug only prevents new infections. It does not cure existing infections - even those that are not yet discovered. -->
   <Penoxycyline.description>Enfeksiyonları yakalanılmadan önce engelleyen bir uyuşturucu. Sıtmayı, uyku hastalığını ve vebayı engeller. Etkisinin sürmesi için 5 günde bir alınmalıdır.\n\nSadece yeni enfeksiyonları engeller. Keşfedilmemiş olsalar bile mevcut olan enfeksiyonları engellemez.</Penoxycyline.description>
   <!-- EN: Take {0} -->
-  <Penoxycyline.ingestible.ingestCommandString>[0} al</Penoxycyline.ingestible.ingestCommandString>
+  <Penoxycyline.ingestible.ingestCommandString>{0} al</Penoxycyline.ingestible.ingestCommandString>
   <!-- EN: Taking {0}. -->
   <Penoxycyline.ingestible.ingestReportString>{0} alıyor.</Penoxycyline.ingestible.ingestReportString>
   

--- a/Core/DefInjected/ThingDef/Plants_Cultivated_Decorative.xml
+++ b/Core/DefInjected/ThingDef/Plants_Cultivated_Decorative.xml
@@ -2,9 +2,9 @@
 <LanguageData>
   
   <!-- EN: daylily -->
-  <Plant_Daylily.label>Güngüzeli</Plant_Daylily.label>
+  <Plant_Daylily.label>güngüzeli</Plant_Daylily.label>
   <!-- EN: A cultivated flower with wide petals and a short lifespan. Daylilies are very beautiful, but must be replanted often. -->
-  <Plant_Daylily.description>Geniş yaprakları ve kısa ömrü olan ekili bir çiçek. Daylilies çok güzeldir, ancak sık sık tekrar dikilmelidir.</Plant_Daylily.description>
+  <Plant_Daylily.description>Geniş yaprakları ve kısa ömrü olan ekili bir çiçek. Güngüzelleri çok güzeldir, ancak sık sık tekrar dikilmelidir.</Plant_Daylily.description>
   
   <!-- EN: rose -->
   <Plant_Rose.label>gül</Plant_Rose.label>

--- a/Core/DefInjected/ThingDef/Plants_Cultivated_Farm.xml
+++ b/Core/DefInjected/ThingDef/Plants_Cultivated_Farm.xml
@@ -42,12 +42,12 @@
   <Plant_Psychoid.description>Psikoid bitki, yaprakları demlenerek psikit çayına dönüştürülebilen ve flake ve yayoya rafine edilebilen yapraklı bir bitkidir. Başlangıçta bitki yiyen hayvanları aşırı uyararak ve hasta ederek düşmanları savuşturmak için bir savunma mekanizması olarak geliştirilen , eğlence amaçlı kullanım için çeşitli biçimlere dönüştürülebilen ve rafine edilebilen Bağımlılık yapıcı bir bitki.</Plant_Psychoid.description>
   
   <!-- EN: rice plant -->
-  <Plant_Rice.label>Pirinç bitkisi</Plant_Rice.label>
+  <Plant_Rice.label>pirinç bitkisi</Plant_Rice.label>
   <!-- EN: A short, fast-growing crop that yields small edible grains. Its great nutritional output and ease of cultivation has made it the economic core of many great civilizations. While rice grows quickly, it is sensitive to soil fertility and will not fare well in poor soil. -->
   <Plant_Rice.description>Küçük yenilebilir taneler veren kısa, hızlı büyüyen bir ürün. Büyük besin verimi ve ekim kolaylığı, onu birçok büyük uygarlığın ekonomik çekirdeği haline getirdi. Pirinç hızlı büyürken, toprak verimliliğine duyarlıdır ve fakir topraklarda iyi sonuç vermez.</Plant_Rice.description>
   
   <!-- EN: smokeleaf plant -->
-  <Plant_Smokeleaf.label>Tütün bitkisi</Plant_Smokeleaf.label>
+  <Plant_Smokeleaf.label>tütün bitkisi</Plant_Smokeleaf.label>
   <!-- EN: A leafy crop grown for the psychological effects of chemicals in its leaves. Smokeleaf leaves can be prepared into joints at the crafting spot. Smokeleaf makes a user feel relaxed, but reduces motivation, and can be addictive. -->
   <Plant_Smokeleaf.description>Yapraklarındaki kimyasalları için yetiştirilen yapraklı bir bitki. Tütün bitkisi, sigara yapmak için kullanılır. Sigara, kullanıcının rahatlamış hissetmesini sağlar, ancak motivasyonu azaltır ve bağımlılık yapabilir.</Plant_Smokeleaf.description>
   

--- a/Core/DefInjected/ThingDef/Plants_Wild_General.xml
+++ b/Core/DefInjected/ThingDef/Plants_Wild_General.xml
@@ -22,7 +22,7 @@
   <Plant_HealrootWild.description>Hasat edildiğinde bitkisel ilaç veren yavaş büyüyen bir bitki.\n\nBu yabani şifalı kök türü, evcilleştirilmiş şifalı kökten daha dayanıklıdır, ancak yetiştirilmesi çok zordur. Soğuk iklimlerde kabile halkları tarafından kullanılır.</Plant_HealrootWild.description>
   
   <!-- EN: tall grass -->
-  <Plant_TallGrass.label>Uzun Ot</Plant_TallGrass.label>
+  <Plant_TallGrass.label>uzun ot</Plant_TallGrass.label>
   <!-- EN: Wild tall grass. Slows down anyone moving over it. -->
   <Plant_TallGrass.description>Yabani uzun ot. Üzerinde hareket eden herkesi yavaşlatır.</Plant_TallGrass.description>
   

--- a/Core/DefInjected/ThingDef/Plants_Wild_Swamp.xml
+++ b/Core/DefInjected/ThingDef/Plants_Wild_Swamp.xml
@@ -7,7 +7,7 @@
   <Plant_Chokevine.description>Yerde büyük kütleler halinde kıvrılan, ipe benzer, dikenli sarmaşıkların birbirine dolanmış kütleleri. Chokevine, üzerinde hareket eden herkesi büyük ölçüde yavaşlatır. Çoğu fazla kabile, çocukları karanlık çökmeden eve gelmeleri için korkutmanın bir yolu olarak, geceleri bu bitkinin çocukları öldürdüğü hikayeler uydurdular.</Plant_Chokevine.description>
   
   <!-- EN: cypress tree -->
-  <Plant_TreeCypress.label>Selvi ağacı</Plant_TreeCypress.label>
+  <Plant_TreeCypress.label>selvi ağacı</Plant_TreeCypress.label>
   <!-- EN: A tall coniferous tree often found in swamps. Despite its slow growth, planting these trees can be profitable as a low-effort, long-term investment because they yield so much usable wood. -->
   <Plant_TreeCypress.description>Genellikle bataklıklarda bulunan uzun iğne yapraklı ağaç. Yavaş büyümesine rağmen, bu ağaçları dikmek, çok fazla kullanılabilir odun sağladıklarından, az çaba gerektiren, uzun vadeli bir yatırım olarak karlı olabilir.</Plant_TreeCypress.description>
   
@@ -17,7 +17,7 @@
   <Plant_TreeMaple.description>Farklı üç köşeli yaprağı ile kolayca tanımlanabilen bir orta boy ağaç</Plant_TreeMaple.description>
   
   <!-- EN: willow tree -->
-  <Plant_TreeWillow.label>Söğüt ağacı</Plant_TreeWillow.label>
+  <Plant_TreeWillow.label>söğüt ağacı</Plant_TreeWillow.label>
   <!-- EN: One of the fastest growing shade trees, willows provide a beautiful, leafy canopy. It doesn't yield much usable wood. -->
   <Plant_TreeWillow.description>En hızlı büyüyen gölge ağaçlarından biri olan söğütler, güzel, yapraklı bir gölgelik sağlar. Fazla kullanılabilir odun vermez.</Plant_TreeWillow.description>
   

--- a/Core/DefInjected/ThingDef/Plants_Wild_Temperate.xml
+++ b/Core/DefInjected/ThingDef/Plants_Wild_Temperate.xml
@@ -2,42 +2,42 @@
 <LanguageData>
   
   <!-- EN: astragalus -->
-  <Plant_Astragalus.label>Geven</Plant_Astragalus.label>
+  <Plant_Astragalus.label>geven</Plant_Astragalus.label>
   <!-- EN: A small perennial wildflower that grows in alpine climates. -->
   <Plant_Astragalus.description>Alp iklimlerinde yetişen küçük, çok uzun ömürlü bir kır çiçeği.</Plant_Astragalus.description>
   
   <!-- EN: berry bush -->
-  <Plant_Berry.label>Ahududu çalısı</Plant_Berry.label>
+  <Plant_Berry.label>böğürtlen çalısı</Plant_Berry.label>
   <!-- EN: A bushy wild plant which yields delicious berries. Berries can be cooked, but they're also good to eat even when raw. -->
   <Plant_Berry.description>Lezzetli meyveler veren gür yabani bir bitki. Meyveler pişirilebilir, ancak çiğ olduklarında bile yemek için iyidirler..</Plant_Berry.description>
   
   <!-- EN: dandelions -->
-  <Plant_Dandelion.label>Karahindiba</Plant_Dandelion.label>
+  <Plant_Dandelion.label>karahindiba</Plant_Dandelion.label>
   <!-- EN: A tiny yellow flower which grows in large clusters. Though it is often considered a weed, dandelions in bloom are quite beautiful. -->
   <Plant_Dandelion.description>Büyük salkımlarda büyüyen küçük sarı bir çiçek. Genellikle bir ot olarak kabul edilse de, çiçek açan karahindiba oldukça güzeldir.</Plant_Dandelion.description>
   
   <!-- EN: moss -->
-  <Plant_Moss.label>Yosun</Plant_Moss.label>
+  <Plant_Moss.label>yosun</Plant_Moss.label>
   <!-- EN: Wild moss that grows in clumps in areas of low light and cool temperatures. Moss takes a long time to grow, but is very frost-resistant. -->
   <Plant_Moss.description>Düşük ışık ve soğuk sıcaklık alanlarında kümeler halinde büyüyen yabani yosun. Yosunun büyümesi uzun zaman alır, ancak dona karşı çok dayanıklıdır.</Plant_Moss.description>
   
   <!-- EN: birch tree -->
-  <Plant_TreeBirch.label>Huş Ağacı</Plant_TreeBirch.label>
+  <Plant_TreeBirch.label>huş ağacı</Plant_TreeBirch.label>
   <!-- EN: A temperate-biome tree known for its thin, white, paper-like bark. -->
   <Plant_TreeBirch.description>İnce ve yaprak gibi olan kabuğuyla bilinen kuzeyde yetişen bir ağaç.</Plant_TreeBirch.description>
   
   <!-- EN: oak tree -->
-  <Plant_TreeOak.label>Meşe ağacı</Plant_TreeOak.label>
+  <Plant_TreeOak.label>meşe ağacı</Plant_TreeOak.label>
   <!-- EN: A hardwood tree. Oaks take a long time to grow, but their wood is so strong that 'oak' is used as a metaphor for strength across many cultures. -->
   <Plant_TreeOak.description>Sert bir ağaç. Meşelerin büyümesi uzun zaman alır, ancak odunları o kadar güçlüdür ki 'meşe' birçok kültürde güç için bir metafor olarak kullanılır.</Plant_TreeOak.description>
   
   <!-- EN: pine tree -->
-  <Plant_TreePine.label>Çam Ağacı</Plant_TreePine.label>
+  <Plant_TreePine.label>Çam ağacı</Plant_TreePine.label>
   <!-- EN: A large conifer covered with prickly pine cones. It grows in a distinctive conical shape. -->
   <Plant_TreePine.description>Dikenli çam kozalakları ile kaplı büyük bir kozalaklı ağaç. Kendine özgü bir konik şekilde büyür.</Plant_TreePine.description>
   
   <!-- EN: poplar tree -->
-  <Plant_TreePoplar.label>Kavak Ağacı</Plant_TreePoplar.label>
+  <Plant_TreePoplar.label>kavak ağacı</Plant_TreePoplar.label>
   <!-- EN: A softwood tree that grows very fast. Unfortunately, its wood is weak and so it yields less useful material than hardwood trees. -->
   <Plant_TreePoplar.description>Çok hızlı büyüyen bir yumuşak ağaç. Ne yazık ki, odunu incedir ve bu nedenle sert ağaçlardan daha az kullanışlı malzeme verir..</Plant_TreePoplar.description>
   

--- a/Core/DefInjected/ThingDef/Plants_Wild_Tropical.xml
+++ b/Core/DefInjected/ThingDef/Plants_Wild_Tropical.xml
@@ -27,7 +27,7 @@
   <Plant_TreeBamboo.description>Sık bahçelerde yetişen, hızlı büyüyen ağaç benzeri bir bitki. Bambu, ahşap benzeri bir malzeme için hasat edilebilir. Bitkinin kendisi güzel değil.</Plant_TreeBamboo.description>
   
   <!-- EN: cecropia tree -->
-  <Plant_TreeCecropia.label>Karınca ağacı</Plant_TreeCecropia.label>
+  <Plant_TreeCecropia.label>karınca ağacı</Plant_TreeCecropia.label>
   <!-- EN: One of the most common rainforest trees. Cecropia grows very fast, but yields little usable wood. -->
   <Plant_TreeCecropia.description>En yaygın yağmur ormanı ağaçların biri. Çok hızlı büyür, ancak çok az odun verir.</Plant_TreeCecropia.description>
   
@@ -37,7 +37,7 @@
   <Plant_TreePalm.description>Çok geniş yapraklardan oluşan bir küme ile tepesinde uzun, çıplak bir gövdeye sahip tropik bir ağaç. Ne yazık ki, bu çeşitte yenilebilir hindistan cevizi yetişmez.</Plant_TreePalm.description>
   
   <!-- EN: teak tree -->
-  <Plant_TreeTeak.label>Tik ağacı</Plant_TreeTeak.label>
+  <Plant_TreeTeak.label>tik ağacı</Plant_TreeTeak.label>
   <!-- EN: An exceptionally strong hardwood tree that grows in warm climates. Because teak wood is so durable and water-resistant, it was used to form the keel of wooden sailing ships in ancient times. -->
   <Plant_TreeTeak.description>Sıcak iklimlerde yetişen son derece güçlü bir sert ağaç. Tik ağacı çok dayanıklı ve suya dayanıklı olduğu için eski zamanlarda ahşap yelkenli gemilerin omurgasını oluşturmak için kullanılıyordu.</Plant_TreeTeak.description>
   

--- a/Core/DefInjected/ThingDef/Things_Special.xml
+++ b/Core/DefInjected/ThingDef/Things_Special.xml
@@ -2,15 +2,15 @@
 <LanguageData>
   
   <!-- EN: drop pod -->
-  <ActiveDropPod.label>İniş Podu</ActiveDropPod.label>
+  <ActiveDropPod.label>İniş podu</ActiveDropPod.label>
   
   <!-- EN: drop pod -->
-  <ActiveDropPodMechanoid.label>İniş Podu</ActiveDropPodMechanoid.label>
+  <ActiveDropPodMechanoid.label>İniş podu</ActiveDropPodMechanoid.label>
   
   <!-- EN: fire -->
-  <Fire.label>Ateş</Fire.label>
+  <Fire.label>ateş</Fire.label>
   
   <!-- EN: spark -->
-  <Spark.label>Kıvılcım</Spark.label>
+  <Spark.label>kıvılcım</Spark.label>
   
 </LanguageData>

--- a/Core/DefInjected/ThoughtDef/Alcohol_Beer.xml
+++ b/Core/DefInjected/ThoughtDef/Alcohol_Beer.xml
@@ -2,18 +2,18 @@
 <LanguageData>
   
   <!-- EN: alcohol withdrawal -->
-  <AlcoholWithdrawal.stages.alcohol_withdrawal.label>alkol çekilme</AlcoholWithdrawal.stages.alcohol_withdrawal.label>
+  <AlcoholWithdrawal.stages.alcohol_withdrawal.label>alkol yoksunluğu</AlcoholWithdrawal.stages.alcohol_withdrawal.label>
   <!-- EN: Feeling shaky. Everything pisses me off. I keep thinking of drinking. -->
   <AlcoholWithdrawal.stages.alcohol_withdrawal.description>Titrek hissediyorum. Her şey beni sinirlendiriyor. Sürekli içmeyi düşünüyorum.</AlcoholWithdrawal.stages.alcohol_withdrawal.description>
   
   <!-- EN: mild hangover -->
   <Hungover.stages.mild_hangover.label>hafif akşamdan kalma</Hungover.stages.mild_hangover.label>
   <!-- EN: The headache is almost gone. -->
-  <Hungover.stages.mild_hangover.description>Baş ağrısı neredeyse gitti</Hungover.stages.mild_hangover.description>
+  <Hungover.stages.mild_hangover.description>Baş ağrısı neredeyse gitti.</Hungover.stages.mild_hangover.description>
   <!-- EN: serious hangover -->
   <Hungover.stages.serious_hangover.label>ciddi akşamdan kalma</Hungover.stages.serious_hangover.label>
   <!-- EN: My head hurts from all that liquor. -->
-  <Hungover.stages.serious_hangover.description>Bütün o içkiden başım ağrıyor</Hungover.stages.serious_hangover.description>
+  <Hungover.stages.serious_hangover.description>Bütün o içkiden başım ağrıyor.</Hungover.stages.serious_hangover.description>
   <!-- EN: pounding hangover -->
   <Hungover.stages.pounding_hangover.label>şiddetli akşamdan kalma</Hungover.stages.pounding_hangover.label>
   <!-- EN: It feels like a gaggle of geese are pecking at my skull. -->
@@ -24,9 +24,9 @@
   <!-- EN: I just feel a bit more relaxed after that drink. That's good. -->
   <Inebriated.stages.alcohol_warmth.description>O içkiden sonra biraz daha rahatlamış hissediyorum. Bu iyi.</Inebriated.stages.alcohol_warmth.description>
   <!-- EN: quite inebriated -->
-  <Inebriated.stages.quite_inebriated.label>oldukça sarhoş</Inebriated.stages.quite_inebriated.label>
+  <Inebriated.stages.quite_inebriated.label>epeyce sarhoş</Inebriated.stages.quite_inebriated.label>
   <!-- EN: I'm a bit wobbly! And this is quite enjoyable. -->
-  <Inebriated.stages.quite_inebriated.description>biraz titriyorum! Ve bu oldukça keyifli.</Inebriated.stages.quite_inebriated.description>
+  <Inebriated.stages.quite_inebriated.description>Biraz titriyorum! Ve bu oldukça keyifli.</Inebriated.stages.quite_inebriated.description>
   <!-- EN: drunk -->
   <Inebriated.stages.drunk.label>sarhoş</Inebriated.stages.drunk.label>
   <!-- EN: I feel so uninhibited and unafraid! This is a great time! -->
@@ -34,6 +34,6 @@
   <!-- EN: hammered -->
   <Inebriated.stages.hammered.label>aşırı sarhoş</Inebriated.stages.hammered.label>
   <!-- EN: Wooo! What's going on? -->
-  <Inebriated.stages.hammered.description>Vay! Neler oluyor?</Inebriated.stages.hammered.description>
+  <Inebriated.stages.hammered.description>Vay canına! Neler oluyor?</Inebriated.stages.hammered.description>
   
 </LanguageData>

--- a/Core/DefInjected/ThoughtDef/Ambrosia.xml
+++ b/Core/DefInjected/ThoughtDef/Ambrosia.xml
@@ -7,7 +7,7 @@
   <AmbrosiaHigh.stages.ambrosia_warmth.description>Bu ambrosia beni daha rahat hissettiriyor ve aynı zamanda bana enerji veriyor.</AmbrosiaHigh.stages.ambrosia_warmth.description>
   
   <!-- EN: ambrosia withdrawal -->
-  <AmbrosiaWithdrawal.stages.ambrosia_withdrawal.label>ambrosia çekilme</AmbrosiaWithdrawal.stages.ambrosia_withdrawal.label>
+  <AmbrosiaWithdrawal.stages.ambrosia_withdrawal.label>ambrosia yoksunluğu</AmbrosiaWithdrawal.stages.ambrosia_withdrawal.label>
   <!-- EN: I feel heavy and cold all the time. I never thought I'd want a piece of fruit so much. -->
   <AmbrosiaWithdrawal.stages.ambrosia_withdrawal.description>Her zaman ağır ve soğuk hissediyorum. Bir parça meyveyi bu kadar çok isteyeceğimi hiç düşünmemiştim.</AmbrosiaWithdrawal.stages.ambrosia_withdrawal.description>
   

--- a/Core/DefInjected/ThoughtDef/GoJuice.xml
+++ b/Core/DefInjected/ThoughtDef/GoJuice.xml
@@ -2,12 +2,12 @@
 <LanguageData>
   
   <!-- EN: high on go-juice -->
-  <GoJuiceHigh.stages.high_on_gojuice.label>go-juice yüksekdoz</GoJuiceHigh.stages.high_on_gojuice.label>
+  <GoJuiceHigh.stages.high_on_gojuice.label>go-juice etkisinde</GoJuiceHigh.stages.high_on_gojuice.label>
   <!-- EN: I feel pumped but steady. I am the bullet in flight, ready to cut through you. -->
   <GoJuiceHigh.stages.high_on_gojuice.description>Pompalanmış ama sabit hissediyorum. Ben uçan kurşunum, seni kesmeye hazırım.</GoJuiceHigh.stages.high_on_gojuice.description>
   
   <!-- EN: go-juice withdrawal -->
-  <GoJuiceWithdrawal.stages.gojuice_withdrawal.label>go-juice çekilme</GoJuiceWithdrawal.stages.gojuice_withdrawal.label>
+  <GoJuiceWithdrawal.stages.gojuice_withdrawal.label>go-juice yoksunluğu</GoJuiceWithdrawal.stages.gojuice_withdrawal.label>
   <!-- EN: I'm all fuzzy and can't think straight. My limbs feel heavy, I'm tired and hungry, everything hurts. And why won't my eyes focus properly? -->
   <GoJuiceWithdrawal.stages.gojuice_withdrawal.description>Tamamen bulanık ve doğru düşünemiyorum. Uzuvlarım ağırlaşıyor, yorgun ve açım, her şey ağrıyor. Ve neden gözlerim düzgün odaklanmıyor?</GoJuiceWithdrawal.stages.gojuice_withdrawal.description>
   

--- a/Core/DefInjected/ThoughtDef/Precepts_AteNutrientPaste.xml
+++ b/Core/DefInjected/ThoughtDef/Precepts_AteNutrientPaste.xml
@@ -2,7 +2,7 @@
 <LanguageData>
   
   <!-- EN: ate nutrient paste meal -->
-  <AteNutrientPasteMeal.stages.ate_nutrient_paste_meal.label>lapa yedim</AteNutrientPasteMeal.stages.ate_nutrient_paste_meal.label>
+  <AteNutrientPasteMeal.stages.ate_nutrient_paste_meal.label>besin ezmesi yedim</AteNutrientPasteMeal.stages.ate_nutrient_paste_meal.label>
   <!-- EN: I had to eat a disgusting, tasteless meal. I know it keeps you alive, but nobody wants to swallow that glop. -->
   <AteNutrientPasteMeal.stages.ate_nutrient_paste_meal.description>İğrenç, tatsız bir yemek yemek zorunda kaldım. Beni hayatta tuttuğunu biliyorum, ama kimse o lapayı yutmak istemiyor.</AteNutrientPasteMeal.stages.ate_nutrient_paste_meal.description>
   

--- a/Core/DefInjected/ThoughtDef/Psychite_Flake.xml
+++ b/Core/DefInjected/ThoughtDef/Psychite_Flake.xml
@@ -2,7 +2,7 @@
 <LanguageData>
   
   <!-- EN: high on flake -->
-  <FlakeHigh.stages.high_on_flake.label>yüksek flake</FlakeHigh.stages.high_on_flake.label>
+  <FlakeHigh.stages.high_on_flake.label>flake etkisinde</FlakeHigh.stages.high_on_flake.label>
   <!-- EN: So good, so good. -->
   <FlakeHigh.stages.high_on_flake.description>Çok iyi, çok iyi.</FlakeHigh.stages.high_on_flake.description>
   

--- a/Core/DefInjected/ThoughtDef/Psychite_Tea.xml
+++ b/Core/DefInjected/ThoughtDef/Psychite_Tea.xml
@@ -2,7 +2,7 @@
 <LanguageData>
   
   <!-- EN: psychite tea -->
-  <PsychiteTeaHigh.stages.psychite_tea.label>psikiyatri çayı</PsychiteTeaHigh.stages.psychite_tea.label>
+  <PsychiteTeaHigh.stages.psychite_tea.label>psikotik çayı</PsychiteTeaHigh.stages.psychite_tea.label>
   <!-- EN: Drinking that tea made me feel great. I love having this energy! -->
   <PsychiteTeaHigh.stages.psychite_tea.description>O çayı içmek beni harika hissettirdi. Bu enerjiye sahip olmayı seviyorum!</PsychiteTeaHigh.stages.psychite_tea.description>
   

--- a/Core/DefInjected/ThoughtDef/Psychite_Yayo.xml
+++ b/Core/DefInjected/ThoughtDef/Psychite_Yayo.xml
@@ -2,12 +2,12 @@
 <LanguageData>
   
   <!-- EN: psychite withdrawal -->
-  <PsychiteWithdrawal.stages.psychite_withdrawal.label>psikiyatrik çekilme</PsychiteWithdrawal.stages.psychite_withdrawal.label>
+  <PsychiteWithdrawal.stages.psychite_withdrawal.label>yayo yoksunluğu</PsychiteWithdrawal.stages.psychite_withdrawal.label>
   <!-- EN: God I'm tired. Everything's so slow and boring. Especially me. -->
   <PsychiteWithdrawal.stages.psychite_withdrawal.description>Tanrım yorgunum. Her şey çok yavaş ve sıkıcı. Özellikle ben.</PsychiteWithdrawal.stages.psychite_withdrawal.description>
   
   <!-- EN: high on yayo -->
-  <YayoHigh.stages.high_on_yayo.label>yüksek yayo</YayoHigh.stages.high_on_yayo.label>
+  <YayoHigh.stages.high_on_yayo.label>yayo etkisinde</YayoHigh.stages.high_on_yayo.label>
   <!-- EN: Feeling pumped! Let's do this! -->
   <YayoHigh.stages.high_on_yayo.description>Pompalanmış hissediyorum! Bunu yapalım!</YayoHigh.stages.high_on_yayo.description>
   

--- a/Core/DefInjected/ThoughtDef/Smokeleaf.xml
+++ b/Core/DefInjected/ThoughtDef/Smokeleaf.xml
@@ -2,12 +2,12 @@
 <LanguageData>
   
   <!-- EN: high on smokeleaf -->
-  <SmokeleafHigh.stages.high_on_smokeleaf.label>yüksek tütün</SmokeleafHigh.stages.high_on_smokeleaf.label>
+  <SmokeleafHigh.stages.high_on_smokeleaf.label>tütün etkisinde</SmokeleafHigh.stages.high_on_smokeleaf.label>
   <!-- EN: I'm, like, stoned, man. -->
   <SmokeleafHigh.stages.high_on_smokeleaf.description>Kafayı bulmuş gibiyim, dostum.</SmokeleafHigh.stages.high_on_smokeleaf.description>
   
   <!-- EN: smokeleaf withdrawal -->
-  <SmokeleafWithdrawal.stages.smokeleaf_withdrawal.label>tütün açlığı</SmokeleafWithdrawal.stages.smokeleaf_withdrawal.label>
+  <SmokeleafWithdrawal.stages.smokeleaf_withdrawal.label>tütün yoksunluğu</SmokeleafWithdrawal.stages.smokeleaf_withdrawal.label>
   <!-- EN: I really wish I could smoke. I feel jittery, and my gut has that anxious sensation all the time. -->
   <SmokeleafWithdrawal.stages.smokeleaf_withdrawal.description>Sigara içmeyi gerçekten çok isterdim. Gergin hissediyorum ve bağırsaklarım her zaman bu endişeli hissi veriyor.</SmokeleafWithdrawal.stages.smokeleaf_withdrawal.description>
   

--- a/Core/DefInjected/ThoughtDef/Thoughts_Memory_Death.xml
+++ b/Core/DefInjected/ThoughtDef/Thoughts_Memory_Death.xml
@@ -12,38 +12,38 @@
   <KnowColonistDied.stages.colonist_died.description>İnsanlarımızdan birisini kaybettik. İnsanlarımızı hayatta tutabilmeliyiz.</KnowColonistDied.stages.colonist_died.description>
   
   <!-- EN: justified execution of colonist -->
-  <KnowColonistExecuted.stages.justified_execution_of_colonist.label>koloniste ötenazi yapıldı</KnowColonistExecuted.stages.justified_execution_of_colonist.label>
+  <KnowColonistExecuted.stages.justified_execution_of_colonist.label>kolonistin haklı infazı</KnowColonistExecuted.stages.justified_execution_of_colonist.label>
   <!-- EN: A guilty colonist was executed. It was justified, but still sad. -->
-  <KnowColonistExecuted.stages.justified_execution_of_colonist.description>Bir koloniste ötenazi uygulandı. İnsanca ama yine de üzücü.</KnowColonistExecuted.stages.justified_execution_of_colonist.description>
+  <KnowColonistExecuted.stages.justified_execution_of_colonist.description>Suçlu bir kolonist idam edildi. Haklıydı ama yine de üzücüydü.</KnowColonistExecuted.stages.justified_execution_of_colonist.description>
   <!-- EN: colonist euthanized -->
-  <KnowColonistExecuted.stages.colonist_euthanized.label>kolonist idam edildi</KnowColonistExecuted.stages.colonist_euthanized.label>
+  <KnowColonistExecuted.stages.colonist_euthanized.label>koloniste ötenazi yapıldı</KnowColonistExecuted.stages.colonist_euthanized.label>
   <!-- EN: A colonist was euthanized. It was humane, but still sad. -->
-  <KnowColonistExecuted.stages.colonist_euthanized.description>Bir kolonist soğukkanlılıkla idam edildi. Bu çok fenaydı.</KnowColonistExecuted.stages.colonist_euthanized.description>
+  <KnowColonistExecuted.stages.colonist_euthanized.description>Bir koloniste ötenazi uygulandı. İnsanca ama yine de üzücü.</KnowColonistExecuted.stages.colonist_euthanized.description>
   <!-- EN: colonist executed -->
-  <KnowColonistExecuted.stages.colonist_executed.label>kolonist organı alındığı için öldü</KnowColonistExecuted.stages.colonist_executed.label>
+  <KnowColonistExecuted.stages.colonist_executed.label>kolonist idam edildi</KnowColonistExecuted.stages.colonist_executed.label>
   <!-- EN: A colonist was killed in cold blood. It seemed a bit evil. -->
-  <KnowColonistExecuted.stages.colonist_executed.description>Bir kolonist organı alındığı için öldü. Bu gerçekten korkunç.</KnowColonistExecuted.stages.colonist_executed.description>
+  <KnowColonistExecuted.stages.colonist_executed.description>Bir kolonist soğukkanlılıkla öldürüldü. Biraz şeytanca görünüyordu.</KnowColonistExecuted.stages.colonist_executed.description>
   <!-- EN: colonist organ-harvested -->
-  <KnowColonistExecuted.stages.colonist_organharvested.label>kolonist organ hasat</KnowColonistExecuted.stages.colonist_organharvested.label>
+  <KnowColonistExecuted.stages.colonist_organharvested.label>kolonist organı alındığı için öldü</KnowColonistExecuted.stages.colonist_organharvested.label>
   <!-- EN: A colonist died because someone took body parts from them. It's horrible. -->
-  <KnowColonistExecuted.stages.colonist_organharvested.description>Biri ondan vücut parçaları aldığı için bir kolonist öldü. Bu korkunç.</KnowColonistExecuted.stages.colonist_organharvested.description>
+  <KnowColonistExecuted.stages.colonist_organharvested.description>Bir kolonist, birisinin kendisinden vücut parçaları alması nedeniyle öldü. Bu korkunç.</KnowColonistExecuted.stages.colonist_organharvested.description>
   
   <!-- EN: justified execution -->
-  <KnowGuestExecuted.stages.justified_execution.label>birisine ötenazi yapıldı</KnowGuestExecuted.stages.justified_execution.label>
+  <KnowGuestExecuted.stages.justified_execution.label>haklı infaz</KnowGuestExecuted.stages.justified_execution.label>
   <!-- EN: A guilty prisoner or guest was executed. It was justified, but still sad. -->
-  <KnowGuestExecuted.stages.justified_execution.description>Bir mahkuma veya misafire ötenazi yapıldı. İnsanca ama yine de üzücü.</KnowGuestExecuted.stages.justified_execution.description>
+  <KnowGuestExecuted.stages.justified_execution.description>Suçlu bir mahkum veya misafir idam edildi. Haklıydı ama yine de üzücüydü.</KnowGuestExecuted.stages.justified_execution.description>
   <!-- EN: someone was euthanized -->
-  <KnowGuestExecuted.stages.someone_was_euthanized.label>birisi idam edildi</KnowGuestExecuted.stages.someone_was_euthanized.label>
+  <KnowGuestExecuted.stages.someone_was_euthanized.label>birisine ötenazi yapıldı</KnowGuestExecuted.stages.someone_was_euthanized.label>
   <!-- EN: A prisoner or guest was euthanized. It was humane, but still sad. -->
-  <KnowGuestExecuted.stages.someone_was_euthanized.description>Bir mahkum veya misafir soğukkanlılıkla idam edildi. Bu çok fenaydı.</KnowGuestExecuted.stages.someone_was_euthanized.description>
+  <KnowGuestExecuted.stages.someone_was_euthanized.description>Bir mahkuma veya misafire ötenazi yapıldı. İnsanca ama yine de üzücü.</KnowGuestExecuted.stages.someone_was_euthanized.description>
   <!-- EN: someone was executed -->
-  <KnowGuestExecuted.stages.someone_was_executed.label>birisi organı alındığı için öldü</KnowGuestExecuted.stages.someone_was_executed.label>
+  <KnowGuestExecuted.stages.someone_was_executed.label>birisi idam edildi</KnowGuestExecuted.stages.someone_was_executed.label>
   <!-- EN: A prisoner or guest was killed in cold blood. It seemed a bit evil. -->
-  <KnowGuestExecuted.stages.someone_was_executed.description>Bir mahkum veya misafir organı alındığı için öldü. Bu gerçekten korkunç.</KnowGuestExecuted.stages.someone_was_executed.description>
+  <KnowGuestExecuted.stages.someone_was_executed.description>Bir mahkum veya misafir soğukkanlılıkla öldürüldü. Biraz şeytanca görünüyordu.</KnowGuestExecuted.stages.someone_was_executed.description>
   <!-- EN: someone was organ-murdered -->
-  <KnowGuestExecuted.stages.someone_was_organmurdered.label>biri organ öldürülmüş.</KnowGuestExecuted.stages.someone_was_organmurdered.label>
+  <KnowGuestExecuted.stages.someone_was_organmurdered.label>biri organ mafyalığı yüzünden öldü</KnowGuestExecuted.stages.someone_was_organmurdered.label>
   <!-- EN: A prisoner or guest died because the colony took body parts from them. It's horrible. -->
-  <KnowGuestExecuted.stages.someone_was_organmurdered.description>Bir mahkum ya da misafir öldü çünkü koloni ondan ceset parçaları aldı. Korkunç bir şey.</KnowGuestExecuted.stages.someone_was_organmurdered.description>
+  <KnowGuestExecuted.stages.someone_was_organmurdered.description>Bir mahkum ya da misafir öldü çünkü koloni ondan vücut parçaları aldı. Korkunç bir şey.</KnowGuestExecuted.stages.someone_was_organmurdered.description>
   
   <!-- EN: innocent prisoner died -->
   <KnowPrisonerDiedInnocent.stages.innocent_prisoner_died.label>masum mahkum öldü</KnowPrisonerDiedInnocent.stages.innocent_prisoner_died.label>
@@ -56,9 +56,9 @@
   <MyAuntDied.stages.my_aunt_died.description>Teyzem vefat etti... Anne yarısıydı...</MyAuntDied.stages.my_aunt_died.description>
   
   <!-- EN: my brother {0} died -->
-  <MyBrotherDied.stages.my_brother_died.label>kardeşim {0} vefat etti</MyBrotherDied.stages.my_brother_died.label>
+  <MyBrotherDied.stages.my_brother_died.label>kardeşim {0} öldü</MyBrotherDied.stages.my_brother_died.label>
   <!-- EN: My brother died. My own flesh and blood... -->
-  <MyBrotherDied.stages.my_brother_died.description>Kardeşim öldü. Benim kanımdı, canımdı...</MyBrotherDied.stages.my_brother_died.description>
+  <MyBrotherDied.stages.my_brother_died.description>Kardeşimi kaybettim. Benim kanımdı, canımdı...</MyBrotherDied.stages.my_brother_died.description>
   
   <!-- EN: my cousin {0} died -->
   <MyCousinDied.stages.my_cousin_died.label>kuzenim {0} öldü</MyCousinDied.stages.my_cousin_died.label>
@@ -66,7 +66,7 @@
   <MyCousinDied.stages.my_cousin_died.description>Kuzenim vefat etti. Onunla büyümüştük. Benim kanımdı, canımdı...</MyCousinDied.stages.my_cousin_died.description>
   
   <!-- EN: my daughter {0} died -->
-  <MyDaughterDied.stages.my_daughter_died.label>kızım {0} vefat etti</MyDaughterDied.stages.my_daughter_died.label>
+  <MyDaughterDied.stages.my_daughter_died.label>kızım {0} öldü</MyDaughterDied.stages.my_daughter_died.label>
   <!-- EN: My daughter is dead. My own flesh and blood... -->
   <MyDaughterDied.stages.my_daughter_died.description>Güzel kızımı kaybettim... Benim canım, kanım. Nasıl ayakta kalabilirim?</MyDaughterDied.stages.my_daughter_died.description>
   
@@ -76,14 +76,14 @@
   <MyFatherDied.stages.my_father_died.description>Babam göçtü gitti. Ona minnettarım ve özleyeceğim.</MyFatherDied.stages.my_father_died.description>
   
   <!-- EN: my fiance {0} died -->
-  <MyFianceDied.stages.my_fiance_died.label>nişanlım {0} vefat etti</MyFianceDied.stages.my_fiance_died.label>
+  <MyFianceDied.stages.my_fiance_died.label>nişanlım {0} öldü</MyFianceDied.stages.my_fiance_died.label>
   <!-- EN: My fiance died. Such a man... my future is gone. -->
-  <MyFianceDied.stages.my_fiance_died.description>Nişanlım öldü. Böyle bir adam... Geleceğimi kaybettim...</MyFianceDied.stages.my_fiance_died.description>
+  <MyFianceDied.stages.my_fiance_died.description>Nişanlımı kaybettim. Böyle bir adam... Geleceğimi kaybettim...</MyFianceDied.stages.my_fiance_died.description>
   
   <!-- EN: my fiancée {0} died -->
   <MyFianceeDied.stages.my_fiance_died.label>nişanlım {0} öldü</MyFianceeDied.stages.my_fiance_died.label>
   <!-- EN: My fiancée died. Such a woman... my future is gone. -->
-  <MyFianceeDied.stages.my_fiance_died.description>Nişanlım öldü. Böyle bir kadın... Geleceğimi kaybettim...</MyFianceeDied.stages.my_fiance_died.description>
+  <MyFianceeDied.stages.my_fiance_died.description>Nişanlımı kaybettim. Böyle bir kadın... Geleceğimi kaybettim...</MyFianceeDied.stages.my_fiance_died.description>
   
   <!-- EN: my grandchild {0} died -->
   <MyGrandchildDied.stages.my_grandchild_died.label>torunum {0} öldü</MyGrandchildDied.stages.my_grandchild_died.label>
@@ -93,15 +93,15 @@
   <!-- EN: my grandparent {0} died -->
   <MyGrandparentDied.stages.my_grandparent_died.label>aile büyüğüm {0} öldü</MyGrandparentDied.stages.my_grandparent_died.label>
   <!-- EN: My grandparent died. -->
-  <MyGrandparentDied.stages.my_grandparent_died.description>Ona yakışır bir torun olmaya devam edeceğim.</MyGrandparentDied.stages.my_grandparent_died.description>
+  <MyGrandparentDied.stages.my_grandparent_died.description>Aile büyüğümü kaybettim. Ona yakışır bir torun olmaya devam edeceğim.</MyGrandparentDied.stages.my_grandparent_died.description>
   
   <!-- EN: my half-sibling {0} died -->
-  <MyHalfSiblingDied.stages.my_halfsibling_died.label>ikizim {0} öldü</MyHalfSiblingDied.stages.my_halfsibling_died.label>
+  <MyHalfSiblingDied.stages.my_halfsibling_died.label>üvey kardeşim {0} öldü</MyHalfSiblingDied.stages.my_halfsibling_died.label>
   <!-- EN: My half-sibling died. My own flesh and blood... -->
-  <MyHalfSiblingDied.stages.my_halfsibling_died.description>İkizimi kaybettim. Kendimi kaybetmek üzereyim. Tanrım yardım et!</MyHalfSiblingDied.stages.my_halfsibling_died.description>
+  <MyHalfSiblingDied.stages.my_halfsibling_died.description>Üvey kardeşimi kaybettim. Kendimi kaybetmek üzereyim. Tanrım yardım et!</MyHalfSiblingDied.stages.my_halfsibling_died.description>
   
   <!-- EN: my husband {0} died -->
-  <MyHusbandDied.stages.my_husband_died.label>eşim {0} vefat etti</MyHusbandDied.stages.my_husband_died.label>
+  <MyHusbandDied.stages.my_husband_died.label>eşim {0} öldü</MyHusbandDied.stages.my_husband_died.label>
   <!-- EN: My husband is dead. I am alone. -->
   <MyHusbandDied.stages.my_husband_died.description>Kocamı, yol arkadaşımı kaybettim. Artık çok yalnızım.</MyHusbandDied.stages.my_husband_died.description>
   
@@ -111,7 +111,7 @@
   <MyKinDied.stages.my_kin_died.description>Yakınımı kaybettim.</MyKinDied.stages.my_kin_died.description>
   
   <!-- EN: my lover {0} died -->
-  <MyLoverDied.stages.my_lover_died.label>sevgilim {0} vefat etti</MyLoverDied.stages.my_lover_died.label>
+  <MyLoverDied.stages.my_lover_died.label>sevgilim {0} öldü</MyLoverDied.stages.my_lover_died.label>
   <!-- EN: My lover died. I am so alone. -->
   <MyLoverDied.stages.my_lover_died.description>Sevgilimi kaybettim... Çok yalnız hissediyorum...</MyLoverDied.stages.my_lover_died.description>
   
@@ -131,12 +131,12 @@
   <MyNieceDied.stages.my_niece_died.description>Yeğenim öldü... Çok muhteşem bir kızdı...</MyNieceDied.stages.my_niece_died.description>
   
   <!-- EN: my sister {0} died -->
-  <MySisterDied.stages.my_sister_died.label>kız kardeşim {0} vefat etti</MySisterDied.stages.my_sister_died.label>
+  <MySisterDied.stages.my_sister_died.label>kız kardeşim {0} öldü</MySisterDied.stages.my_sister_died.label>
   <!-- EN: My sister died. My own flesh and blood... -->
   <MySisterDied.stages.my_sister_died.description>Kardeşim öldü. Benim kanımdı, canımdı...</MySisterDied.stages.my_sister_died.description>
   
   <!-- EN: my son {0} died -->
-  <MySonDied.stages.my_son_died.label>oğlum {0} vefat etti</MySonDied.stages.my_son_died.label>
+  <MySonDied.stages.my_son_died.label>oğlum {0} öldü</MySonDied.stages.my_son_died.label>
   <!-- EN: My son is dead. My own flesh and blood... -->
   <MySonDied.stages.my_son_died.description>Oğlumu kaybettim... Benim canım, kanım. Nasıl ayakta kalabilirim?</MySonDied.stages.my_son_died.description>
   
@@ -146,7 +146,7 @@
   <MyUncleDied.stages.my_uncle_died.description>Amcam vefat etti... Baba yarısıydı...</MyUncleDied.stages.my_uncle_died.description>
   
   <!-- EN: my wife {0} died -->
-  <MyWifeDied.stages.my_wife_died.label>karım {0} vefat etti</MyWifeDied.stages.my_wife_died.label>
+  <MyWifeDied.stages.my_wife_died.label>karım {0} öldü</MyWifeDied.stages.my_wife_died.label>
   <!-- EN: My wife is dead. I am alone. -->
   <MyWifeDied.stages.my_wife_died.description>Karımı, yol arkadaşımı kaybettim. Artık çok yalnızım.</MyWifeDied.stages.my_wife_died.description>
   

--- a/Core/DefInjected/ThoughtDef/Thoughts_Memory_Debug.xml
+++ b/Core/DefInjected/ThoughtDef/Thoughts_Memory_Debug.xml
@@ -2,12 +2,12 @@
 <LanguageData>
   
   <!-- EN: debug bad thought -->
-  <DebugBad.stages.debug_bad_thought.label>Debug kötü düşüncesi</DebugBad.stages.debug_bad_thought.label>
+  <DebugBad.stages.debug_bad_thought.label>debug kötü düşüncesi</DebugBad.stages.debug_bad_thought.label>
   <!-- EN: Test thought for debugging. -->
   <DebugBad.stages.debug_bad_thought.description>Debug için test düşüncesi.</DebugBad.stages.debug_bad_thought.description>
   
   <!-- EN: debug good thought -->
-  <DebugGood.stages.debug_good_thought.label>Debug iyi düşüncesi</DebugGood.stages.debug_good_thought.label>
+  <DebugGood.stages.debug_good_thought.label>debug iyi düşüncesi</DebugGood.stages.debug_good_thought.label>
   <!-- EN: Test thought for debugging. -->
   <DebugGood.stages.debug_good_thought.description>Debug için test düşüncesi.</DebugGood.stages.debug_good_thought.description>
   

--- a/Core/DefInjected/ThoughtDef/Thoughts_Memory_Eating.xml
+++ b/Core/DefInjected/ThoughtDef/Thoughts_Memory_Eating.xml
@@ -19,37 +19,37 @@
   <!-- EN: cooked cannibalism -->
   <AteHumanlikeMeatAsIngredientCannibal.stages.cooked_cannibalism.label>leziz bir yamyamlıktı</AteHumanlikeMeatAsIngredientCannibal.stages.cooked_cannibalism.label>
   <!-- EN: I ate a meal made from the meat of another human. So pleasurable. If only I had some fava beans and a nice chianti. -->
-  <AteHumanlikeMeatAsIngredientCannibal.stages.cooked_cannibalism.description>Bir hayvan gibi başka bir insanın etini çiğ çiğ yedim. Çok ... lezzetliydi.</AteHumanlikeMeatAsIngredientCannibal.stages.cooked_cannibalism.description>
+  <AteHumanlikeMeatAsIngredientCannibal.stages.cooked_cannibalism.description>Başka bir insanın etinden yapılmış bir yemek yedim. Çok keyifliydi. Keşke biraz bakla ve güzel bir chianti olsaydı.</AteHumanlikeMeatAsIngredientCannibal.stages.cooked_cannibalism.description>
   
   <!-- EN: raw cannibalism -->
-  <AteHumanlikeMeatDirect.stages.raw_cannibalism.label>ham yamyamlık</AteHumanlikeMeatDirect.stages.raw_cannibalism.label>
+  <AteHumanlikeMeatDirect.stages.raw_cannibalism.label>çiğ yamyamlık</AteHumanlikeMeatDirect.stages.raw_cannibalism.label>
   <!-- EN: I ate the meat of another human, raw, like an animal. This is a nightmare. -->
   <AteHumanlikeMeatDirect.stages.raw_cannibalism.description>Başka bir insanın etini bir hayvan gibi çiğ olarak yedim. Bu bir kabus.</AteHumanlikeMeatDirect.stages.raw_cannibalism.description>
   
   <!-- EN: raw cannibalism -->
-  <AteHumanlikeMeatDirectCannibal.stages.raw_cannibalism.label>zorunlu yamyamlık yaptım</AteHumanlikeMeatDirectCannibal.stages.raw_cannibalism.label>
+  <AteHumanlikeMeatDirectCannibal.stages.raw_cannibalism.label>çiğ yamyamlık</AteHumanlikeMeatDirectCannibal.stages.raw_cannibalism.label>
   <!-- EN: I ate the meat of another human, raw, like an animal. It was so... succulent. -->
-  <AteHumanlikeMeatDirectCannibal.stages.raw_cannibalism.description>Başka bir insanın etini yemek zorunda kaldım. Çiğ, adete hayvan gibi. Bu bir kabus olmalı...</AteHumanlikeMeatDirectCannibal.stages.raw_cannibalism.description>
+  <AteHumanlikeMeatDirectCannibal.stages.raw_cannibalism.description>Başka bir insanın çiğ etini, bir hayvan gibi yedim. Çok... lezzetliydi.</AteHumanlikeMeatDirectCannibal.stages.raw_cannibalism.description>
   
   <!-- EN: ate cooked insect meat -->
   <AteInsectMeatAsIngredient.stages.ate_cooked_insect_meat.label>pişmiş böcek eti yedim</AteInsectMeatAsIngredient.stages.ate_cooked_insect_meat.label>
   <!-- EN: I ate a meal cooked from gray, slimy insect meat. The seasoning partly covered the taste, but there were glands and fluid pockets in there that I can't identify. -->
-  <AteInsectMeatAsIngredient.stages.ate_cooked_insect_meat.description>Gri, yapışkan böcek etinden pişirilmiş bir yemek yedim. Baharat kısmen tadı kapattı, ama orada tanımlayamadığım bezler ve sıvı cepleri vardı..</AteInsectMeatAsIngredient.stages.ate_cooked_insect_meat.description>
+  <AteInsectMeatAsIngredient.stages.ate_cooked_insect_meat.description>Gri, yapışkan böcek etinden pişirilmiş bir yemek yedim. Baharat kısmen tadı kapattı, ama orada tanımlayamadığım bezler ve sıvı cepleri vardı.</AteInsectMeatAsIngredient.stages.ate_cooked_insect_meat.description>
   
   <!-- EN: ate insect meat -->
   <AteInsectMeatDirect.stages.ate_insect_meat.label>böcek eti yedim</AteInsectMeatDirect.stages.ate_insect_meat.label>
   <!-- EN: I ate some gray, slimy insect meat. It was, possibly, the most disgusting thing I've ever tasted. -->
-  <AteInsectMeatDirect.stages.ate_insect_meat.description>Biraz gri, yapışkan böcek eti yedim. Muhtemelen şimdiye kadar tattığım en iğrenç şeydi..</AteInsectMeatDirect.stages.ate_insect_meat.description>
+  <AteInsectMeatDirect.stages.ate_insect_meat.description>Biraz gri, yapışkan böcek eti yedim. Muhtemelen şimdiye kadar tattığım en iğrenç şeydi.</AteInsectMeatDirect.stages.ate_insect_meat.description>
   
   <!-- EN: ate kibble -->
-  <AteKibble.stages.ate_kibble.label>kuru mama yedim</AteKibble.stages.ate_kibble.label>
+  <AteKibble.stages.ate_kibble.label>hayvan maması yedim</AteKibble.stages.ate_kibble.label>
   <!-- EN: I had to eat animal kibble. It's like I don't get to be human any more. -->
   <AteKibble.stages.ate_kibble.description>Hayvan maması yemek zorunda kaldım. Sanki artık insan olamayacakmışım gibi.</AteKibble.stages.ate_kibble.description>
   
   <!-- EN: ate lavish meal -->
   <AteLavishMeal.stages.ate_lavish_meal.label>lüks yemek yedim</AteLavishMeal.stages.ate_lavish_meal.label>
   <!-- EN: That lavish meal was amazing. It nourished my body and my soul. -->
-  <AteLavishMeal.stages.ate_lavish_meal.description>Lüks yemek çok lezzetliydi. Bedenimi ve neredeyse ruhumu besledi...</AteLavishMeal.stages.ate_lavish_meal.description>
+  <AteLavishMeal.stages.ate_lavish_meal.description>Bu lüks yemek çok lezzetliydi. Bedenimi ve neredeyse ruhumu besledi.</AteLavishMeal.stages.ate_lavish_meal.description>
   
   <!-- EN: ate raw food -->
   <AteRawFood.stages.ate_raw_food.label>çiğ yemek yedim</AteRawFood.stages.ate_raw_food.label>

--- a/Core/DefInjected/ThoughtDef/Thoughts_Memory_Gatherings.xml
+++ b/Core/DefInjected/ThoughtDef/Thoughts_Memory_Gatherings.xml
@@ -2,7 +2,7 @@
 <LanguageData>
   
   <!-- EN: attended concert -->
-  <AttendedConcert.stages.attended_concert.label>konsere katıldı </AttendedConcert.stages.attended_concert.label>
+  <AttendedConcert.stages.attended_concert.label>konsere katıldı</AttendedConcert.stages.attended_concert.label>
   <!-- EN: I enjoyed listening to that performance. -->
   <AttendedConcert.stages.attended_concert.description>O performansı zevkle dinledim.</AttendedConcert.stages.attended_concert.description>
   
@@ -27,12 +27,12 @@
   <GotMarried.stages.got_married_to.description>Evlendim! Hayat olasılıklarla dolu!</GotMarried.stages.got_married_to.description>
   
   <!-- EN: held concert -->
-  <HeldConcert.stages.held_concert.label> konser düzenlendi</HeldConcert.stages.held_concert.label>
+  <HeldConcert.stages.held_concert.label>konser düzenlendi</HeldConcert.stages.held_concert.label>
   <!-- EN: They loved me. They really loved me. -->
   <HeldConcert.stages.held_concert.description>Beni sevdiler. Beni gerçekten sevdiler.</HeldConcert.stages.held_concert.description>
   
   <!-- EN: inspirational speech -->
-  <InspirationalSpeech.stages.inspirational_speech.label>ilham verici konuşma</InspirationalSpeech.stages.inspirational_speech.label>
+  <InspirationalSpeech.stages.inspirational_speech.label>İlham verici konuşma</InspirationalSpeech.stages.inspirational_speech.label>
   <!-- EN: That speech was moving emotionally and intellectually. I am filled with purpose. -->
   <InspirationalSpeech.stages.inspirational_speech.description>Bu konuşma duygusal ve entelektüel olarak hareket ediyordu. Amaç doluyum.</InspirationalSpeech.stages.inspirational_speech.description>
   
@@ -42,8 +42,8 @@
   <TerribleSpeech.stages.terrible_speech.description>O konuşma iğrençti. Gerçekten ne kadar az umudumuz olduğunu anlamamı sağladı.</TerribleSpeech.stages.terrible_speech.description>
   
   <!-- EN: uninspiring speech -->
-  <UninspiringSpeech.stages.uninspiring_speech.label>ilham vermeyen konuşma</UninspiringSpeech.stages.uninspiring_speech.label>
+  <UninspiringSpeech.stages.uninspiring_speech.label>İlham vermeyen konuşma</UninspiringSpeech.stages.uninspiring_speech.label>
   <!-- EN: That speech was more awkward than inspiring. If that's who we're listening to, I'm worried. -->
-  <UninspiringSpeech.stages.uninspiring_speech.description>Bu konuşma ilham vermekten daha garipti. Eğer dinlediğimiz kişi buysa, endişeleniyorum.</UninspiringSpeech.stages.uninspiring_speech.description>
+  <UninspiringSpeech.stages.uninspiring_speech.description>Bu konuşma ilham vermektense daha çok garipti. Eğer dinlediğimiz kişi buysa, endişeleniyorum.</UninspiringSpeech.stages.uninspiring_speech.description>
   
 </LanguageData>

--- a/Core/DefInjected/ThoughtDef/Thoughts_Memory_Lost.xml
+++ b/Core/DefInjected/ThoughtDef/Thoughts_Memory_Lost.xml
@@ -57,9 +57,9 @@
   <MyGrandchildLost.stages.my_grandchild_lost.description>Torunum kayboldu. Umarım bir gün bize dönerler.</MyGrandchildLost.stages.my_grandchild_lost.description>
   
   <!-- EN: my grandparent {0} lost -->
-  <MyGrandparentLost.stages.my_grandparent_lost.label>Dedem-nenem {0} kayboldu</MyGrandparentLost.stages.my_grandparent_lost.label>
+  <MyGrandparentLost.stages.my_grandparent_lost.label>aile büyüğüm {0} kayboldu</MyGrandparentLost.stages.my_grandparent_lost.label>
   <!-- EN: My grandparent has gone lost. -->
-  <MyGrandparentLost.stages.my_grandparent_lost.description>Dedem-nenem kayboldu.</MyGrandparentLost.stages.my_grandparent_lost.description>
+  <MyGrandparentLost.stages.my_grandparent_lost.description>Aile büyüğüm kayboldu.</MyGrandparentLost.stages.my_grandparent_lost.description>
   
   <!-- EN: my half-sibling {0} lost -->
   <MyHalfSiblingLost.stages.my_halfsibling_lost.label>üvey kardeşim {0} kayboldu</MyHalfSiblingLost.stages.my_halfsibling_lost.label>
@@ -92,7 +92,7 @@
   <MyNephewLost.stages.my_nephew_lost.description>Yeğenim kayboldu. Umarım bir gün bize geri döner.</MyNephewLost.stages.my_nephew_lost.description>
   
   <!-- EN: my niece {0} lost -->
-  <MyNieceLost.stages.my_niece_lost.label>erkekyeğenim {0} kayboldu</MyNieceLost.stages.my_niece_lost.label>
+  <MyNieceLost.stages.my_niece_lost.label>erkek yeğenim {0} kayboldu</MyNieceLost.stages.my_niece_lost.label>
   <!-- EN: My niece has gone lost. I hope she will get back to us someday. -->
   <MyNieceLost.stages.my_niece_lost.description>Yeğenim kayboldu. Umarım bir gün bize geri döner.</MyNieceLost.stages.my_niece_lost.description>
   
@@ -117,7 +117,7 @@
   <MyWifeLost.stages.my_wife_lost.description>Karım kayboldu. Umarım bir gün bize geri döner.</MyWifeLost.stages.my_wife_lost.description>
   
   <!-- EN: my rival {0} lost -->
-  <PawnWithBadOpinionLost.stages.my_rival_lost.label>rakibim {0} kayboldu</PawnWithBadOpinionLost.stages.my_rival_lost.label>
+  <PawnWithBadOpinionLost.stages.my_rival_lost.label>rakibim {0} cehennemin dibine girdi</PawnWithBadOpinionLost.stages.my_rival_lost.label>
   <!-- EN: Serves them right. At least there's some justice in this world. -->
   <PawnWithBadOpinionLost.stages.my_rival_lost.description>Onlara hizmet ederdi. En azından bu dünyada biraz adalet var.</PawnWithBadOpinionLost.stages.my_rival_lost.description>
   

--- a/Core/DefInjected/ThoughtDef/Thoughts_Memory_Misc.xml
+++ b/Core/DefInjected/ThoughtDef/Thoughts_Memory_Misc.xml
@@ -12,7 +12,7 @@
   <BondedAnimalBanished.stages.bonded_animal_banished.description>Bağlı hayvanım sürgüne gönderildi!</BondedAnimalBanished.stages.bonded_animal_banished.description>
   
   <!-- EN: I butchered humanlike -->
-  <ButcheredHumanlikeCorpse.stages.I_butchered_humanlike.label>insan birini doğradım...</ButcheredHumanlikeCorpse.stages.I_butchered_humanlike.label>
+  <ButcheredHumanlikeCorpse.stages.I_butchered_humanlike.label>İnsan birini doğradım...</ButcheredHumanlikeCorpse.stages.I_butchered_humanlike.label>
   <!-- EN: I butchered someone up like an animal. -->
   <ButcheredHumanlikeCorpse.stages.I_butchered_humanlike.description>Birini hayvan gibi doğradım.</ButcheredHumanlikeCorpse.stages.I_butchered_humanlike.description>
   
@@ -20,7 +20,7 @@
   <ButcheredHumanlikeCorpseOpinion.stages.butchered_humanlike_corpse.label>doğranmış insan cesedi</ButcheredHumanlikeCorpseOpinion.stages.butchered_humanlike_corpse.label>
   
   <!-- EN: catharsis -->
-  <Catharsis.stages.catharsis.label>içini döktü</Catharsis.stages.catharsis.label>
+  <Catharsis.stages.catharsis.label>İçini döktü</Catharsis.stages.catharsis.label>
   <!-- EN: It felt good to finally unbottle my feelings. -->
   <Catharsis.stages.catharsis.description>Sonunda hislerimi dışarı vurmak mükemmel bir duyguydu.</Catharsis.stages.catharsis.description>
   
@@ -65,10 +65,10 @@
   <!-- EN: failed to rescue {0} -->
   <FailedToRescueRelative.stages.failed_to_rescue.label>{0} kurtarılamadı</FailedToRescueRelative.stages.failed_to_rescue.label>
   <!-- EN: We had a chance to rescue my relative, and failed. I could have helped! -->
-  <FailedToRescueRelative.stages.failed_to_rescue.description>Bir akrabamı kurtarma şansımız oldu ve olmadı. yardım edebilirdim!</FailedToRescueRelative.stages.failed_to_rescue.description>
+  <FailedToRescueRelative.stages.failed_to_rescue.description>Bir akrabamı kurtarma şansımız oldu ama olmadı. Yardım edebilirdim!</FailedToRescueRelative.stages.failed_to_rescue.description>
   
   <!-- EN: freed from slavery -->
-  <FreedFromSlavery.stages.freed_from_slavery.label>kölelikten kurtulmuş </FreedFromSlavery.stages.freed_from_slavery.label>
+  <FreedFromSlavery.stages.freed_from_slavery.label>kölelikten kurtuldu</FreedFromSlavery.stages.freed_from_slavery.label>
   <!-- EN: I have been freed from slavery. I'm so thankful! -->
   <FreedFromSlavery.stages.freed_from_slavery.description>Kölelikten kurtuldum. Çok minnettarım!</FreedFromSlavery.stages.freed_from_slavery.description>
   
@@ -88,7 +88,7 @@
   <KnowBuriedInSarcophagus.stages.buried_in_sarcophagus.description>Bu koloni, birini süslü bir lahite gömdü. Ruhları huzur içinde yatsın.</KnowBuriedInSarcophagus.stages.buried_in_sarcophagus.description>
   
   <!-- EN: we butchered humanlike -->
-  <KnowButcheredHumanlikeCorpse.stages.we_butchered_humanlike.label>insan birini doğradık</KnowButcheredHumanlikeCorpse.stages.we_butchered_humanlike.label>
+  <KnowButcheredHumanlikeCorpse.stages.we_butchered_humanlike.label>İnsan birini doğradık</KnowButcheredHumanlikeCorpse.stages.we_butchered_humanlike.label>
   <!-- EN: We butchered someone up like an animal. -->
   <KnowButcheredHumanlikeCorpse.stages.we_butchered_humanlike.description>Bir insanı hayvanmış gibi kestik</KnowButcheredHumanlikeCorpse.stages.we_butchered_humanlike.description>
   
@@ -108,7 +108,7 @@
   <KnowPrisonerSold.stages.prisoner_sold.description>Bu koloni bir esiri köleliğe sattı. Bu endişe verici bir düşünce.</KnowPrisonerSold.stages.prisoner_sold.description>
   
   <!-- EN: my organ harvested -->
-  <MyOrganHarvested.stages.my_organ_harvested.label>organım çalındı</MyOrganHarvested.stages.my_organ_harvested.label>
+  <MyOrganHarvested.stages.my_organ_harvested.label>organım hasat edildi</MyOrganHarvested.stages.my_organ_harvested.label>
   <!-- EN: The colony harvested body parts from me! They're breaking me down like an old engine! -->
   <MyOrganHarvested.stages.my_organ_harvested.description>Koloni bir vücut parçamı benden çaldı! Beni eski bir motor gibi kırıyorlar!</MyOrganHarvested.stages.my_organ_harvested.description>
   
@@ -138,12 +138,12 @@
   <ObservedLayingRottingCorpse.stages.observed_rotting_corpse.description>Yerde yatan çürümüş bir ceset gördüm. İğrençti.</ObservedLayingRottingCorpse.stages.observed_rotting_corpse.description>
   
   <!-- EN: on duty -->
-  <OnDuty.stages.on_duty.label>iş başında</OnDuty.stages.on_duty.label>
+  <OnDuty.stages.on_duty.label>İş başında</OnDuty.stages.on_duty.label>
   <!-- EN: I have a job to do. -->
   <OnDuty.stages.on_duty.description>Yapacak bir işim var.</OnDuty.stages.on_duty.description>
   
   <!-- EN: prisoner banished to death -->
-  <PrisonerBanishedToDie.stages.prisoner_banished_to_death.label>mahkum ölüme sürgün edildi </PrisonerBanishedToDie.stages.prisoner_banished_to_death.label>
+  <PrisonerBanishedToDie.stages.prisoner_banished_to_death.label>mahkum ölüme sürgün edildi</PrisonerBanishedToDie.stages.prisoner_banished_to_death.label>
   <!-- EN: We banished a prisoner in such a way that there's almost no way they'll survive. -->
   <PrisonerBanishedToDie.stages.prisoner_banished_to_death.description>Bir tutsağı öyle bir sürgüne gönderdik ki, hayatta kalmalarının neredeyse hiçbir yolu yok.</PrisonerBanishedToDie.stages.prisoner_banished_to_death.description>
   

--- a/Core/DefInjected/ThoughtDef/Thoughts_Memory_RoomStats.xml
+++ b/Core/DefInjected/ThoughtDef/Thoughts_Memory_RoomStats.xml
@@ -31,7 +31,7 @@
   <AteInImpressiveDiningRoom.stages.wondrously_impressive_dining_room.description>Yemeğimi harika bir yemek odasında yedim. Karnım da, ruhum da doydu!</AteInImpressiveDiningRoom.stages.wondrously_impressive_dining_room.description>
   
   <!-- EN: decent rec room -->
-  <JoyActivityInImpressiveRecRoom.stages.decent_rec_room.label>iyi dinlenme odası</JoyActivityInImpressiveRecRoom.stages.decent_rec_room.label>
+  <JoyActivityInImpressiveRecRoom.stages.decent_rec_room.label>İyi dinlenme odası</JoyActivityInImpressiveRecRoom.stages.decent_rec_room.label>
   <!-- EN: I had fun in a decent rec room. -->
   <JoyActivityInImpressiveRecRoom.stages.decent_rec_room.description>İyi bir dinlenme odasında eğlendim.</JoyActivityInImpressiveRecRoom.stages.decent_rec_room.description>
   <!-- EN: slightly impressive rec room -->
@@ -72,7 +72,7 @@
   <!-- EN: I had to sleep in a mediocre barracks with other people around. I really don't like this. -->
   <SleptInBarracks.stages.mediocre_barracks.description>Etraftaki diğer insanlarla vasat bir barakada uyumak zorunda kaldım. Bunu gerçekten sevmiyorum.</SleptInBarracks.stages.mediocre_barracks.description>
   <!-- EN: decent barracks -->
-  <SleptInBarracks.stages.decent_barracks.label>iyi baraka</SleptInBarracks.stages.decent_barracks.label>
+  <SleptInBarracks.stages.decent_barracks.label>İyi baraka</SleptInBarracks.stages.decent_barracks.label>
   <!-- EN: I slept in a decent barracks, but I really dislike sharing a sleeping space. -->
   <SleptInBarracks.stages.decent_barracks.description>İyi bir barakada uyudum, ama bir uyku alanını paylaşmaktan gerçekten hoşlanmıyorum.</SleptInBarracks.stages.decent_barracks.description>
   <!-- EN: slightly impressive barracks -->
@@ -92,7 +92,7 @@
   <!-- EN: I slept in an extremely impressive barracks. I don't even mind sharing it. -->
   <SleptInBarracks.stages.extremely_impressive_barracks.description>Son derece etkileyici bir barakada uyudum. Paylaşmayı umursamıyorum bile.</SleptInBarracks.stages.extremely_impressive_barracks.description>
   <!-- EN: unbelievably impressive barracks -->
-  <SleptInBarracks.stages.unbelievably_impressive_barracks.label>inanılmaz etkileyici baraka</SleptInBarracks.stages.unbelievably_impressive_barracks.label>
+  <SleptInBarracks.stages.unbelievably_impressive_barracks.label>İnanılmaz etkileyici baraka</SleptInBarracks.stages.unbelievably_impressive_barracks.label>
   <!-- EN: The barracks I slept in was so impressive that I don't even mind sharing it. -->
   <SleptInBarracks.stages.unbelievably_impressive_barracks.description>Uyuduğum baraka o kadar etkileyiciydi ki paylaşmaktan çekinmiyorum bile.</SleptInBarracks.stages.unbelievably_impressive_barracks.description>
   <!-- EN: wondrously impressive barracks -->
@@ -125,7 +125,7 @@
   <!-- EN: I slept in an extremely impressive bedroom. It was marvelous. -->
   <SleptInBedroom.stages.extremely_impressive_bedroom.description>Son derece etkileyici bir yatak odasında uyudum. Muhteşemdi.</SleptInBedroom.stages.extremely_impressive_bedroom.description>
   <!-- EN: unbelievably impressive bedroom -->
-  <SleptInBedroom.stages.unbelievably_impressive_bedroom.label>inanılmaz etkileyici yatak odası</SleptInBedroom.stages.unbelievably_impressive_bedroom.label>
+  <SleptInBedroom.stages.unbelievably_impressive_bedroom.label>İnanılmaz etkileyici yatak odası</SleptInBedroom.stages.unbelievably_impressive_bedroom.label>
   <!-- EN: I slept in an unbelievably impressive bedroom. It was truly astounding. -->
   <SleptInBedroom.stages.unbelievably_impressive_bedroom.description>İnanılmaz etkileyici bir yatak odasında uyudum. Gerçekten şaşırtıcıydı.</SleptInBedroom.stages.unbelievably_impressive_bedroom.description>
   <!-- EN: wondrously impressive bedroom -->

--- a/Core/DefInjected/ThoughtDef/Thoughts_Memory_Social.xml
+++ b/Core/DefInjected/ThoughtDef/Thoughts_Memory_Social.xml
@@ -137,7 +137,7 @@
   <KindWordsMood.stages.kind_words.description>Nazik sözlerle bahşedildim! Ne güzel bir insan!</KindWordsMood.stages.kind_words.description>
   
   <!-- EN: rapport built -->
-  <RapportBuilt.stages.rapport_built.label>ilişki kurdu</RapportBuilt.stages.rapport_built.label>
+  <RapportBuilt.stages.rapport_built.label>İlişki kurdu</RapportBuilt.stages.rapport_built.label>
   
   <!-- EN: rebuffed me -->
   <RebuffedMyRomanceAttempt.stages.rebuffed_me.label>beni geri çevirdi</RebuffedMyRomanceAttempt.stages.rebuffed_me.label>

--- a/Core/DefInjected/ThoughtDef/Thoughts_Memory_Special.xml
+++ b/Core/DefInjected/ThoughtDef/Thoughts_Memory_Special.xml
@@ -2,7 +2,7 @@
 <LanguageData>
   
   <!-- EN: strange feeling -->
-  <ArtifactMoodBoost.stages.strange_feeling.label>Garip duygu</ArtifactMoodBoost.stages.strange_feeling.label>
+  <ArtifactMoodBoost.stages.strange_feeling.label>garip duygu</ArtifactMoodBoost.stages.strange_feeling.label>
   <!-- EN: I feel strange, but also very relaxed. -->
   <ArtifactMoodBoost.stages.strange_feeling.description>Garip hissediyorum, ama aynı zamanda çok rahat.</ArtifactMoodBoost.stages.strange_feeling.description>
   

--- a/Core/DefInjected/ThoughtDef/Thoughts_Situation_General.xml
+++ b/Core/DefInjected/ThoughtDef/Thoughts_Situation_General.xml
@@ -67,36 +67,36 @@
   <EnvironmentHot.stages.blistering_hot.description>Burası çok sıcak. Sanırım bu sıcaktan ölebilirim!</EnvironmentHot.stages.blistering_hot.description>
   
   <!-- EN: human leather {0} -->
-  <HumanLeatherApparelHappy.stages.human_leather.label>insan derisi {0}</HumanLeatherApparelHappy.stages.human_leather.label>
+  <HumanLeatherApparelHappy.stages.human_leather.label>İnsan derisi {0}</HumanLeatherApparelHappy.stages.human_leather.label>
   <!-- EN: I enjoy wearing the suffering of others. -->
   <HumanLeatherApparelHappy.stages.human_leather.description>Başkalarının acılarını giymekten zevk alıyorum.</HumanLeatherApparelHappy.stages.human_leather.description>
   <!-- EN: human leather {0} (+1) -->
-  <HumanLeatherApparelHappy.stages.human_leather_1.label>insan derisi {0} (+1)</HumanLeatherApparelHappy.stages.human_leather_1.label>
+  <HumanLeatherApparelHappy.stages.human_leather_1.label>İnsan derisi {0} (+1)</HumanLeatherApparelHappy.stages.human_leather_1.label>
   <!-- EN: This will scare them. All will know my power. -->
   <HumanLeatherApparelHappy.stages.human_leather_1.description>Bu onları korkutacaktır. Herkes gücümü bilecek.</HumanLeatherApparelHappy.stages.human_leather_1.description>
   <!-- EN: human leather {0} (+2) -->
-  <HumanLeatherApparelHappy.stages.human_leather_2.label>insan derisi {0} (+2)</HumanLeatherApparelHappy.stages.human_leather_2.label>
+  <HumanLeatherApparelHappy.stages.human_leather_2.label>İnsan derisi {0} (+2)</HumanLeatherApparelHappy.stages.human_leather_2.label>
   <!-- EN: The faces on my clothes aren't smiling, but they make *me* happy. -->
   <HumanLeatherApparelHappy.stages.human_leather_2.description>Giysilerimdeki yüzler gülmüyor ama *beni* mutlu ediyor.</HumanLeatherApparelHappy.stages.human_leather_2.description>
   <!-- EN: human leather {0} etc -->
-  <HumanLeatherApparelHappy.stages.human_leather_etc.label>insan derisi {0} etc</HumanLeatherApparelHappy.stages.human_leather_etc.label>
+  <HumanLeatherApparelHappy.stages.human_leather_etc.label>İnsan derisi {0} etc</HumanLeatherApparelHappy.stages.human_leather_etc.label>
   <!-- EN: The flesh! The flesh signals my triumph! -->
   <HumanLeatherApparelHappy.stages.human_leather_etc.description>Et! Et, zaferimi işaret ediyor!</HumanLeatherApparelHappy.stages.human_leather_etc.description>
   
   <!-- EN: human leather {0} -->
-  <HumanLeatherApparelSad.stages.human_leather.label>insan derisi</HumanLeatherApparelSad.stages.human_leather.label>
+  <HumanLeatherApparelSad.stages.human_leather.label>İnsan derisi</HumanLeatherApparelSad.stages.human_leather.label>
   <!-- EN: Wearing parts of someone's body is... disturbing. -->
   <HumanLeatherApparelSad.stages.human_leather.description>Birinin vücudunun bazı kısımlarını giymek... rahatsız edici.</HumanLeatherApparelSad.stages.human_leather.description>
   <!-- EN: human leather {0} (+1) -->
-  <HumanLeatherApparelSad.stages.human_leather_1.label>insan derisi {0} (+1)</HumanLeatherApparelSad.stages.human_leather_1.label>
+  <HumanLeatherApparelSad.stages.human_leather_1.label>İnsan derisi {0} (+1)</HumanLeatherApparelSad.stages.human_leather_1.label>
   <!-- EN: I'm dressed like an insane person. -->
   <HumanLeatherApparelSad.stages.human_leather_1.description>Deli gibi giyindim.</HumanLeatherApparelSad.stages.human_leather_1.description>
   <!-- EN: human leather {0} (+2) -->
-  <HumanLeatherApparelSad.stages.human_leather_2.label>insan derisi {0} (+2)</HumanLeatherApparelSad.stages.human_leather_2.label>
+  <HumanLeatherApparelSad.stages.human_leather_2.label>İnsan derisi {0} (+2)</HumanLeatherApparelSad.stages.human_leather_2.label>
   <!-- EN: I think there may be a face on my clothes. Oh no... my clothes *are* a face. -->
   <HumanLeatherApparelSad.stages.human_leather_2.description>Sanırım kıyafetlerimde bir yüz olabilir. Oh hayır... kıyafetlerim *bir yüz*.</HumanLeatherApparelSad.stages.human_leather_2.description>
   <!-- EN: human leather {0} etc -->
-  <HumanLeatherApparelSad.stages.human_leather_etc.label>insan derisi {0} etc</HumanLeatherApparelSad.stages.human_leather_etc.label>
+  <HumanLeatherApparelSad.stages.human_leather_etc.label>İnsan derisi {0} etc</HumanLeatherApparelSad.stages.human_leather_etc.label>
   <!-- EN: I look like a freak from a horror show, and I feel like I'm living in a horror show. -->
   <HumanLeatherApparelSad.stages.human_leather_etc.description>Bir korku şovundan kaçmış bir ucube gibi görünüyorum ve bir korku şovunda yaşıyormuşum gibi hissediyorum.</HumanLeatherApparelSad.stages.human_leather_etc.description>
   
@@ -115,7 +115,7 @@
   <Sick.stages.sick.description>Kendimi pek iyi hissetmiyorum.</Sick.stages.sick.description>
   
   <!-- EN: interesting textbook -->
-  <SkillBookPassion.stages.interesting_textbook.label>ilginç kılavuz</SkillBookPassion.stages.interesting_textbook.label>
+  <SkillBookPassion.stages.interesting_textbook.label>İlginç kılavuz</SkillBookPassion.stages.interesting_textbook.label>
   <!-- EN: This book covers a topic I'm passionate about. It's interesting. -->
   <SkillBookPassion.stages.interesting_textbook.description>Bu kitap tutkuyla bağlı olduğum bir konuyu ele alıyor. İlginç.</SkillBookPassion.stages.interesting_textbook.description>
   <!-- EN: amazing textbook -->

--- a/Core/DefInjected/ThoughtDef/Thoughts_Situation_Needs.xml
+++ b/Core/DefInjected/ThoughtDef/Thoughts_Situation_Needs.xml
@@ -2,51 +2,51 @@
 <LanguageData>
   
   <!-- EN: chemical want -->
-  <DrugDesireFascination.stages.chemical_want.label>kimyasal istek</DrugDesireFascination.stages.chemical_want.label>
+  <DrugDesireFascination.stages.chemical_want.label>uyuşturucu isteği</DrugDesireFascination.stages.chemical_want.label>
   <!-- EN: I'm fascinated by drugs. I want to experience them more. -->
   <DrugDesireFascination.stages.chemical_want.description>Uyuşturucuya bayılırım. Onları daha fazla deneyimlemek istiyorum.</DrugDesireFascination.stages.chemical_want.description>
   <!-- EN: chemical hunger -->
-  <DrugDesireFascination.stages.chemical_hunger.label>kimyasal açlık</DrugDesireFascination.stages.chemical_hunger.label>
+  <DrugDesireFascination.stages.chemical_hunger.label>uyuşturucu açlığı</DrugDesireFascination.stages.chemical_hunger.label>
   <!-- EN: I'm fascinated by drugs. I want to experience them a lot harder. -->
   <DrugDesireFascination.stages.chemical_hunger.description>Uyuşturucuya bayılırım. Onları daha çok deneyimlemek istiyorum.</DrugDesireFascination.stages.chemical_hunger.description>
   <!-- EN: chemical starvation -->
-  <DrugDesireFascination.stages.chemical_starvation.label>kimyasal açlık</DrugDesireFascination.stages.chemical_starvation.label>
+  <DrugDesireFascination.stages.chemical_starvation.label>aşırı uyuşturucu açlığı</DrugDesireFascination.stages.chemical_starvation.label>
   <!-- EN: I'm fascinated by drugs. I want them! More intensity! -->
   <DrugDesireFascination.stages.chemical_starvation.description>Uyuşturucuya bayılırım. Onları istiyorum! Daha fazla!</DrugDesireFascination.stages.chemical_starvation.description>
   
   <!-- EN: chemical comfort -->
-  <DrugDesireFascinationSatisfied.stages.chemical_comfort.label>kimyasal konfor</DrugDesireFascinationSatisfied.stages.chemical_comfort.label>
+  <DrugDesireFascinationSatisfied.stages.chemical_comfort.label>uyuşturucu konforu</DrugDesireFascinationSatisfied.stages.chemical_comfort.label>
   <!-- EN: I'm fascinated by drugs, and I love satisfying my desires. -->
   <DrugDesireFascinationSatisfied.stages.chemical_comfort.description>Uyuşturucu beni büyülüyor ve arzularımı tatmin etmeyi seviyorum.</DrugDesireFascinationSatisfied.stages.chemical_comfort.description>
   <!-- EN: chemical satisfaction -->
-  <DrugDesireFascinationSatisfied.stages.chemical_satisfaction.label>kimyasal tatmin</DrugDesireFascinationSatisfied.stages.chemical_satisfaction.label>
+  <DrugDesireFascinationSatisfied.stages.chemical_satisfaction.label>uyuşturucu tatmini</DrugDesireFascinationSatisfied.stages.chemical_satisfaction.label>
   <!-- EN: I'm fascinated by drugs, and I am fully satisfied with my drug consumption. -->
   <DrugDesireFascinationSatisfied.stages.chemical_satisfaction.description>Uyuşturuculardan çok etkileniyorum ve uyuşturucu tüketimimden tamamen memnunum.</DrugDesireFascinationSatisfied.stages.chemical_satisfaction.description>
   
   <!-- EN: chemical want -->
-  <DrugDesireInterest.stages.chemical_want.label>kimyasal istek</DrugDesireInterest.stages.chemical_want.label>
+  <DrugDesireInterest.stages.chemical_want.label>uyuşturucu isteği</DrugDesireInterest.stages.chemical_want.label>
   <!-- EN: I'm interested in drugs. I want to try more. -->
   <DrugDesireInterest.stages.chemical_want.description>Uyuşturucuyla ilgileniyorum. Daha fazlasını denemek istiyorum.</DrugDesireInterest.stages.chemical_want.description>
   <!-- EN: chemical hunger -->
-  <DrugDesireInterest.stages.chemical_hunger.label>kimyasal açlık</DrugDesireInterest.stages.chemical_hunger.label>
+  <DrugDesireInterest.stages.chemical_hunger.label>uyuşturucu açlığı</DrugDesireInterest.stages.chemical_hunger.label>
   <!-- EN: I'm interested in drugs. I want to experience a lot more. -->
   <DrugDesireInterest.stages.chemical_hunger.description>Uyuşturucuyla ilgileniyorum. Daha fazlasını deneyimlemek istiyorum.</DrugDesireInterest.stages.chemical_hunger.description>
   <!-- EN: chemical starvation -->
-  <DrugDesireInterest.stages.chemical_starvation.label>kimyasal açlık</DrugDesireInterest.stages.chemical_starvation.label>
+  <DrugDesireInterest.stages.chemical_starvation.label>aşırı uyuşturucu açlığı</DrugDesireInterest.stages.chemical_starvation.label>
   <!-- EN: I'm interested in drugs. I want to consume drugs really badly. -->
   <DrugDesireInterest.stages.chemical_starvation.description>Uyuşturucuyla ilgileniyorum. Uyuşturucuyu çok fena tüketmek istiyorum.</DrugDesireInterest.stages.chemical_starvation.description>
   
   <!-- EN: chemical comfort -->
-  <DrugDesireInterestSatisfied.stages.chemical_comfort.label>kimyasal konfor</DrugDesireInterestSatisfied.stages.chemical_comfort.label>
+  <DrugDesireInterestSatisfied.stages.chemical_comfort.label>uyuşturucu konforu</DrugDesireInterestSatisfied.stages.chemical_comfort.label>
   <!-- EN: I'm interested in drugs. I enjoyed satisfying my desire. -->
   <DrugDesireInterestSatisfied.stages.chemical_comfort.description>Uyuşturucuyla ilgileniyorum. Arzumu tatmin etmekten zevk aldım.</DrugDesireInterestSatisfied.stages.chemical_comfort.description>
   <!-- EN: chemical satisfaction -->
-  <DrugDesireInterestSatisfied.stages.chemical_satisfaction.label>kimyasal tatmin</DrugDesireInterestSatisfied.stages.chemical_satisfaction.label>
+  <DrugDesireInterestSatisfied.stages.chemical_satisfaction.label>uyuşturucu tatmini</DrugDesireInterestSatisfied.stages.chemical_satisfaction.label>
   <!-- EN: I'm interested in drugs. I am really satisfied with all the drugs I've gotten recently. -->
   <DrugDesireInterestSatisfied.stages.chemical_satisfaction.description>Uyuşturucuyla ilgileniyorum. Son zamanlarda aldığım tüm ilaçlardan gerçekten memnunum.</DrugDesireInterestSatisfied.stages.chemical_satisfaction.description>
   
   <!-- EN: hideous environment -->
-  <NeedBeauty.stages.hideous_environment.label>iğrenç ortam</NeedBeauty.stages.hideous_environment.label>
+  <NeedBeauty.stages.hideous_environment.label>İğrenç ortam</NeedBeauty.stages.hideous_environment.label>
   <!-- EN: This place is unbearably grotesque. I can't look at this any more. -->
   <NeedBeauty.stages.hideous_environment.description>Burada durmak insanın göz zevkini bozuyor.</NeedBeauty.stages.hideous_environment.description>
   <!-- EN: ugly environment -->
@@ -171,15 +171,15 @@
   <!-- EN: How long have I been underground? I need to get out in the fresh air and spend some time under the sky. -->
   <NeedOutdoors.stages.trapped_underground.description>Ne zamandır yeraltındayım? Temiz havaya çıkıp gökyüzünün altında biraz zaman geçirmem gerekiyor.</NeedOutdoors.stages.trapped_underground.description>
   <!-- EN: cabin fever -->
-  <NeedOutdoors.stages.cabin_fever.label>kulube ateşi</NeedOutdoors.stages.cabin_fever.label>
+  <NeedOutdoors.stages.cabin_fever.label>kulübe ateşi</NeedOutdoors.stages.cabin_fever.label>
   <!-- EN: I've spent so long indoors I feel like the roof is pressing in. I need to get out and see the sky. -->
   <NeedOutdoors.stages.cabin_fever.description>İçeride o kadar uzun zaman geçirdim ki, sanki çatı bastırıyormuş gibi hissediyorum. Dışarı çıkıp gökyüzünü görmem gerekiyor.</NeedOutdoors.stages.cabin_fever.description>
   <!-- EN: trapped indoors -->
-  <NeedOutdoors.stages.trapped_indoors.label>içeride kapana kısılmış</NeedOutdoors.stages.trapped_indoors.label>
+  <NeedOutdoors.stages.trapped_indoors.label>İçeride kapana kısılmış</NeedOutdoors.stages.trapped_indoors.label>
   <!-- EN: It's been too long since I've seen the sky. -->
   <NeedOutdoors.stages.trapped_indoors.description>Gökyüzünü görmeyeli çok uzun zaman oldu.</NeedOutdoors.stages.trapped_indoors.description>
   <!-- EN: stuck indoors -->
-  <NeedOutdoors.stages.stuck_indoors.label>içeride sıkışmış</NeedOutdoors.stages.stuck_indoors.label>
+  <NeedOutdoors.stages.stuck_indoors.label>İçeride sıkışmış</NeedOutdoors.stages.stuck_indoors.label>
   <!-- EN: I'd like to go outside and get some fresh air. -->
   <NeedOutdoors.stages.stuck_indoors.description>Dışarı çıkıp biraz temiz hava almak istiyorum.</NeedOutdoors.stages.stuck_indoors.description>
   

--- a/Core/DefInjected/ThoughtDef/Thoughts_Situation_RoomStats.xml
+++ b/Core/DefInjected/ThoughtDef/Thoughts_Situation_RoomStats.xml
@@ -26,11 +26,11 @@
   <!-- EN: My hospital is extremely impressive. It makes me feel better already. -->
   <HospitalPatientRoomStats.stages.extremely_impressive_hospital.description>Bu hastane inanılmaz derecede güzel. Tamamen iyileşeceğime şimdiden eminim.</HospitalPatientRoomStats.stages.extremely_impressive_hospital.description>
   <!-- EN: unbelievably impressive hospital -->
-  <HospitalPatientRoomStats.stages.unbelievably_impressive_hospital.label>inanılmaz derecede etkileyici hastane</HospitalPatientRoomStats.stages.unbelievably_impressive_hospital.label>
+  <HospitalPatientRoomStats.stages.unbelievably_impressive_hospital.label>İnanılmaz derecede etkileyici hastane</HospitalPatientRoomStats.stages.unbelievably_impressive_hospital.label>
   <!-- EN: My hospital is unbelievably impressive. It makes me feel better already. -->
   <HospitalPatientRoomStats.stages.unbelievably_impressive_hospital.description>Hastanem inanılmaz derecede etkileyici. Şimdiden kendimi daha iyi hissetmemi sağlıyor.</HospitalPatientRoomStats.stages.unbelievably_impressive_hospital.description>
   <!-- EN: wondrously impressive hospital -->
-  <HospitalPatientRoomStats.stages.wondrously_impressive_hospital.label>inanılmaz etkileyici hastane</HospitalPatientRoomStats.stages.wondrously_impressive_hospital.label>
+  <HospitalPatientRoomStats.stages.wondrously_impressive_hospital.label>İnanılmaz etkileyici hastane</HospitalPatientRoomStats.stages.wondrously_impressive_hospital.label>
   <!-- EN: My hospital is wonderful! It makes me feel better already. -->
   <HospitalPatientRoomStats.stages.wondrously_impressive_hospital.description>Hastanem harika! Şimdiden kendimi daha iyi hissetmemi sağlıyor.</HospitalPatientRoomStats.stages.wondrously_impressive_hospital.description>
   
@@ -59,7 +59,7 @@
   <!-- EN: My prison barracks is extremely impressive. I can't believe they are keeping me in a place like this. -->
   <PrisonBarracks.stages.extremely_impressive_barracks.description>Hapishane barakam son derece etkileyici. Beni böyle bir yerde tuttuklarına inanamıyorum.</PrisonBarracks.stages.extremely_impressive_barracks.description>
   <!-- EN: unbelievably impressive barracks -->
-  <PrisonBarracks.stages.unbelievably_impressive_barracks.label>inanılmaz etkileyici baraka</PrisonBarracks.stages.unbelievably_impressive_barracks.label>
+  <PrisonBarracks.stages.unbelievably_impressive_barracks.label>İnanılmaz etkileyici baraka</PrisonBarracks.stages.unbelievably_impressive_barracks.label>
   <!-- EN: My prison barracks is unbelievably impressive. I can't believe they are keeping me in a place like this. -->
   <PrisonBarracks.stages.unbelievably_impressive_barracks.description>Hapishane barakam inanılmaz derecede etkileyici. Beni böyle bir yerde tuttuklarına inanamıyorum.</PrisonBarracks.stages.unbelievably_impressive_barracks.description>
   <!-- EN: wondrously impressive barracks -->

--- a/Core/DefInjected/ThoughtDef/Thoughts_Situation_Social.xml
+++ b/Core/DefInjected/ThoughtDef/Thoughts_Situation_Social.xml
@@ -2,7 +2,7 @@
 <LanguageData>
   
   <!-- EN: affair -->
-  <Affair.stages.affair.label>ilişki</Affair.stages.affair.label>
+  <Affair.stages.affair.label>İlişki</Affair.stages.affair.label>
   
   <!-- EN: annoying voice -->
   <AnnoyingVoice.stages.annoying_voice.label>sinir bozucu ses</AnnoyingVoice.stages.annoying_voice.label>
@@ -73,7 +73,7 @@
   <NotBondedAnimalMaster.stages.not_master_of.description>Bağlı hayvanlarla birlikte olmalıyım.</NotBondedAnimalMaster.stages.not_master_of.description>
   
   <!-- EN: opinion of my {0} {1} -->
-  <OpinionOfMyLover.stages.opinion_of_my.label>benim {0}m {1} hakkında görüşüm</OpinionOfMyLover.stages.opinion_of_my.label>
+  <OpinionOfMyLover.stages.opinion_of_my.label>benim {0}m {1} hakkındaki görüşüm</OpinionOfMyLover.stages.opinion_of_my.label>
   <!-- EN: Being with them makes me feel this way. -->
   <OpinionOfMyLover.stages.opinion_of_my.description>Sevgilimle olmak bana böyle hissettiriyor.</OpinionOfMyLover.stages.opinion_of_my.description>
   

--- a/Core/DefInjected/ThoughtDef/Thoughts_Situation_Special.xml
+++ b/Core/DefInjected/ThoughtDef/Thoughts_Situation_Special.xml
@@ -2,7 +2,7 @@
 <LanguageData>
   
   <!-- EN: beautiful aurora -->
-  <Aurora.stages.beautiful_aurora.label>muhteşem seher</Aurora.stages.beautiful_aurora.label>
+  <Aurora.stages.beautiful_aurora.label>muhteşem kuzey ışıkları</Aurora.stages.beautiful_aurora.label>
   <!-- EN: The view is amazing. -->
   <Aurora.stages.beautiful_aurora.description>Manzara inanılmaz.</Aurora.stages.beautiful_aurora.description>
   
@@ -12,11 +12,11 @@
   <ColonistLeftUnburied.stages.colonist_left_unburied.description>Birimiz öldü ve onları açıkta bırakıyoruz. Kimse öyle kalmamalı. İnsanlar düzgün bir cenazeyi hak ediyor.</ColonistLeftUnburied.stages.colonist_left_unburied.description>
   
   <!-- EN: minor passion for my work -->
-  <DoingPassionateWork.stages.minor_passion_for_my_work.label>işim için küçük bir tutku</DoingPassionateWork.stages.minor_passion_for_my_work.label>
+  <DoingPassionateWork.stages.minor_passion_for_my_work.label>İşim için küçük bir tutku</DoingPassionateWork.stages.minor_passion_for_my_work.label>
   <!-- EN: I enjoy my work. -->
   <DoingPassionateWork.stages.minor_passion_for_my_work.description>İşimden zevk alıyorum.</DoingPassionateWork.stages.minor_passion_for_my_work.description>
   <!-- EN: burning passion for my work -->
-  <DoingPassionateWork.stages.burning_passion_for_my_work.label>işim için yanan tutku</DoingPassionateWork.stages.burning_passion_for_my_work.label>
+  <DoingPassionateWork.stages.burning_passion_for_my_work.label>İşim için yanan tutku</DoingPassionateWork.stages.burning_passion_for_my_work.label>
   <!-- EN: I love my work. I could do this all day, every day. -->
   <DoingPassionateWork.stages.burning_passion_for_my_work.description>İşimi seviyorum. Bunu bütün gün, her gün yapabilirim.</DoingPassionateWork.stages.burning_passion_for_my_work.description>
   

--- a/Core/DefInjected/ThoughtDef/Thoughts_Situation_Traits.xml
+++ b/Core/DefInjected/ThoughtDef/Thoughts_Situation_Traits.xml
@@ -6,7 +6,7 @@
   <!-- EN: My bedroom is just how I want it to be. Very humble and simple. -->
   <Ascetic.stages.ascetic_has_awful_bedroom.description>Yatak odam tam da olmasını istediğim gibi. Çok mütevazı ve basit.</Ascetic.stages.ascetic_has_awful_bedroom.description>
   <!-- EN: ascetic has dull bedroom -->
-  <Ascetic.stages.ascetic_has_dull_bedroom.label>itici yatak odası</Ascetic.stages.ascetic_has_dull_bedroom.label>
+  <Ascetic.stages.ascetic_has_dull_bedroom.label>İtici yatak odası</Ascetic.stages.ascetic_has_dull_bedroom.label>
   <!-- EN: My bedroom is just how I want it to be. Very humble and simple. -->
   <Ascetic.stages.ascetic_has_dull_bedroom.description>Yatak odam tam da olmasını istediğim gibi. Çok mütevazı ve basit.</Ascetic.stages.ascetic_has_dull_bedroom.description>
   <!-- EN: ascetic has mediocre bedroom -->

--- a/Core/DefInjected/ThoughtDef/Thoughts_Situation_TraitsPerm.xml
+++ b/Core/DefInjected/ThoughtDef/Thoughts_Situation_TraitsPerm.xml
@@ -17,12 +17,12 @@
   <MoodOffsetPessimist.stages.pessimist.description>Kötümser özelliğinden doğal ceza.</MoodOffsetPessimist.stages.pessimist.description>
   
   <!-- EN: sanguine -->
-  <MoodOffsetSanguine.stages.sanguine.label>iyimser</MoodOffsetSanguine.stages.sanguine.label>
+  <MoodOffsetSanguine.stages.sanguine.label>İyimser</MoodOffsetSanguine.stages.sanguine.label>
   <!-- EN: Natural bonus from 'sanguine' trait. -->
   <MoodOffsetSanguine.stages.sanguine.description>Iyimserlik özelliğinden doğal bonus.</MoodOffsetSanguine.stages.sanguine.description>
   
   <!-- EN: Tortured artist -->
-  <MoodOffsetTorturedArtist.stages.Tortured_artist.label>işkence görmüş sanatçı</MoodOffsetTorturedArtist.stages.Tortured_artist.label>
+  <MoodOffsetTorturedArtist.stages.Tortured_artist.label>İşkence görmüş sanatçı</MoodOffsetTorturedArtist.stages.Tortured_artist.label>
   <!-- EN: Natural penalty from 'tortured artist' trait. -->
   <MoodOffsetTorturedArtist.stages.Tortured_artist.description>'İşkence görmüş sanatçı' özelliğinden doğal ceza.</MoodOffsetTorturedArtist.stages.Tortured_artist.description>
   

--- a/Core/DefInjected/ThoughtDef/WakeUp.xml
+++ b/Core/DefInjected/ThoughtDef/WakeUp.xml
@@ -2,7 +2,7 @@
 <LanguageData>
   
   <!-- EN: wake-up withdrawal -->
-  <WakeUpWithdrawal.stages.wakeup_withdrawal.label>wake-up bitişi</WakeUpWithdrawal.stages.wakeup_withdrawal.label>
+  <WakeUpWithdrawal.stages.wakeup_withdrawal.label>wake-up yoksunluğu</WakeUpWithdrawal.stages.wakeup_withdrawal.label>
   <!-- EN: I feel all fuzzy and unfocused. And I'm so tired. -->
   <WakeUpWithdrawal.stages.wakeup_withdrawal.description>Tamamen bulanık ve odaklanmamış hissediyorum. Ve çok yorgunum.</WakeUpWithdrawal.stages.wakeup_withdrawal.description>
   

--- a/Core/DefInjected/TimeAssignmentDef/TimeAssignments.xml
+++ b/Core/DefInjected/TimeAssignmentDef/TimeAssignments.xml
@@ -2,15 +2,15 @@
 <LanguageData>
   
   <!-- EN: anything -->
-  <Anything.label>Herhangi</Anything.label>
+  <Anything.label>herhangi</Anything.label>
   
   <!-- EN: recreation -->
-  <Joy.label>Eğlence</Joy.label>
+  <Joy.label>eğlence</Joy.label>
   
   <!-- EN: sleep -->
-  <Sleep.label>Uyku</Sleep.label>
+  <Sleep.label>uyku</Sleep.label>
   
   <!-- EN: work -->
-  <Work.label>Çalışma</Work.label>
+  <Work.label>çalışma</Work.label>
   
 </LanguageData>

--- a/Core/DefInjected/TipSetDef/Tips.xml
+++ b/Core/DefInjected/TipSetDef/Tips.xml
@@ -56,9 +56,9 @@
   <!-- EN: Carefully-slaughtered animals yield more meat and leather than those who were killed violently. -->
   <GameplayTips.GreaterSlaughterYield>Dikkatlice kesilmiş hayvanlar, vahşice öldürülmüş hayvanlara göre daha fazla et ve deri vermektedir.</GameplayTips.GreaterSlaughterYield>
   <!-- EN: Place the caravan hitching spot where you want your caravans to form up. It's usually best to place it near your storage areas. -->
-  <GameplayTips.CaravanHitchingSpot>Karavan bağlama noktasını, karavanlarınızın oluşmasını istediğiniz yere yerleştirin. Genellikle depolama alanlarınızın yakınına yerleştirmek en iyisidir.</GameplayTips.CaravanHitchingSpot>
+  <GameplayTips.CaravanHitchingSpot>Kervan bağlama noktasını, karavanlarınızın oluşmasını istediğiniz yere yerleştirin. Genellikle depolama alanlarınızın yakınına yerleştirmek en iyisidir.</GameplayTips.CaravanHitchingSpot>
   <!-- EN: During encounters away from home, you can place a caravan hitching spot to keep your animals from wandering. -->
-  <GameplayTips.CaravanHitchingSpotRoamers>Evden uzaktaki karşılaşmalarda, hayvanlarınızın başıboş dolaşmaması için karavan bağlama noktası yerleştirebilirsiniz.</GameplayTips.CaravanHitchingSpotRoamers>
+  <GameplayTips.CaravanHitchingSpotRoamers>Evden uzaktaki karşılaşmalarda, hayvanlarınızın başıboş dolaşmaması için kervan bağlama noktası yerleştirebilirsiniz.</GameplayTips.CaravanHitchingSpotRoamers>
   <!-- EN: Caravans move faster if they include rideable animals like horses, donkeys and dromedaries. -->
   <GameplayTips.CaravanRideableAnimals>At, eşek ve hörgüçlü hayvanlar içeren kervanlar, daha hızlı hareket eder.</GameplayTips.CaravanRideableAnimals>
   <!-- EN: Smaller caravans get attacked less often because they're less visible. -->

--- a/Core/DefInjected/ToolCapacityDef/ToolCapacity.xml
+++ b/Core/DefInjected/ToolCapacityDef/ToolCapacity.xml
@@ -11,7 +11,7 @@
   <Cut.label>kesmek</Cut.label>
   
   <!-- EN: demolish -->
-  <Demolish.label>Yerlebir etme</Demolish.label>
+  <Demolish.label>yerlebir etme</Demolish.label>
   
   <!-- EN: kick material in eyes -->
   <KickMaterialInEyes.label>gözlerdeki tekme malzemesi</KickMaterialInEyes.label>

--- a/Core/DefInjected/TraderKindDef/TraderKinds_Caravan_Outlander.xml
+++ b/Core/DefInjected/TraderKindDef/TraderKinds_Caravan_Outlander.xml
@@ -5,7 +5,7 @@
   <Caravan_Outlander_BulkGoods.label>toptancı</Caravan_Outlander_BulkGoods.label>
   
   <!-- EN: combat supplier -->
-  <Caravan_Outlander_CombatSupplier.label>muharebe tedarikçisi</Caravan_Outlander_CombatSupplier.label>
+  <Caravan_Outlander_CombatSupplier.label>savaş tedarikçisi</Caravan_Outlander_CombatSupplier.label>
   
   <!-- EN: exotic goods trader -->
   <Caravan_Outlander_Exotic.label>egzotik ürün tüccarı</Caravan_Outlander_Exotic.label>

--- a/Core/DefInjected/TraderKindDef/TraderKinds_Orbital_Misc.xml
+++ b/Core/DefInjected/TraderKindDef/TraderKinds_Orbital_Misc.xml
@@ -5,7 +5,7 @@
   <Orbital_BulkGoods.label>toptancı</Orbital_BulkGoods.label>
   
   <!-- EN: combat supplier -->
-  <Orbital_CombatSupplier.label>savaş tedarikçisi</Orbital_CombatSupplier.label>
+  <Orbital_CombatSupplier.label>muharebe tedarikçisi</Orbital_CombatSupplier.label>
   
   <!-- EN: exotic goods trader -->
   <Orbital_Exotic.label>egzotik ürün tüccarı</Orbital_Exotic.label>

--- a/Core/DefInjected/TraderKindDef/TraderKinds_Visitor_Neolithic.xml
+++ b/Core/DefInjected/TraderKindDef/TraderKinds_Visitor_Neolithic.xml
@@ -2,6 +2,6 @@
 <LanguageData>
   
   <!-- EN: trader -->
-  <Visitor_Neolithic_Standard.label>Tüccar</Visitor_Neolithic_Standard.label>
+  <Visitor_Neolithic_Standard.label>tüccar</Visitor_Neolithic_Standard.label>
   
 </LanguageData>

--- a/Core/DefInjected/TraderKindDef/TraderKinds_Visitor_Outlander.xml
+++ b/Core/DefInjected/TraderKindDef/TraderKinds_Visitor_Outlander.xml
@@ -2,6 +2,6 @@
 <LanguageData>
   
   <!-- EN: trader -->
-  <Visitor_Outlander_Standard.label>Tüccar</Visitor_Outlander_Standard.label>
+  <Visitor_Outlander_Standard.label>tüccar</Visitor_Outlander_Standard.label>
   
 </LanguageData>

--- a/Core/DefInjected/TrainableDef/Trainables.xml
+++ b/Core/DefInjected/TrainableDef/Trainables.xml
@@ -2,22 +2,22 @@
 <LanguageData>
   
   <!-- EN: haul -->
-  <Haul.label>taşı</Haul.label>
+  <Haul.label>taşıma</Haul.label>
   <!-- EN: The animal will randomly haul items from time to time (though it can't be directed to haul specific items). -->
   <Haul.description>Hayvan zaman zaman rastgele eşyaları taşıyacak (belirli eşyaları taşıması için yönlendirilemez).</Haul.description>
   
   <!-- EN: guard -->
-  <Obedience.label>koru</Obedience.label>
+  <Obedience.label>koruma</Obedience.label>
   <!-- EN: The animal can be assigned a master whom it will follow and defend. -->
   <Obedience.description>Hayvan efendisini takip etmeye ve korumaya atanabilir.</Obedience.description>
   
   <!-- EN: attack -->
-  <Release.label>saldır</Release.label>
+  <Release.label>saldırma</Release.label>
   <!-- EN: The animal can be released to attack distant targets instead of just guarding its master. -->
   <Release.description>Hayvan sadece efendisini korumak yerine uzak hedeflere saldırması için salınabilir.</Release.description>
   
   <!-- EN: rescue -->
-  <Rescue.label>kurtar</Rescue.label>
+  <Rescue.label>kurtarma</Rescue.label>
   <!-- EN: The animal will rescue wounded allies and drag them to safety. -->
   <Rescue.description>Hayvan yaralı mütefikleri kurtarmak veya güvende tutmak için sürükleyebilir.</Rescue.description>
   

--- a/Core/DefInjected/TraitDef/Traits_Singular.xml
+++ b/Core/DefInjected/TraitDef/Traits_Singular.xml
@@ -7,7 +7,7 @@
   <Abrasive.degreeDatas.abrasive.description>[PAWN_nameDef] her zaman rahatsız edici bir hali vardır. İnsanları yanlış yönlendirir, tedirgin eder.</Abrasive.degreeDatas.abrasive.description>
   
   <!-- EN: annoying voice -->
-  <AnnoyingVoice.degreeDatas.annoying_voice.label>itici ses</AnnoyingVoice.degreeDatas.annoying_voice.label>
+  <AnnoyingVoice.degreeDatas.annoying_voice.label>İtici ses</AnnoyingVoice.degreeDatas.annoying_voice.label>
   <!-- EN: {PAWN_nameDef}'s voice has a particularly grating, nasal quality to it, and {PAWN_pronoun} tends to talk in barked, garbled phrases. This predisposes others to dislike {PAWN_objective}. -->
   <AnnoyingVoice.degreeDatas.annoying_voice.description>[PAWN_nameDef] sesi burnu etinden dolayı sesi kötü ve rahatsız edici olabilmekte. Bundan dolayı diğer kolonistler tarafından pek sevilmez.</AnnoyingVoice.degreeDatas.annoying_voice.description>
   
@@ -44,7 +44,7 @@
   <!-- EN: cannibal -->
   <Cannibal.degreeDatas.cannibal.label>yamyam</Cannibal.degreeDatas.cannibal.label>
   <!-- EN: {PAWN_nameDef} was taught that eating human meat is wrong and horrible. But one time, long ago, {PAWN_pronoun} tried it... and {PAWN_pronoun} liked it. -->
-  <Cannibal.degreeDatas.cannibal.description>[PAWN_nameDef] insan eti yemenin yanlış ve iğrenç birşey olduğu öğretildi. Fakat uzun zaman önce birkez denedi ve sevdi...</Cannibal.degreeDatas.cannibal.description>
+  <Cannibal.degreeDatas.cannibal.description>[PAWN_nameDef] insan eti yemenin yanlış ve iğrenç bir şey olduğunu biliyordu. Ama bir zamanlar, uzun zaman önce, {PAWN_pronoun} bunu denedi... ve sevdi.</Cannibal.degreeDatas.cannibal.description>
   
   <!-- EN: creepy breathing -->
   <CreepyBreathing.degreeDatas.creepy_breathing.label>hırıltılı nefes</CreepyBreathing.degreeDatas.creepy_breathing.label>
@@ -124,7 +124,7 @@
   <!-- EN: pyromaniac -->
   <Pyromaniac.degreeDatas.pyromaniac.label>ateş manyağı</Pyromaniac.degreeDatas.pyromaniac.label>
   <!-- EN: {PAWN_nameDef} loves fire. {PAWN_pronoun} will never extinguish fires, and will occasionally go on random fire starting sprees. {PAWN_pronoun} will be happy around flames, and happier when wielding an incendiary weapon. -->
-  <Pyromaniac.degreeDatas.pyromaniac.description>[PAWN_nameDef] alevleri ve ateşi sever.. [PAWN_pronoun] bazen yangın başlayacak ve o hiç söndürmek istemeyecek.</Pyromaniac.degreeDatas.pyromaniac.description>
+  <Pyromaniac.degreeDatas.pyromaniac.description>{PAWN_nameDef} ateşi sever. {PAWN_pronoun} asla yangınları söndürmez ve ara sıra rastgele yangın çıkarma çılgınlıklarına girişir. {PAWN_pronoun} alevlerin etrafında mutlu olur ve yanıcı bir silah kullandığında daha da mutlu olur.</Pyromaniac.degreeDatas.pyromaniac.description>
   
   <!-- EN: quick sleeper -->
   <QuickSleeper.degreeDatas.quick_sleeper.label>hızlı uyuyan</QuickSleeper.degreeDatas.quick_sleeper.label>
@@ -142,7 +142,7 @@
   <TooSmart.degreeDatas.too_smart.description>[PAWN_nameDef] kendi iyiliği için çok akıllıdır. [PAWN_pronoun] her şeyi herkesten daha hızlı öğrenir, fakat biraz tuhaf olabilir.</TooSmart.degreeDatas.too_smart.description>
   
   <!-- EN: tortured artist -->
-  <TorturedArtist.degreeDatas.tortured_artist.label>işkence görmüş sanatçı</TorturedArtist.degreeDatas.tortured_artist.label>
+  <TorturedArtist.degreeDatas.tortured_artist.label>İşkence görmüş sanatçı</TorturedArtist.degreeDatas.tortured_artist.label>
   <!-- EN: {PAWN_nameDef} feels alienated and misunderstood by other human beings. {PAWN_pronoun} will have a constant mood debuff, but gain a chance (50%) to get a creativity inspiration after a mental break. -->
   <TorturedArtist.degreeDatas.tortured_artist.description>{PAWN_nameDef} diğer insanlar tarafından dışlanmış ve yanlış anlaşılmış hissediyor. {PAWN_pronoun} sürekli bir olumsuz ruh hali özelliğine sahip olacak. ancak zihinsel çöküşten sonra yaratıcılık ilhamı almak için (% 50) şans kazanacak.</TorturedArtist.degreeDatas.tortured_artist.description>
   <!-- EN: As a suffering tortured artist, [PAWN_nameIndef] has experienced an inspiration. -->

--- a/Core/DefInjected/TraitDef/Traits_Spectrum.xml
+++ b/Core/DefInjected/TraitDef/Traits_Spectrum.xml
@@ -8,15 +8,15 @@
   <!-- EN: pretty -->
   <Beauty.degreeDatas.pretty.label>sevimli</Beauty.degreeDatas.pretty.label>
   <!-- EN: [PAWN_nameDef] has a pretty face, which predisposes people to like [PAWN_objective]. -->
-  <Beauty.degreeDatas.pretty.description>[PAWN_nameDef], insanları [PAWN_objective] beğenmeye yatkın kılan güzel bir yüze sahip.</Beauty.degreeDatas.pretty.description>
+  <Beauty.degreeDatas.pretty.description>[PAWN_nameDef], insanları onu beğenmeye yatkın kılan güzel bir yüze sahip.</Beauty.degreeDatas.pretty.description>
   <!-- EN: ugly -->
   <Beauty.degreeDatas.ugly.label>çirkin</Beauty.degreeDatas.ugly.label>
   <!-- EN: [PAWN_nameDef] is somewhat ugly. This subtly repels others during social interactions. -->
   <Beauty.degreeDatas.ugly.description>[PAWN_nameDef] biraz çirkin. Bu, sosyal etkileşimler sırasında başkalarına itici gelir.</Beauty.degreeDatas.ugly.description>
   <!-- EN: staggeringly ugly -->
-  <Beauty.degreeDatas.staggeringly_ugly.label>inanılmaz derecede çirkin</Beauty.degreeDatas.staggeringly_ugly.label>
+  <Beauty.degreeDatas.staggeringly_ugly.label>İnanılmaz derecede çirkin</Beauty.degreeDatas.staggeringly_ugly.label>
   <!-- EN: [PAWN_nameDef] is staggeringly ugly. [PAWN_possessive] face looks like a cross between a drawing by an untalented child, a malformed fetus in a jar of formaldehyde, and a piece of modern art. Others must exert conscious effort to look at [PAWN_objective] while conversing. -->
-  <Beauty.degreeDatas.staggeringly_ugly.description>[PAWN_nameDef] inanılmaz derecede çirkin. [PAWN_possessive] yüzü, yeteneksiz bir çocuğun çizimi, formaldehit kavanozundaki özürlü bir cenin ve bir modern sanat eserinin birleşimi gibi görünüyor. Diğerleri, konuşurken [PAWN_objective] 'e bakmak için çaba sarf etmelidir.</Beauty.degreeDatas.staggeringly_ugly.description>
+  <Beauty.degreeDatas.staggeringly_ugly.description>[PAWN_nameDef] inanılmaz derecede çirkin. [PAWN_possessive] yüzü, yeteneksiz bir çocuğun çizimi, formaldehit kavanozundaki özürlü bir cenin ve bir modern sanat eserinin birleşimi gibi görünüyor. Diğerleri, konuşurken [PAWN_objective] bakmak için çaba sarf etmelidir.</Beauty.degreeDatas.staggeringly_ugly.description>
   
   <!-- EN: chemical fascination -->
   <DrugDesire.degreeDatas.chemical_fascination.label>kimyasal düşkünlüğü</DrugDesire.degreeDatas.chemical_fascination.label>
@@ -120,7 +120,7 @@
   <!-- EN: careful shooter -->
   <ShootingAccuracy.degreeDatas.careful_shooter.label>dikkatli nişancı</ShootingAccuracy.degreeDatas.careful_shooter.label>
   <!-- EN: [PAWN_nameDef] takes more time to aim when shooting. [PAWN_pronoun] shoots less often than others, but with more accuracy. -->
-  <ShootingAccuracy.degreeDatas.careful_shooter.description>[PAWN_nameDef] oldukça iyi bir atış yapar, ancak [PAWN_pronoun]'un [PAWN_possessive] hedefine odaklanmak için daha fazla zamana ihtiyacı var.</ShootingAccuracy.degreeDatas.careful_shooter.description>
+  <ShootingAccuracy.degreeDatas.careful_shooter.description>[PAWN_nameDef] oldukça iyi bir atış yapar, ancak onun hedefine odaklanmak için daha fazla zamana ihtiyacı var.</ShootingAccuracy.degreeDatas.careful_shooter.description>
   <!-- EN: trigger-happy -->
   <ShootingAccuracy.degreeDatas.triggerhappy.label>silah sever</ShootingAccuracy.degreeDatas.triggerhappy.label>
   <!-- EN: Pew! Pew! Pew! [PAWN_nameDef] just likes pulling the trigger. [PAWN_pronoun] shoots faster than others, but less accurately. -->

--- a/Core/DefInjected/WeaponClassDef/WeaponClassDefs.xml
+++ b/Core/DefInjected/WeaponClassDef/WeaponClassDefs.xml
@@ -8,13 +8,13 @@
   <Melee.label>yakın dövüş</Melee.label>
   
   <!-- EN: melee blunt -->
-  <MeleeBlunt.label>yakın dövüş köreltmesi</MeleeBlunt.label>
+  <MeleeBlunt.label>bıçak tarzı yakın dövüş</MeleeBlunt.label>
   
   <!-- EN: melee piercer -->
-  <MeleePiercer.label>yakın dövüş delisi</MeleePiercer.label>
+  <MeleePiercer.label>delici tarzı yakın dövüş</MeleePiercer.label>
   
   <!-- EN: neolithic -->
-  <Neolithic.label>Neolitik</Neolithic.label>
+  <Neolithic.label>neolitik</Neolithic.label>
   
   <!-- EN: ranged -->
   <Ranged.label>menzilli</Ranged.label>

--- a/Core/DefInjected/WeatherDef/Weathers.xml
+++ b/Core/DefInjected/WeatherDef/Weathers.xml
@@ -2,42 +2,42 @@
 <LanguageData>
   
   <!-- EN: clear -->
-  <Clear.label>Açık Hava</Clear.label>
+  <Clear.label>açık hava</Clear.label>
   <!-- EN: A clear day. No penalties or modifiers. -->
   <Clear.description>Berrak bir gün.</Clear.description>
   
   <!-- EN: dry thunderstorm -->
-  <DryThunderstorm.label>Kuru Fırtına</DryThunderstorm.label>
+  <DryThunderstorm.label>kuru fırtına</DryThunderstorm.label>
   <!-- EN: Dry thunderstorms are dangerous because the lightning can start fires and there is no rain to put them out. -->
   <DryThunderstorm.description>Kuru fırtınalar tehlikelidir çünkü yıldırımlar yangınları başlatabilir ve onları söndürecek yağmur yoktur.</DryThunderstorm.description>
   
   <!-- EN: fog -->
-  <Fog.label>Sisli</Fog.label>
+  <Fog.label>sisli</Fog.label>
   <!-- EN: Fog reduces the accuracy of ranged weapons. -->
   <Fog.description>Sis, atışın doğruluğunu azaltır.</Fog.description>
   
   <!-- EN: foggy rain -->
-  <FoggyRain.label>Sisli Yağmurlu</FoggyRain.label>
+  <FoggyRain.label>sisli yağmurlu</FoggyRain.label>
   <!-- EN: Reduces accuracy and movement speed. -->
   <FoggyRain.description>Doğruluğu ve hızı azaltır.</FoggyRain.description>
   
   <!-- EN: rain -->
-  <Rain.label>Yağmurlu</Rain.label>
+  <Rain.label>yağmurlu</Rain.label>
   <!-- EN: Rain reduces the accuracy of ranged weapons, extinguishes fire, and slows people down. -->
   <Rain.description>Yağmur, atışın doğruluğunu, indirgeme hızlarını azaltır ve ateşi söndürür.</Rain.description>
   
   <!-- EN: rainy thunderstorm -->
-  <RainyThunderstorm.label>Sağanak Yağışlı</RainyThunderstorm.label>
+  <RainyThunderstorm.label>sağanak yağışlı</RainyThunderstorm.label>
   <!-- EN: The lightning will start fires, but the rain will put it out. The rain also reduces movement speed and shooting accuracy. -->
   <RainyThunderstorm.description>Yıldırım yangınları başlatacak ama yağmur söndürecek. Yağmur ayrıca hareket hızını ve atış doğruluğunu azaltır.</RainyThunderstorm.description>
   
   <!-- EN: gentle snow -->
-  <SnowGentle.label>Hafif Karlı</SnowGentle.label>
+  <SnowGentle.label>hafif karlı</SnowGentle.label>
   <!-- EN: Snow reduces the accuracy of ranged weapons, extinguishes fire, and slows people down. -->
   <SnowGentle.description>Kar atış doğruluğunu, koşu hızını azaltır ve ateşi söndürür.</SnowGentle.description>
   
   <!-- EN: hard snow -->
-  <SnowHard.label>Şiddetli Kar</SnowHard.label>
+  <SnowHard.label>şiddetli karlı</SnowHard.label>
   <!-- EN: Snow reduces the accuracy of ranged weapons, extinguishes fire, and slows people down. -->
   <SnowHard.description>Kar atış doğruluğunu, koşu hızını azaltır ve ateşi söndürür.</SnowHard.description>
   

--- a/Core/DefInjected/WorkTypeDef/WorkTypes.xml
+++ b/Core/DefInjected/WorkTypeDef/WorkTypes.xml
@@ -2,7 +2,7 @@
 <LanguageData>
   
   <!-- EN: Create beautiful works of art from raw materials. -->
-  <Art.description>Sanatkârlar güzel eserler yapar.</Art.description>
+  <Art.description>Sanatkarlar güzel eserler yapar.</Art.description>
   <!-- EN: art -->
   <Art.gerundLabel>sanat</Art.gerundLabel>
   <!-- EN: art -->
@@ -57,7 +57,7 @@
   <Cooking.verb>Yemek yap</Cooking.verb>
   
   <!-- EN: Do general low-skilled labor at work stations. This includes stonecutting, smelting, and more. -->
-  <Crafting.description>Zanaatkârlar, hammaddeden işe yarar şeyler üretir.</Crafting.description>
+  <Crafting.description>Zanaatkarlar, ham maddeden işe yarar şeyler üretir.</Crafting.description>
   <!-- EN: crafting -->
   <Crafting.gerundLabel>zanaat</Crafting.gerundLabel>
   <!-- EN: craft -->
@@ -160,7 +160,7 @@
   <!-- EN: resting in bed -->
   <PatientBedRest.gerundLabel>yatakta dinlenme</PatientBedRest.gerundLabel>
   <!-- EN: bed rest -->
-  <PatientBedRest.labelShort>Yatakta Dinlenme</PatientBedRest.labelShort>
+  <PatientBedRest.labelShort>Dinlenme</PatientBedRest.labelShort>
   <!-- EN: Bed rester -->
   <PatientBedRest.pawnLabel>Hasta</PatientBedRest.pawnLabel>
   <!-- EN: Become patient -->
@@ -189,7 +189,7 @@
   <Research.verb>Araştır</Research.verb>
   
   <!-- EN: Create weapons and tools from raw materials, either as a blacksmith or by machining. -->
-  <Smithing.description>Hammaddelerden silah yapar.</Smithing.description>
+  <Smithing.description>Ham maddelerden silah yapar.</Smithing.description>
   <!-- EN: smithing -->
   <Smithing.gerundLabel>dövme</Smithing.gerundLabel>
   <!-- EN: smith -->
@@ -200,7 +200,7 @@
   <Smithing.verb>Döv</Smithing.verb>
   
   <!-- EN: Create apparel from raw materials. -->
-  <Tailoring.description>Hammaddelerden giysi yapar.</Tailoring.description>
+  <Tailoring.description>Ham maddelerden giysi yapar.</Tailoring.description>
   <!-- EN: tailoring -->
   <Tailoring.gerundLabel>dikme</Tailoring.gerundLabel>
   <!-- EN: tailor -->

--- a/Core/DefInjected/WorldObjectDef/Incidents_Caravan_All.xml
+++ b/Core/DefInjected/WorldObjectDef/Incidents_Caravan_All.xml
@@ -2,7 +2,7 @@
 <LanguageData>
   
   <!-- EN: ambush -->
-  <Ambush.label>Pusu(Baskın)</Ambush.label>
+  <Ambush.label>pusu (baskın)</Ambush.label>
   <!-- EN: An ongoing ambush battle. -->
   <Ambush.description>Devam eden bir pusu savaşı.</Ambush.description>
   

--- a/Core/Keyed/Alerts.xml
+++ b/Core/Keyed/Alerts.xml
@@ -281,7 +281,7 @@
   <!-- EN: Pen needed -->
   <AlertAnimalPenNeeded>Ağıl gerekiyor</AlertAnimalPenNeeded>
   <!-- EN: Some of your tame animals are roamers. If not kept in a pen or roped to a caravan hitching spot, they will wander away. -->
-  <AlertAnimalPenNeededDesc>Evcil hayvanlarınızdan bazıları gezicidir. Bir ağılda tutulmazlarsa veya bir karavan bağlantı noktasına bağlanmazlarsa, uzaklaşırlar.</AlertAnimalPenNeededDesc>
+  <AlertAnimalPenNeededDesc>Evcil hayvanlarınızdan bazıları gezicidir. Bir ağılda tutulmazlarsa veya bir kervan bağlantı noktasına bağlanmazlarsa, uzaklaşırlar.</AlertAnimalPenNeededDesc>
   <!-- EN: You do not have any handlers to take animals to a pen.\n\nAssign a colonist to the Handling work type. -->
   <AlertAnimalPenNeededNoHandlers>Hayvanları bir ağıla götürecek hayvan bakıcın yok.\n\Hayvancılık iş türüne bir kolonist atayın.</AlertAnimalPenNeededNoHandlers>
   <!-- EN: Create an animal pen by building a pen marker inside a fenced, barricaded, or walled area. Select the pen marker to see which animals it accepts and how many its pen can support.\n\nYour animal handlers will bring animals to their assigned pen automatically.\n\nA pen needs a door or gate to admit animals. -->

--- a/Core/Keyed/Dates.xml
+++ b/Core/Keyed/Dates.xml
@@ -8,7 +8,7 @@
   <!-- EN: Year -->
   <ClockYear>Yıl</ClockYear>
   <!-- EN: Days passed since your arrival: {0}\nCurrent quadrum: {4}\nLocal season: {2}\n\nThe year is divided into 4 quadrums of {3} days each. Quadrums are the same everywhere, while seasons are different in different places.\n\nLocal seasons for each quadrum:\n{5} -->
-  <DateReadoutTip>Şu ana kadar geçirilen gün(ler): {0}\nÇeyrek: {4}\nMevsim: {2}\n\nYıl, her biri {3} günlük 4 çeyreğe bölünmüştür. Mevsimler bölgelere göre değişiklik gösterir iken çeyrekler her yerde aynıdır.\n\nHer bir çeyreğin mevsimleri:\n{5}.</DateReadoutTip>
+  <DateReadoutTip>Şu ana kadar geçirilen gün(ler): {0}\nÇeyrek: {4}\nMevsim: {2}\n\nYıl, her biri {3} günlük 4 çeyreğe bölünmüştür. Mevsimler bölgelere göre değişiklik gösterir iken çeyrekler her yerde aynıdır.\n\nHer bir çeyreğin mevsimleri:\n{5}</DateReadoutTip>
 
   <!-- EN: {0} of {1}, {2} -->
   <FullDate>{0} {1}, {2}</FullDate>

--- a/Core/Keyed/Dialogs_Various.xml
+++ b/Core/Keyed/Dialogs_Various.xml
@@ -196,7 +196,7 @@
   <!-- EN: first name -->
   <FirstName>ilk isim</FirstName>
   <!-- EN: nickname -->
-  <NickName>nickname</NickName>
+  <NickName>takma isim</NickName>
   <!-- EN: last name -->
   <LastName>soyad</LastName>
   <!-- EN: suggested -->
@@ -309,7 +309,7 @@
   <!-- EN: Minimum skills: -->
   <MinimumSkills>Minimum beceri:</MinimumSkills>
   <!-- EN: Requires -->
-  <BillRequires>{0} {1} gerektirir</BillRequires>
+  <BillRequires>Gerektirir:</BillRequires>
   <!-- EN: nutrition -->
   <BillNutrition>beslenme</BillNutrition>
   <!-- EN: Note: Small-volume ingredients like gold require {0}x as much. -->
@@ -319,14 +319,14 @@
   <!-- EN: ingredients -->
   <UsableIngredients>malzemeler</UsableIngredients>
   <!-- EN: To {0} -->
-  <BillRepeatTargetCountShort>{0} 'a kadar</BillRepeatTargetCountShort>
+  <BillRepeatTargetCountShort>{0}'a kadar</BillRepeatTargetCountShort>
 
   <!-- EN: Pause when satisfied -->
   <PauseWhenSatisfied>Koşul karşılandığında duraklat</PauseWhenSatisfied>
   <!-- EN: Unpause at -->
   <UnpauseWhenYouHave>Duraklatmayı iptal et</UnpauseWhenYouHave>
   <!-- EN: paused -->
-  <Paused>Duraklatıldı</Paused>
+  <Paused>duraklatıldı</Paused>
   <!-- EN: Unpause -->
   <Unpause>Devam ettir</Unpause>
 
@@ -733,7 +733,7 @@
   <!-- EN: Items -->
   <ItemsTab>Eşyalar</ItemsTab>
   <!-- EN: Travel supplies -->
-  <TravelSupplies>Seyehat erzakalrı</TravelSupplies>
+  <TravelSupplies>Seyahat erzakları</TravelSupplies>
   <!-- EN: You must assign at least one non-downed colonist. -->
   <CaravanMustHaveAtLeastOneColonist>En az bir adet sağlıklı kolonist atamalısın.</CaravanMustHaveAtLeastOneColonist>
   <!-- EN: The chosen exit location ({0}) is inaccessible. -->
@@ -1147,7 +1147,7 @@
   
   <!-- Cleanup translation files -->
   <!-- EN: Are you sure you want to cleanup all translation files for language {0}?\n\nThis will:\n  - Add placeholders for missing keyed translations, def-injected translations, and backstories\n  - Add or update comments containing the original, untranslated text\n  - Move all keyed and def-injected translations to the appropriate XML files\n  - Apply automatic formatting to all XML files\n  - Update back-compatible def names\n  - Remove all existing XML comments (except in full-list injections)\n\nNon-XML files will not be removed or modified.\n\nRemember to restart the game after modifying the language files before running this tool in order to reload all data.\n\nMake sure to back up all translation files before using this tool. -->
-  <ConfirmCleanupTranslationFiles>{0} dili için tüm çeviri dosyalarını temizlemek istediğinden emin misin?\n\nBu olacak:\n - Eksik keyed çevirileri, def-injected çeviriler ve yedeklemeler için yer tutucular ekle\n - Orijinal çevrilmemiş metinleri güncelle ve ekleme yap\n - Anahtarlı ve def-enjekte edilmiş tüm çevirileri uygun XML dosyalarına taşı\n - Tüm XML dosyalarına otomatik biçimlendirme uygula\n - Geri uyumlu def adlarını güncelle\n - Varolan tüm XML yorumlarını kaldır (liste enjeksiyonları dahil tüm liste)\n\nXML olmayan dosyalar kaldırılmaz veya değiştirilmez.\n\nTüm verileri yeniden yüklemek için bu aracı çalıştırmadan önce dil dosyalarını değiştirip sonra oyunu yeniden başlatmayı unutma.\n\nBu aracı kullanmadan önce tüm çevirileri yedeklediğinden emin ol.</ConfirmCleanupTranslationFiles>
+  <ConfirmCleanupTranslationFiles>{0} dili için tüm çeviri dosyalarını temizleyip yenilemek istediğinden emin misin?\n\nBunlar olacak:\n - Eksik keyed, def-injected ve backstory çevirileri için yer tutucular eklenecek\n - Orijinal çevrilmemiş metinler güncellenecek ve ekleme yapılacak\n - Keyed ve def-injected tüm çeviriler uygun XML dosyalarına taşınacak\n - Tüm XML dosyalarına otomatik biçimlendirme uygulanacak\n - Geri uyumlu def adları güncellenecek\n - Var olan tüm XML yorum satırları kaldırılacak (liste enjeksiyonları dahil tüm liste)\n\nXML olmayan dosyalar kaldırılmaz veya değiştirilmez.\n\nTüm verileri yeniden yüklemek için bu aracı çalıştırmadan önce dil dosyalarını değiştirip sonra oyunu yeniden başlatmayı unutma.\n\nBu aracı kullanmadan önce tüm çevirileri yedeklediğinden emin ol.</ConfirmCleanupTranslationFiles>
   <!-- EN: Yes, I have a backup -->
   <ConfirmCleanupTranslationFiles_Confirm>Evet, bir yedeğim var</ConfirmCleanupTranslationFiles_Confirm>
 
@@ -1419,8 +1419,5 @@
   <MapSearchResultSingular>1 sonuç bulundu</MapSearchResultSingular>
   <!-- EN: Searching -->
   <Searching>Aranıyor</Searching>
-
-  <!-- UNUSED -->
-  <MedGroupColonist>Kolonistler</MedGroupColonist>
 
 </LanguageData>

--- a/Core/Keyed/Enums.xml
+++ b/Core/Keyed/Enums.xml
@@ -259,9 +259,9 @@
 
   <!-- Temperature -->
   <!-- EN: Celsius -->
-  <Celsius>Celsius</Celsius>
+  <Celsius>Santigrat</Celsius>
   <!-- EN: Fahrenheit -->
-  <Fahrenheit>Fahrenheit</Fahrenheit>
+  <Fahrenheit>Fahrenhayt</Fahrenheit>
   <!-- EN: Kelvin -->
   <Kelvin>Kelvin</Kelvin>
   

--- a/Core/Keyed/FloatMenu.xml
+++ b/Core/Keyed/FloatMenu.xml
@@ -141,7 +141,7 @@
   <!-- EN: no suitable food -->
   <NoFoodToFillHopper>uygun yiyecek yok</NoFoodToFillHopper>
   <!-- EN: self-tend disabled -->
-  <SelfTendDisabled>kendi kendine tedavi devre dışı</SelfTendDisabled>
+  <SelfTendDisabled>kendine tedavi devre dışı</SelfTendDisabled>
   <!-- EN: reserved for prisoners -->
   <ReservedForPrisoners>mahkumlar için ayırtılmış</ReservedForPrisoners>
   <!-- EN: cannot reach -->
@@ -183,7 +183,7 @@
   <!-- EN: being carried by {0_labelShort} -->
   <BeingCarriedBy>{0_labelShort} tarafından taşınıyor</BeingCarriedBy>
   <!-- EN: full -->
-  <ContainerFull>full</ContainerFull>
+  <ContainerFull>ful</ContainerFull>
   <!-- EN: already assigned -->
   <AlreadyAssigned>zaten atanmış</AlreadyAssigned>
   

--- a/Core/Keyed/GameplayCommands.xml
+++ b/Core/Keyed/GameplayCommands.xml
@@ -574,39 +574,39 @@
 
   <!-- Carry -->
   <!-- EN: Drop {0_nameDef} -->
-  <CommandDropPawn>{0_nameDef} 'ı bırak</CommandDropPawn>
+  <CommandDropPawn>{0_nameDef}'i bırak</CommandDropPawn>
   <!-- EN: Drop the person being carried. -->
   <CommandDropPawnDesc>Taşınan kişiyi bırakın.</CommandDropPawnDesc>
   <!-- EN: Select {0_nameDef} -->
-  <CommandSelectCarriedPawn>seç {0_nameDef}</CommandSelectCarriedPawn>
+  <CommandSelectCarriedPawn>Seç: {0_nameDef}</CommandSelectCarriedPawn>
   <!-- EN: Select the creature being carried. -->
   <CommandSelectCarriedPawnDesc>Taşınan şeyi seçin.</CommandSelectCarriedPawnDesc>
   <!-- EN: Select {0_label} -->
-  <CommandSelectCarriedThing>seç {0_label}</CommandSelectCarriedThing>
+  <CommandSelectCarriedThing>Seç: {0_label}</CommandSelectCarriedThing>
   <!-- EN: Select the carried item. -->
   <CommandSelectCarriedThingDesc>Taşınan öğeyi seçin.</CommandSelectCarriedThingDesc>
   <!-- EN: Select {0_label} -->
-  <CommandSelectContainerThing>seç {0_label}</CommandSelectContainerThing>
+  <CommandSelectContainerThing>Seç: {0_label}</CommandSelectContainerThing>
   <!-- EN: Select the containing item. -->
-  <CommandSelectContainerThingDesc>Taşınan itemi seçin</CommandSelectContainerThingDesc>
+  <CommandSelectContainerThingDesc>Taşınan öğeyi seçin</CommandSelectContainerThingDesc>
   <!-- EN: Select {0_nameDef} -->
-  <CommandSelectCarryingPawn>seç {0_nameDef}</CommandSelectCarryingPawn>
+  <CommandSelectCarryingPawn>Seç: {0_nameDef}</CommandSelectCarryingPawn>
   <!-- EN: Select the carrying creature. -->
   <CommandSelectCarryingPawnDesc>Taşıyan şeyi seçin.</CommandSelectCarryingPawnDesc>
   <!-- EN: Select {0_nameDef} -->
-  <CommandSelectContainedPawn>seç {0_nameDef}</CommandSelectContainedPawn>
+  <CommandSelectContainedPawn>Seç: {0_nameDef}</CommandSelectContainedPawn>
   <!-- EN: Select the contained creature. -->
   <CommandSelectContainedPawnDesc>İçerdiği şeyi seçin.</CommandSelectContainedPawnDesc>
   <!-- EN: Select {0_label} -->
-  <CommandSelectContainedThing>Select {0_label}</CommandSelectContainedThing>
+  <CommandSelectContainedThing>Seç: {0_label}</CommandSelectContainedThing>
   <!-- EN: Select the contained item. -->
-  <CommandSelectContainedThingDesc>İçerdiği itemi seçin.</CommandSelectContainedThingDesc>
+  <CommandSelectContainedThingDesc>İçerdiği öğeyi seçin.</CommandSelectContainedThingDesc>
 
   <!-- Take a drug -->
   <!-- EN: Take drug... -->
-  <TakeDrug>İlaç kullan...</TakeDrug>
+  <TakeDrug>Uyuşturucu kullan...</TakeDrug>
   <!-- EN: Choose a drug from inventory to ingest immediately. -->
-  <TakeDrugDesc>Hemen kullanmak için envanterden bir ilaç seçin.</TakeDrugDesc>
+  <TakeDrugDesc>Hemen kullanmak için envanterden bir uyuşturucu seçin.</TakeDrugDesc>
 
   <!-- Build X -->
   <!-- EN: Build {0} -->

--- a/Core/Keyed/ITabs.xml
+++ b/Core/Keyed/ITabs.xml
@@ -196,9 +196,9 @@
   <!-- EN: Overview -->
   <HealthOverview>Genel bakış</HealthOverview>
   <!-- EN: Operations -->
-  <MedicalOperationsShort>Operasyonlar ({0})</MedicalOperationsShort>
+  <MedicalOperationsShort>Operasyonlar</MedicalOperationsShort>
   <!-- EN: Modifications -->
-  <MedicalOperationsMechanoidsShort>Değişiklikler ({0})</MedicalOperationsMechanoidsShort>
+  <MedicalOperationsMechanoidsShort>Değişiklikler</MedicalOperationsMechanoidsShort>
   <!-- EN: Medical operations -->
   <MedicalOperations>Tıbbi operasyonlar</MedicalOperations>
   <!-- EN: amputate -->
@@ -222,7 +222,7 @@
   <!-- EN: Prevents infection -->
   <PreventsInfection>Enfeksiyonu önleme</PreventsInfection>
   <!-- EN: Allow self-tend -->
-  <AllowSelfTend>Kendi kendine tedavi</AllowSelfTend>
+  <AllowSelfTend>Kendine tedavi</AllowSelfTend>
   <!-- EN: {0} with self-tend enabled will automatically tend to themselves on the spot at {1} the normal efficiency. -->
   <AllowSelfTendTip>Kendi kendine tedavi etkinken {0} otomatik olarak kendilerini normal verimlilikte {1} seviyesinde tedavi edebilirler.</AllowSelfTendTip>
   <!-- EN: death in {0} -->

--- a/Core/Keyed/MainTabs.xml
+++ b/Core/Keyed/MainTabs.xml
@@ -333,7 +333,7 @@
   <!-- EN: Whether you wish to be rewarded with {FACTION_royalFavorLabel} from {FACTION_name}.\n\nIf this is disabled, {FACTION_name} will offer other types of rewards instead.\n\nThis setting only affects newly-arriving quests. -->
   <AcceptRoyalFavorDesc>{FACTION_name} 'dan {FACTION_royalFavorLabel} ile ödüllendirilmek isteyip istemediğinizi.\n\nBu devre dışı bırakılırsa, {FACTION_name} bunun yerine başka tür ödüller sunar.\n\nBu ayar yalnızca yeni gelen görevleri etkiler.</AcceptRoyalFavorDesc>
   <!-- EN: Accept goodwill -->
-  <AcceptGoodwill>iyi niyeti kabul et</AcceptGoodwill>
+  <AcceptGoodwill>İyi niyeti kabul et</AcceptGoodwill>
   <!-- EN: Whether you wish to be rewarded via improved faction relations with {FACTION_name}.\n\nIf this is disabled, {FACTION_name} will offer other types of rewards instead.\n\nThis setting only affects newly-generated quests. -->
   <AcceptGoodwillDesc>{FACTION_name} ile geliştirilmiş hizip ilişkileri yoluyla ödüllendirilmek isteyip istemediğinizi.\n\nBu devre dışı bırakılırsa, {FACTION_name} bunun yerine başka tür ödüller sunacaktır.\n\nBu ayar yalnızca yeni oluşturulan görevleri etkiler.</AcceptGoodwillDesc>
   <!-- EN: You are currently opting in to receive {FACTION_royalFavorLabel}. -->

--- a/Core/Keyed/Menus_Main.xml
+++ b/Core/Keyed/Menus_Main.xml
@@ -21,15 +21,15 @@
   <!-- EN: Mods -->
   <Mods>Modlar</Mods>
   <!-- EN: Save translation report -->
-  <SaveTranslationReport>Çeviri raporunu kaydet</SaveTranslationReport>
+  <SaveTranslationReport>Çeviri raporu oluştur</SaveTranslationReport>
   <!-- EN: Generating translation report -->
-  <GeneratingTranslationReport>Çeviri raporu oluştur</GeneratingTranslationReport>
+  <GeneratingTranslationReport>Çeviri raporu oluşturuluyor</GeneratingTranslationReport>
   <!-- EN: Cleanup translation files -->
-  <CleanupTranslationFiles>Çeviri dosyalarını temizle</CleanupTranslationFiles>
+  <CleanupTranslationFiles>Çeviri dosyalarını yenile</CleanupTranslationFiles>
   <!-- EN: Update translations files (TKey's) -->
   <TranslationFilesTKeyUpdate>Çeviri dosyalarını güncelle</TranslationFilesTKeyUpdate>
   <!-- EN: Cleaning translation files -->
-  <CleaningTranslationFiles>Çeviri dosyaları temizleniyor</CleaningTranslationFiles>
+  <CleaningTranslationFiles>Çeviri dosyaları yenileniyor</CleaningTranslationFiles>
   <!-- EN: Dev quicktest -->
   <DevQuickTest>Geliştirici hızlı test</DevQuickTest>
   <!-- EN: Credits -->
@@ -151,7 +151,7 @@
   <!-- EN: Are you sure you want to disable the core mod? The game won't work at all unless you have another mod that replaces all the core functionality.\n\nRemember, other mods can override defs in the core mod by using the same defName. -->
   <ConfirmDisableCoreMod>Çekirdek modu devre dışı bırakmak istediğinizden emin misiniz? Tüm temel işlevlerin yerini alan başka bir modunuz olmadığı sürece oyun hiç çalışmayacaktır.\n\nUnutmayın, diğer modlar aynı defName kullanarak çekirdek moddaki tanımları geçersiz kılabilir.</ConfirmDisableCoreMod>
   <!-- EN: Are you sure you want to delete all the content for {0}? -->
-  <ConfirmDeleteMod>{0} İçin tüm içeriği silmek istediğinizden emin misiniz?</ConfirmDeleteMod>
+  <ConfirmDeleteMod>{0} için tüm içeriği silmek istediğinizden emin misiniz?</ConfirmDeleteMod>
   <!-- EN: Auto-sort mods -->
   <ResolveModOrder>Modları otomatik sırala</ResolveModOrder>
   <!-- EN: Save and apply changes -->
@@ -175,11 +175,11 @@
   <!-- EN: Enabled -->
   <Enabled>Etkinleştirilmiş</Enabled>
   <!-- EN: Disabled -->
-  <Disabled>devre dışı</Disabled>
+  <Disabled>Devre dışı bırakılmış</Disabled>
   <!-- EN: Enable -->
-  <Enable>Etkinleştirilmiş</Enable>
+  <Enable>Etkinleştir</Enable>
   <!-- EN: Disable -->
-  <Disable>devre dışı</Disable>
+  <Disable>Devre dışı bırak</Disable>
   <!-- EN: Get mods from... -->
   <GetMods>Modları şuradan alın...</GetMods>
   <!-- EN: Unsubscribe from... -->
@@ -197,13 +197,13 @@
   <!-- EN: Shared mods -->
   <SharedModsList>Paylaşılan modlar</SharedModsList>
   <!-- EN: Website -->
-  <ModWebsite>Website</ModWebsite>
+  <ModWebsite>Web sitesi</ModWebsite>
   <!-- EN: Open folder -->
   <ModFolder>Dosyayı aç</ModFolder>
   <!-- EN: Mod options -->
   <ModOptions>Mod seçenekleri</ModOptions>
   <!-- EN: Workshop -->
-  <FromWorkshop>Workshop</FromWorkshop>
+  <FromWorkshop>Atölye</FromWorkshop>
   <!-- EN: Forum -->
   <FromForum>Forum</FromForum>
   <!-- EN: Advanced... -->
@@ -215,21 +215,21 @@
   <!-- EN: All incompatible mods -->
   <AllIncompatibleMods>Tüm uyumsuz modlar</AllIncompatibleMods>
   <!-- EN: Workshop page -->
-  <WorkshopPage>Atölye Sayfası</WorkshopPage>
+  <WorkshopPage>Atölye sayfası</WorkshopPage>
   <!-- EN: Upload to Steam Workshop -->
   <UploadToSteamWorkshop>Steam atölyesine yükle</UploadToSteamWorkshop>
   <!-- EN: Update on Steam Workshop -->
   <UpdateOnSteamWorkshop>Steam atölyesindeki dosyayı güncelle</UpdateOnSteamWorkshop>
   <!-- EN: Upload already in progress. -->
-  <UploadAlreadyInProgress>Zaten yükleniyor</UploadAlreadyInProgress>
+  <UploadAlreadyInProgress>Zaten yükleniyor.</UploadAlreadyInProgress>
   <!-- EN: Workshop submission failed.\n\nReason: {0} -->
-  <WorkshopSubmissionFailed>Yükleme Tamamlanamadı\n\nSebep: {0}</WorkshopSubmissionFailed>
+  <WorkshopSubmissionFailed>Atölye yüklemesi tamamlanamadı.\n\nSebep: {0}</WorkshopSubmissionFailed>
   <!-- EN: Successfully uploaded {0}. -->
-  <WorkshopUploadSucceeded>Başarıyla Yüklendi {0}.</WorkshopUploadSucceeded>
+  <WorkshopUploadSucceeded>{0} başarıyla yüklendi.</WorkshopUploadSucceeded>
   <!-- EN: Downloading -->
-  <Downloading>Indiriliyor</Downloading>
+  <Downloading>İndiriliyor</Downloading>
   <!-- EN: Workshop ID -->
-  <WorkshopId>Workshop ID</WorkshopId>
+  <WorkshopId>Atölye ID</WorkshopId>
   <!-- EN: Display fulfilled requirements -->
   <ModDisplayFulfilledRequirements>Karşılanan gereksinimleri görüntüle</ModDisplayFulfilledRequirements>
   <!-- EN: Click to select. -->
@@ -269,29 +269,29 @@
   <!-- EN: This mod was made for a newer version of RimWorld than this, and will probably not work correctly. -->
   <ModNotMadeForThisVersion_Newer>Bu mod Rimworld'ün daha yeni bir versiyonu için yapılmıştır, muhtemelen düzgün çalışmayacaktır.</ModNotMadeForThisVersion_Newer>
   <!-- EN: Mod needs properly formatted supported version information in About.xml. Like this: <supportedVersions><li>{0}</li></supportedVersions> - <targetVersion> is deprecated. Check log for further information. -->
-  <MessageModNeedsWellFormattedTargetVersion>Mod needs properly formatted supported version information in About.xml. Like this: &lt;supportedVersions>&lt;li>{0}&lt;/li>&lt;/supportedVersions> - &lt;targetVersion> is deprecated. Check log for further information.</MessageModNeedsWellFormattedTargetVersion>
+  <MessageModNeedsWellFormattedTargetVersion>Mod, About.xml'de desteklenen sürümlerin doğru biçimlendirilmiş bir listesini gerektirir. Bunun gibi: {0}. Etiketin geçerliliği sona ermiştir. Daha fazla bilgi için günlük dosyasını kontrol edin.</MessageModNeedsWellFormattedTargetVersion>
   <!-- EN: Mod needs a unique, properly formatted packageId in About.xml. It must must meet following requirements:\n\n  - Alphanumeric characters and dot only.\n  - No spaces.\n  - At least one dot.\n  - No repeated dots in a row, or starting or ending with a dot.\n  - 60 characters or less.\n  - Cannot contain word "Ludeon".\n\nFor example:\n<packageId>AuthorName.ModName</packageId>\n<packageId>AuthorName.ModName.Specific</packageId> -->
-  <MessageModNeedsWellFormattedPackageId>Mod needs a unique, properly formatted packageId in About.xml. It must must meet following requirements:\n\n  - Alphanumeric characters and dot only.\n  - No spaces.\n  - At least one dot.\n  - No repeated dots in a row, or starting or ending with a dot.\n  - 60 characters or less.\n  - Cannot contain word "Ludeon".\n\nFor example:\n&lt;packageId>AuthorName.ModName&lt;/packageId>\n&lt;packageId>AuthorName.ModName.Specific&lt;/packageId></MessageModNeedsWellFormattedPackageId>
+  <MessageModNeedsWellFormattedPackageId>Modun About.xml'de benzersiz ve doğru biçimlendirilmiş bir paket kimliğine ihtiyacı var. Aşağıdaki gereksinimleri karşılaması gerekir:\n\n - Yalnızca alfanümerik karakterler ve noktalar.\n - Boşluk yok.\n - En az bir nokta.\n - Bir satırda tekrarlanan nokta yok veya bir kimlik ile başlayan veya biten bir kimlik yok nokta.\n - 60 karakter veya daha az.\n - "Ludeon" kelimesini içeremez.\n\nÖrneğin:\nAuthorName.ModName\nAuthorName.ModName.Specific</MessageModNeedsWellFormattedPackageId>
   <!-- EN: This mod has issues in LoadFolders.xml, that you need to resolve before uploading: -->
-  <ModHadLoadFolderIssues>This mod has issues in LoadFolders.xml, that you need to resolve before uploading:</ModHadLoadFolderIssues>
+  <ModHadLoadFolderIssues>Bu modun LoadFolders.xml dosyasında yüklemeden önce çözmeniz gereken sorunlar var:</ModHadLoadFolderIssues>
   <!-- EN: Folder {0} specified for version {1} doesn't exist. -->
-  <ModLoadFolderDoesntExist>Folder {0} specified for version {1} doesn't exist.</ModLoadFolderDoesntExist>
+  <ModLoadFolderDoesntExist>{1} sürümü için belirtilen {0} klasörü mevcut değil.</ModLoadFolderDoesntExist>
   <!-- EN: Malformed version string '{0}'. Correct format is Major.Minor (e.g. 1.1) -->
-  <ModLoadFolderMalformedVersion>Malformed version string '{0}'. Correct format is Major.Minor (e.g. 1.1)</ModLoadFolderMalformedVersion>
+  <ModLoadFolderMalformedVersion>Hatalı biçimli sürüm dizesi '{0}'. Doğru biçim Büyük.Küçük'dür (örn. 1.1)</ModLoadFolderMalformedVersion>
   <!-- EN: The list of load folders for version {0} is empty. -->
-  <ModLoadFolderListEmpty>The list of load folders for version {0} is empty.</ModLoadFolderListEmpty>
+  <ModLoadFolderListEmpty>{0} sürümü için yükleme klasörlerinin listesi boş.</ModLoadFolderListEmpty>
   <!-- EN: Version {0} lists the same folder more than once: {1}. -->
-  <ModLoadFolderRepeatingFolder>Version {0} lists the same folder more than once: {1}.</ModLoadFolderRepeatingFolder>
+  <ModLoadFolderRepeatingFolder>Sürüm {0} aynı klasörü birden fazla listeliyor: {1}.</ModLoadFolderRepeatingFolder>
   <!-- EN: Invalid version order: {0} should come before {1}. -->
-  <ModLoadFolderOutOfOrder>Invalid version order: {0} should come before {1}.</ModLoadFolderOutOfOrder>
+  <ModLoadFolderOutOfOrder>Geçersiz sürüm sırası: {0}, {1}'den önce gelmelidir.</ModLoadFolderOutOfOrder>
   <!-- EN: Invalid version order: 'default' should be defined first. -->
-  <ModLoadFolderOutOfOrderDefault>Invalid version order: 'default' should be defined first.</ModLoadFolderOutOfOrderDefault>
+  <ModLoadFolderOutOfOrderDefault>Geçersiz sürüm sırası: 'default' ilk olarak tanımlanmalıdır.</ModLoadFolderOutOfOrderDefault>
   <!-- EN: Using 'default' in load folders is deprecated. Please define folders for each version using the <v...> tags. -->
-  <ModLoadFolderDefaultDeprecated>Yükleme klasörlerinde 'varsayılan' kullanılması kullanımdan kaldırılmıştır. Lütfen v...-Tags etiketlerini kullanarak her sürüm için klasör tanımlayın.</ModLoadFolderDefaultDeprecated>
+  <ModLoadFolderDefaultDeprecated>Yükleme klasörlerinde 'default' kullanılması kullanımdan kaldırılmıştır. Lütfen v...-Tags etiketlerini kullanarak her sürüm için klasör tanımlayın.</ModLoadFolderDefaultDeprecated>
   <!-- EN: Version {0} is defined in load folders, but is not listed in 'supportedVersions' of mod's About.xml. -->
-  <ModLoadFolderDefinesUnsupportedGameVersion>Version {0} is defined in load folders, but is not listed in 'supportedVersions' of mod's About.xml.</ModLoadFolderDefinesUnsupportedGameVersion>
+  <ModLoadFolderDefinesUnsupportedGameVersion>Sürüm {0} yükleme klasörlerinde tanımlanmış, ancak modun About.xml dosyasının 'supportedVersions' bölümünde listelenmiyor.</ModLoadFolderDefinesUnsupportedGameVersion>
   <!-- EN: Drag to reorder -->
-  <DragToReorder>Drag to reorder</DragToReorder>
+  <DragToReorder>Yeniden sıralamak için sürükleyin</DragToReorder>
 
   <!-- Select scenario -->
   <!-- EN: Choose scenario -->
@@ -319,7 +319,7 @@
   <!-- EN: All text fields must be filled. -->
   <TextFieldsMustBeFilled>Tüm alanlar doldurulmalıdır.</TextFieldsMustBeFilled>
   <!-- EN: Are you sure you want to upload this to the Steam Workshop?\n\nYou must agree to the Steam Workshop terms of service. Find the full terms here:\n\nhttp://steamcommunity.com/sharedfiles/workshoplegalagreement -->
-  <ConfirmSteamWorkshopUpload>Are you sure you want to upload this to the Steam Workshop?\n\nYou must agree to the Steam Workshop terms of service. Find the full terms here:\n\nhttp://steamcommunity.com/sharedfiles/workshoplegalagreement</ConfirmSteamWorkshopUpload>
+  <ConfirmSteamWorkshopUpload>Bunu Steam Atölyesi'ne yüklemek istediğinizden emin misiniz?\n\nSteam Workshop hizmet şartlarını kabul etmelisiniz. Tam şartları burada bulabilirsiniz:\n\nhttp://steamcommunity.com/sharedfiles/workshoplegalagreement</ConfirmSteamWorkshopUpload>
   <!-- EN: Obviously you should only upload content that you created yourself.\n\nDid you create this content yourself? -->
   <ConfirmContentAuthor>Yalnızca kendi oluşturduğunuz içeriği yüklemelisiniz.\n\nBu içeriği kendiniz mi oluşturdunuz?</ConfirmContentAuthor>
   <!-- EN: Incompatible -->
@@ -623,7 +623,7 @@
   <!-- EN: Backstory -->
   <Backstory>Geçmişi</Backstory>
   <!-- EN: Incapable of -->
-  <IncapableOf>Yapamayacakları;</IncapableOf>
+  <IncapableOf>Yapamayacakları</IncapableOf>
   <!-- EN: Abilities -->
   <Abilities>Beceriler</Abilities>
   <!-- EN: Caused by -->

--- a/Core/Keyed/Messages.xml
+++ b/Core/Keyed/Messages.xml
@@ -264,7 +264,7 @@
   <MessageNoLongerSocialFighting>{PAWN1_labelShort} ve {PAWN2_labelShort} artık tartışmıyorlar.</MessageNoLongerSocialFighting>
   
   <!-- EN: {2_labelShort} is no longer binging on {1}. -->
-  <MessageNoLongerBingingOnDrug>{2_labelShort} is no longer binging on {1}.</MessageNoLongerBingingOnDrug>
+  <MessageNoLongerBingingOnDrug>{2_labelShort} artık {1} üzerinde aşırıya kaçmıyor.</MessageNoLongerBingingOnDrug>
 
   <!-- EN: {PAWN_labelShort} is no longer on an insulting spree against {TARGET_label}. -->
   <MessageNoLongerOnTargetedInsultingSpree>{PAWN_labelShort} artık {TARGET_label}'e saydırmayı bıraktı.</MessageNoLongerOnTargetedInsultingSpree>
@@ -450,9 +450,9 @@
   <!-- EN: Health condition healed: {0}. -->
   <MessageHediffCuredByItem>Sağlık durumu iyileşti: {0}.</MessageHediffCuredByItem>
   <!-- EN: Body part restored: {0}. -->
-  <MessageBodyPartCuredByItem>Vücut bölgesi iyileştirilde: {0}.</MessageBodyPartCuredByItem>
+  <MessageBodyPartCuredByItem>Vücut bölgesi iyileştirildi: {0}.</MessageBodyPartCuredByItem>
   <!-- EN: Technology given: {0}. -->
-  <MessageResearchProjectFinishedByItem>Technology given: {0}.</MessageResearchProjectFinishedByItem>
+  <MessageResearchProjectFinishedByItem>Verilen teknoloji: {0}.</MessageResearchProjectFinishedByItem>
 
   <!-- EN: {0} has been brought back to life! -->
   <MessagePawnResurrected>{0} hayata geri getirildi!</MessagePawnResurrected>
@@ -509,7 +509,7 @@
   <!-- EN: downgraded {0} -->
   <GoodwillChangedReason_DowngradedImplant>{0} eski sürüme geçirildi</GoodwillChangedReason_DowngradedImplant>
   <!-- EN: needlessly installed {0} -->
-  <GoodwillChangedReason_NeedlesslyInstalledWorseBodyPart>needlessly installed {0}</GoodwillChangedReason_NeedlesslyInstalledWorseBodyPart>
+  <GoodwillChangedReason_NeedlesslyInstalledWorseBodyPart>{0} gereksiz yere nakledildi</GoodwillChangedReason_NeedlesslyInstalledWorseBodyPart>
   <!-- EN: captured {1_labelShort} -->
   <GoodwillChangedReason_CapturedPawn>{1_labelShort} ele geçirildi</GoodwillChangedReason_CapturedPawn>
   <!-- EN: {1_labelShort} crushed -->
@@ -569,21 +569,21 @@
   <MessageFormedCaravan_Orders>Emirler</MessageFormedCaravan_Orders>
 
   <!-- EN: {1}'s "{0}" can no longer deliver to deleted stockpile {2}. -->
-  <MessageBillValidationStoreZoneDeleted>{1}  "{0}" artık silinen '{2}' depolama alanına gönderilemiyor.</MessageBillValidationStoreZoneDeleted>
+  <MessageBillValidationStoreZoneDeleted>{1}'in "{0}" öğesi artık silinen '{2}' depolama alanına gönderilemiyor.</MessageBillValidationStoreZoneDeleted>
   <!-- EN: {1}'s "{0}" can no longer deliver to unavailable stockpile {2}. -->
-  <MessageBillValidationStoreZoneUnavailable>{1} "{0}" artık kullanılamayan '{2}' depolama alanına teslimat yapamaz.</MessageBillValidationStoreZoneUnavailable>
+  <MessageBillValidationStoreZoneUnavailable>{1}'in "{0}" öğesi artık kullanılamayan '{2}' depolama alanına teslimat yapamaz.</MessageBillValidationStoreZoneUnavailable>
   <!-- EN: {0} can no longer work on "{1}" at {2}. The restriction has been removed. -->
-  <MessageBillValidationPawnUnavailable>{0} can no longer work on "{1}" at {2}. The restriction has been removed.</MessageBillValidationPawnUnavailable>
+  <MessageBillValidationPawnUnavailable>{0} artık {2} adresindeki "{1}" üzerinde çalışamaz. Kısıtlama kaldırıldı.</MessageBillValidationPawnUnavailable>
   <!-- EN: {1}'s "{0}" can no longer count items in deleted stockpile {2}. -->
-  <MessageBillValidationIncludeZoneDeleted>{1}s "{0}" artık silinen '{2}' depolama alanındaki malları sayamaz.</MessageBillValidationIncludeZoneDeleted>
+  <MessageBillValidationIncludeZoneDeleted>{1}s "{0}" artık silinen '{2}' depolama alanındaki öğeleri sayamaz.</MessageBillValidationIncludeZoneDeleted>
   <!-- EN: {1}'s "{0}" can no longer count items in deleted building {2}. -->
-  <MessageBillValidationIncludeBuildingDeleted>{1}'in "{0}" öğesi artık silinen {2} binasındaki öğeleri sayamaz.</MessageBillValidationIncludeBuildingDeleted>
+  <MessageBillValidationIncludeBuildingDeleted>{1}'in "{0}" öğesi artık silinen '{2}' binasındaki öğeleri sayamaz.</MessageBillValidationIncludeBuildingDeleted>
   <!-- EN: {1}'s "{0}" can no longer count items in deleted storage group {2}. -->
-  <MessageBillValidationIncludeStorageGroupDeleted>{1}'in "{0}" öğesi artık silinen depolama grubu {2}'deki öğeleri sayamaz.</MessageBillValidationIncludeStorageGroupDeleted>
+  <MessageBillValidationIncludeStorageGroupDeleted>{1}'in "{0}" öğesi artık silinen '{2}' depolama grubundaki öğeleri sayamaz.</MessageBillValidationIncludeStorageGroupDeleted>
   <!-- EN: {1}'s "{0}" can no longer count items in unavailable stockpile {2}. -->
-  <MessageBillValidationIncludeZoneUnavailable>{1} "{0}", artık kullanılamayan '{2}' depolama alanındaki malları sayamaz.</MessageBillValidationIncludeZoneUnavailable>
+  <MessageBillValidationIncludeZoneUnavailable>{1}'in "{0}" öğesi artık kullanılamayan '{2}' depolama alanındaki öğeleri sayamaz.</MessageBillValidationIncludeZoneUnavailable>
   <!-- EN: {1}'s "{0}" can no longer deliver all products to stockpile {2}. -->
-  <MessageBillValidationStoreZoneInsufficient>{1}'s "{0}" can no longer deliver all products to stockpile {2}.</MessageBillValidationStoreZoneInsufficient>
+  <MessageBillValidationStoreZoneInsufficient>{1}'in "{0}" öğesi artık '{2}' depolama alanındaki öğeleri teslim edemez.</MessageBillValidationStoreZoneInsufficient>
 
   <!-- EN: Because of a lack of taming maintenance, {1_labelShort} has returned to the wild. -->
   <MessageAnimalReturnedWild>Yeterli bakılmadığı için, {1_labelShort} vahşi hayatına geri döndü.</MessageAnimalReturnedWild>

--- a/Core/Keyed/Misc.xml
+++ b/Core/Keyed/Misc.xml
@@ -33,21 +33,21 @@
   
   <!-- General-use words -->
   <!-- EN: Yes -->
-  <Yes>evet</Yes>
+  <Yes>Evet</Yes>
   <!-- EN: No -->
-  <No>hayır</No>
+  <No>Hayır</No>
   <!-- EN: No {0} -->
   <NoSubject>Hayır: {0}</NoSubject>
   <!-- EN: new -->
   <New>yeni</New>
   <!-- EN: Gender -->
-  <Gender>cinsiyet</Gender>
+  <Gender>Cinsiyet</Gender>
   <!-- EN: Sex -->
-  <Sex>cinsiyet</Sex>
+  <Sex>Cinsiyet</Sex>
   <!-- EN: min -->
   <min>min</min>
   <!-- EN: max -->
-  <max>max</max>
+  <max>maks</max>
   <!-- EN: chance -->
   <chance>şans</chance>
   <!-- EN: context -->
@@ -89,7 +89,7 @@
   <!-- EN: Cause -->
   <Cause>Sebep</Cause>
   <!-- EN: etc -->
-  <Etc>v.b.</Etc>
+  <Etc>vs.</Etc>
   <!-- EN: ${0} -->
   <MoneyFormat>₺{0}</MoneyFormat>
   <!-- EN: Factors -->

--- a/Core/Keyed/Misc_Gameplay.xml
+++ b/Core/Keyed/Misc_Gameplay.xml
@@ -399,9 +399,9 @@
   <!-- EN: {0} trainability -->
   <CreatureTrainability>{0} eğitilebilirlik</CreatureTrainability>
   <!-- EN: Follow master while drafted -->
-  <CreatureFollowDrafted>Taslak hazırlanırken ustayı takip et</CreatureFollowDrafted>
+  <CreatureFollowDrafted>Görevlendirilmişken ustayı takip et</CreatureFollowDrafted>
   <!-- EN: Follow master while doing field work -->
-  <CreatureFollowFieldwork>Saha çalışması yaparken ustayı takip edin</CreatureFollowFieldwork>
+  <CreatureFollowFieldwork>Çalışma yaparken ustayı takip et</CreatureFollowFieldwork>
   <!-- EN: {0} with {1} -->
   <ProximitySingleGoodwillChange>{1} ile {0}</ProximitySingleGoodwillChange>
   <!-- EN: Too dangerous to re-enter for {0}. -->
@@ -441,7 +441,7 @@
   <!-- EN: {0} x{1} -->
   <FilthLabel>{0} x{1}</FilthLabel>
   <!-- EN: {0} of {1} x{2} -->
-  <FilthLabelWithSource>{0}/{1} x {2}</FilthLabelWithSource>
+  <FilthLabelWithSource>{0}/{1} x{2}</FilthLabelWithSource>
   <!-- EN: Required -->
   <Required>Gerekli</Required>
   <!-- EN: Warning: You cannot complete trade requests by using transport pods.\nIf you send the goods, the settlement will accept them as gifts but they will not reward you.\n\nFor trading, approach the settlement with a caravan!\n\nAre you sure you want to gift the loaded goods to the faction? -->
@@ -1578,7 +1578,7 @@
   <!-- EN: Soldier -->
   <OutfitSoldier>Asker</OutfitSoldier>
   <!-- EN: Nudist -->
-  <OutfitNudist>Nudist</OutfitNudist>
+  <OutfitNudist>Çıplak</OutfitNudist>
 
   <!-- Hibernatable -->
   <!-- EN: Hibernating -->
@@ -1733,7 +1733,7 @@
 
   <!-- Rituals -->
   <!-- EN: ritual -->
-  <Ritual>ritual</Ritual>
+  <Ritual>ritüel</Ritual>
 
   <!-- EN: Takes place at -->
   <RitualTakesPlaceAt>konumunda gerçekleşir</RitualTakesPlaceAt>
@@ -1886,7 +1886,7 @@
   <!-- EN: ability already queued. -->
   <AbilityAlreadyQueued>yetenek zaten sıraya alındı.</AbilityAlreadyQueued>
   <!-- EN: Ability ready for {PAWN_nameDef}: {0} -->
-  <AbilityReadyLabel>Yetenek hazır: {0}</AbilityReadyLabel>
+  <AbilityReadyLabel>{PAWN_nameDef} için yetenek hazır: {0}</AbilityReadyLabel>
   <!-- EN: Abilities ready for {PAWN_nameDef}: {0} -->
   <AbilitiesReadyLabel>{PAWN_nameDef} için hazır yetenekler: {0}</AbilitiesReadyLabel>
   <!-- EN: {0_nameDef} is ready to use {1}. -->
@@ -2028,8 +2028,5 @@
 
   <!-- EN: blocked by roof -->
   <BlockedByRoof>çatı tarafından engellendi</BlockedByRoof>
-  
-  <!-- UNUSED -->
-  <HealingCureHediff>{0_nameDef} için {1} tedavi edildi.</HealingCureHediff>
 
 </LanguageData>

--- a/Core/Keyed/WorkTags.xml
+++ b/Core/Keyed/WorkTags.xml
@@ -26,7 +26,7 @@
   <!-- EN: cooking -->
   <WorkTagCooking>aşçı</WorkTagCooking>
   <!-- EN: firefighting -->
-  <WorkTagFirefighting>itfaiye</WorkTagFirefighting>
+  <WorkTagFirefighting>İtfaiye</WorkTagFirefighting>
   <!-- EN: cleaning -->
   <WorkTagCleaning>temizlik</WorkTagCleaning>
   <!-- EN: hauling -->
@@ -38,7 +38,7 @@
   <!-- EN: hunting -->
   <WorkTagHunting>avcılık</WorkTagHunting>
   <!-- EN: constructing -->
-  <WorkTagConstructing>inşaat</WorkTagConstructing>
+  <WorkTagConstructing>İnşaat</WorkTagConstructing>
   <!-- EN: commoner work -->
   <WorkTagCommoner>ortak çalışma</WorkTagCommoner>
   <!-- EN: all work -->

--- a/README.md
+++ b/README.md
@@ -5,10 +5,9 @@
 
 # Çeviriye başlarken
 
-   * Önce projeyi **forklayın** (sağ üstte), sonra forkladığınız projede yaptığınız değişiklikleri **Contribute** butonunu kullanarak **Open pull request** ile gönderin.
+   * Önce projeyi **forklayın** (sağ üstte), sonra forkladığınız projede yaptığınız değişiklikleri **Contribute** butonunu kullanarak **Open pull request** ile gönderin.  
+   * Çeviri yapmadan önce **mutlaka** [Discord topluluğumuza](https://discord.gg/yjnA2rm5UX) katılın. Discord sunucumuz üzerinden **Çevirmen Olmak İstiyorum** tuşuna basarak açılan kanallardan çeviri yaparken hangi programların kullanılması gerektiğini, projenin nasıl forklanacağını, çeviri dosyalarının nasıl güncelleneceğini, çeviri yaparken düzen için uymanız gereken kuralları ve bazı tam olarak Türkçe karşılığı olmayan sözcüklerin özel çevirilerine ayrıntılı olarak ulaşabilirsiniz. Çeviri yapmaya başlamadan önce **mutlaka** Discord sunucumuz üzerinden **Çevirmen** rolünü alarak **aktif-çeviriler** kanalından yapacağınız çeviriyi bildirin. Bu sayede birden fazla kişi aynı dosyalar üzerinde çeviri yapmaz ve boşuna uğraşmaktan kurtulmuş olur. Ayrıca çeviri yapmadan önce yapacağınız çevirinin **aktif-çeviriler** kanalında aktif olarak yapılıp yapılmadığını kontrol edin. Ek olarak topluluğumuza katılarak çeviri hatalarını ilgili kanaldan raporlayabilirsiniz. Ayrıntılı bilgiler için Discord topluluğumuza katılın ve gerekli yönergeleri okuyun. [Discord sunucumuza katılmak için tıklayın.](https://discord.gg/yjnA2rm5UX)
    * Wiki kısmından anasayfaya tıklatıp "Katkıda bulunmak için" kısmını okuyun.
-   * Çeviriyi güncellemek ve çeviri raporunu oluşturmak için okuyun: [#388](https://github.com/Ludeon/RimWorld-Turkish/issues/388)
-   * Çeviride dikkat etmeniz gereken konular için: [#387](https://github.com/Ludeon/RimWorld-Turkish/issues/387)
 
 ## Translators - Çevirmenler
 
@@ -28,7 +27,7 @@
 * [@Deniz "deniztheraven" Gümüş](https://github.com/denizubu)
 
 
-:star: Çeviri hataları için [Issue tracker](https://github.com/Ludeon/RimWorld-Turkish/issues)'a not bırakabilir veya kendiniz katkıda bulunabilirsiniz. Katkıda bulunmak istiyorsanız hali hazırda çevirilmeyi bekleyen çevirileri ve düzenlemeleri proje sayfamızdan kontrol edebilirsiniz.
+:star: Çeviri hataları için [Issue tracker](https://github.com/Ludeon/RimWorld-Turkish/issues)'a not bırakabilir veya [Discord sunucumuza](https://discord.gg/yjnA2rm5UX) katılarak **hata-raporu** kanalına gönderi atabilirsiniz. Ayrıca direk kendiniz de katkıda bulunabilirsiniz. Katkıda bulunmak istiyorsanız hali hazırda çevirilmeyi bekleyen çevirileri ve düzenlemeleri proje sayfamızdan kontrol edebilirsiniz.
 [Proje sayfasına bir göz atın.](https://github.com/Ludeon/RimWorld-Turkish/projects)
 
 


### PR DESCRIPTION
1.5 çevirisini paylaştıktan sonra olası hataları düzelteceğim bir güncelleme daha çıkacağını söylemiştim. 1.5 çevirisindeki bulduğum hataları düzelttim. Ayrıca İngilizce olarak bırakılıp çevrilmemiş bütün Core metinlerini çevirdim. Ayrıca genel olarak Core/DefInjected ve Core/Keyed klasörlerinin içindeki bütün dosyaları inceledim ve bulduğum bütün hataları düzelttim.

Ayrıca daha önce Discussions kısmında açtığım tartışmada bahsettiğim Türkçe RimWorld Discord Topluluğunu açtım. Discord sunucumuza bütün çevirmenleri bekliyoruz. Gerekli yazıları artık anasayfada gözüken README.md dosyasından okuyabilirler. Oraya Discord sunucusunun bağlantısını ve amacını yazdım. Birçok işi oradan düzenlemeyi ve artık çevirmenler ile koordine bir şekilde çalışmayı planlıyoruz. Ayrıntılı bilgiler için Code sayfasındaki README.md yazısını okuyun.

Düzeltilen çeviriler başlıca şunlardır:
-> Backstory'lerde '\n\n' önüne ve arkasına boşluk konması hatası düzeltildi.
-> Yanlış büyük-küçük harf ile başlama hataları düzeltildi.
-> İngilizcesinde küçük harf ile başlatılmış ancak oyun içerisinde baş harfi büyütülen 'i' lerin 'I' ya dönüşmemesi için belirli çeviriler 'İ' ile başlatıldı.
-> Mimari-Çeşitli menüsündeki yapıların çevirileri olmasına rağmen İngilizce gözükmesi hatası düzeltildi.
-> Bazı yazım hataları (eşşek, mustarip vs.) düzeltildi.
-> Gözden kaçmış bir TODO çevirisi eklendi.
-> İngilizce olarak bırakılmış bazı yazılar çevrildi.
-> Ana menüdeki mod ayarları çevirileri düzenlendi.
-> 'Çeviri dosyalarını temizle' düzgün bir çeviri değil ve kafa karıştırıcı dolayısıyla 'Çeviri dosyalarını yenile' olarak düzenlendi.
-> Kendilerine ayrılmış alanlara sığmayan bazı yazılar kısaltıldı.
-> Yanlış konulmuş bazı 'ın, 'in, 'i, 'e ekleri kaldırıldı.
-> Konulmaması gereken bazı '.' işaretleri kaldırıldı.
-> README.md'ye Türkçe Rimworld Discord Topluluğu eklendi.